### PR TITLE
fix: prevent erratic vertical drag in charts

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -e
 CI=true pnpm install --frozen-lockfile
+# pnpm v10 blocks postinstall scripts by default; ensure esbuild binary is executable
+chmod +x node_modules/.pnpm/@esbuild+linux-x64@*/node_modules/@esbuild/linux-x64/bin/esbuild 2>/dev/null || true
 exec pnpm dev --host

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -196,6 +196,13 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
       rightPriceScale: { borderColor: theme.border },
       timeScale: { borderColor: theme.border, visible: false },
       crosshair: { mode: 1 },
+      handleScroll: {
+        pressedMouseMove: true,
+        vertTouchDrag: false,
+      },
+      handleScale: {
+        axisPressedMouseMove: { time: true, price: true },
+      },
     })
 
     const candleSeries = mainChart.addSeries(CandlestickSeries, {
@@ -307,6 +314,13 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
       },
       timeScale: { borderColor: theme.border, timeVisible: false },
       crosshair: { mode: 1 },
+      handleScroll: {
+        pressedMouseMove: true,
+        vertTouchDrag: false,
+      },
+      handleScale: {
+        axisPressedMouseMove: { time: true, price: true },
+      },
     })
 
     const rsiSeries = rsiChart.addSeries(LineSeries, {


### PR DESCRIPTION
## Summary
- Configure `handleScroll` and `handleScale` on both main candlestick and RSI charts to prevent disorienting zoom when dragging vertically inside the chart area
- Disable `vertTouchDrag` so vertical drag doesn't trigger time-axis panning
- Explicitly enable `axisPressedMouseMove` for both time and price axes so axis-label drag still works
- Fix esbuild EACCES permission error in `docker-entrypoint.sh` caused by pnpm v10 blocking postinstall scripts

## Test plan
- [ ] Vertical drag inside main chart no longer zooms erratically
- [ ] Vertical drag inside RSI chart behaves the same
- [ ] Horizontal drag still pans through time on both charts
- [ ] Dragging on Y-axis labels still scales the price axis
- [ ] Mouse wheel zoom still works
- [ ] Frontend dev server starts without esbuild permission errors

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)