### PR TITLE
fix: filter list_assets by watchlisted=true for soft-delete

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -12,7 +12,9 @@ router = APIRouter(prefix="/api/assets", tags=["assets"])
 
 @router.get("", response_model=list[AssetResponse])
 async def list_assets(db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Asset).order_by(Asset.symbol))
+    result = await db.execute(
+        select(Asset).where(Asset.watchlisted == True).order_by(Asset.symbol)  # noqa: E712
+    )
     return result.scalars().all()
 
 


### PR DESCRIPTION
## Summary
- `GET /api/assets` now filters by `watchlisted=true`, so soft-deleted assets are excluded from the list
- Aligns the endpoint with the watchlist decoupling pattern described in CLAUDE.md

Closes #15

## Test plan
- [x] `test_delete_asset` passes (soft-deleted asset no longer appears in list)
- [x] All 8 asset tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)