### PR TITLE
fix: return 400 for duplicate asset creation

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -23,12 +23,12 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     existing = await db.execute(select(Asset).where(Asset.symbol == symbol))
     asset = existing.scalar_one_or_none()
     if asset:
-        # If asset already exists but caller wants it watchlisted, update that
-        if data.watchlisted and not asset.watchlisted:
+        if not asset.watchlisted and data.watchlisted:
             asset.watchlisted = True
             await db.commit()
             await db.refresh(asset)
-        return asset
+            return asset
+        raise HTTPException(400, f"Asset with symbol {symbol} already exists")
 
     name = data.name
     asset_type = data.type


### PR DESCRIPTION
## Summary
- `POST /api/assets` now returns 400 with error message when a duplicate symbol is posted
- Preserves soft-delete re-activation: posting a previously unwatchlisted symbol re-watchlists it and returns 201
- `test_create_duplicate_asset` now passes

Closes #14

## Test plan
- [x] `test_create_duplicate_asset` passes (returns 400)
- [x] `test_create_asset_with_name` still passes (new assets return 201)
- [x] Soft-delete re-activation path preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)