### PR TITLE
feat: enrich OpenAPI spec with app metadata and endpoint summaries

### DIFF
--- a/backend/app/routers/annotations.py
+++ b/backend/app/routers/annotations.py
@@ -9,7 +9,7 @@ from app.schemas.annotation import AnnotationCreate, AnnotationResponse
 router = APIRouter(prefix="/api/assets/{symbol}/annotations", tags=["annotations"])
 
 
-@router.get("", response_model=list[AnnotationResponse])
+@router.get("", response_model=list[AnnotationResponse], summary="List chart annotations for an asset")
 async def list_annotations(symbol: str, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
     asset = result.scalar_one_or_none()
@@ -24,7 +24,7 @@ async def list_annotations(symbol: str, db: AsyncSession = Depends(get_db)):
     return result.scalars().all()
 
 
-@router.post("", response_model=AnnotationResponse, status_code=201)
+@router.post("", response_model=AnnotationResponse, status_code=201, summary="Create a chart annotation")
 async def create_annotation(symbol: str, data: AnnotationCreate, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
     asset = result.scalar_one_or_none()
@@ -44,7 +44,7 @@ async def create_annotation(symbol: str, data: AnnotationCreate, db: AsyncSessio
     return annotation
 
 
-@router.delete("/{annotation_id}", status_code=204)
+@router.delete("/{annotation_id}", status_code=204, summary="Delete a chart annotation")
 async def delete_annotation(symbol: str, annotation_id: int, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
     asset = result.scalar_one_or_none()

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -10,7 +10,7 @@ from app.services.yahoo import validate_symbol
 router = APIRouter(prefix="/api/assets", tags=["assets"])
 
 
-@router.get("", response_model=list[AssetResponse])
+@router.get("", response_model=list[AssetResponse], summary="List watchlisted assets")
 async def list_assets(db: AsyncSession = Depends(get_db)):
     result = await db.execute(
         select(Asset).where(Asset.watchlisted == True).order_by(Asset.symbol)  # noqa: E712
@@ -18,7 +18,7 @@ async def list_assets(db: AsyncSession = Depends(get_db)):
     return result.scalars().all()
 
 
-@router.post("", response_model=AssetResponse, status_code=201)
+@router.post("", response_model=AssetResponse, status_code=201, summary="Add an asset to the watchlist")
 async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     symbol = data.symbol.upper()
 
@@ -50,7 +50,7 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     return asset
 
 
-@router.delete("/{symbol}", status_code=204)
+@router.delete("/{symbol}", status_code=204, summary="Soft-delete an asset from the watchlist")
 async def delete_asset(symbol: str, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
     asset = result.scalar_one_or_none()

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -9,13 +9,13 @@ from app.schemas.group import GroupAddAssets, GroupCreate, GroupResponse, GroupU
 router = APIRouter(prefix="/api/groups", tags=["groups"])
 
 
-@router.get("", response_model=list[GroupResponse])
+@router.get("", response_model=list[GroupResponse], summary="List all groups")
 async def list_groups(db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Group).order_by(Group.name))
     return result.scalars().all()
 
 
-@router.post("", response_model=GroupResponse, status_code=201)
+@router.post("", response_model=GroupResponse, status_code=201, summary="Create a group")
 async def create_group(data: GroupCreate, db: AsyncSession = Depends(get_db)):
     existing = await db.execute(select(Group).where(Group.name == data.name))
     if existing.scalar_one_or_none():
@@ -28,7 +28,7 @@ async def create_group(data: GroupCreate, db: AsyncSession = Depends(get_db)):
     return group
 
 
-@router.get("/{group_id}", response_model=GroupResponse)
+@router.get("/{group_id}", response_model=GroupResponse, summary="Get a group by ID")
 async def get_group(group_id: int, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Group).where(Group.id == group_id))
     group = result.scalar_one_or_none()
@@ -37,7 +37,7 @@ async def get_group(group_id: int, db: AsyncSession = Depends(get_db)):
     return group
 
 
-@router.put("/{group_id}", response_model=GroupResponse)
+@router.put("/{group_id}", response_model=GroupResponse, summary="Update a group")
 async def update_group(group_id: int, data: GroupUpdate, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Group).where(Group.id == group_id))
     group = result.scalar_one_or_none()
@@ -54,7 +54,7 @@ async def update_group(group_id: int, data: GroupUpdate, db: AsyncSession = Depe
     return group
 
 
-@router.delete("/{group_id}", status_code=204)
+@router.delete("/{group_id}", status_code=204, summary="Delete a group")
 async def delete_group(group_id: int, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Group).where(Group.id == group_id))
     group = result.scalar_one_or_none()
@@ -64,7 +64,7 @@ async def delete_group(group_id: int, db: AsyncSession = Depends(get_db)):
     await db.commit()
 
 
-@router.post("/{group_id}/assets", response_model=GroupResponse)
+@router.post("/{group_id}/assets", response_model=GroupResponse, summary="Add assets to a group")
 async def add_assets_to_group(group_id: int, data: GroupAddAssets, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Group).where(Group.id == group_id))
     group = result.scalar_one_or_none()
@@ -84,7 +84,7 @@ async def add_assets_to_group(group_id: int, data: GroupAddAssets, db: AsyncSess
     return group
 
 
-@router.delete("/{group_id}/assets/{asset_id}", response_model=GroupResponse)
+@router.delete("/{group_id}/assets/{asset_id}", response_model=GroupResponse, summary="Remove an asset from a group")
 async def remove_asset_from_group(group_id: int, asset_id: int, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Group).where(Group.id == group_id))
     group = result.scalar_one_or_none()

--- a/backend/app/routers/holdings.py
+++ b/backend/app/routers/holdings.py
@@ -33,7 +33,7 @@ def _bb_position(close: float, upper: float, middle: float, lower: float) -> str
         return "below"
 
 
-@router.get("", response_model=EtfHoldingsResponse)
+@router.get("", response_model=EtfHoldingsResponse, summary="Get ETF top holdings")
 async def get_holdings(symbol: str, db: AsyncSession = Depends(get_db)):
     asset = await _get_asset(symbol, db)
     if asset.type.value != "etf":
@@ -44,7 +44,7 @@ async def get_holdings(symbol: str, db: AsyncSession = Depends(get_db)):
     return data
 
 
-@router.get("/indicators", response_model=list[HoldingIndicatorResponse])
+@router.get("/indicators", response_model=list[HoldingIndicatorResponse], summary="Get technical indicators for each ETF holding")
 async def get_holdings_indicators(symbol: str, db: AsyncSession = Depends(get_db)):
     """Return latest indicator snapshot for each of the ETF's top holdings."""
     asset = await _get_asset(symbol, db)

--- a/backend/app/routers/portfolio.py
+++ b/backend/app/routers/portfolio.py
@@ -39,7 +39,7 @@ async def _get_watchlisted_ids(db: AsyncSession) -> list[int]:
     return list(result.scalars().all())
 
 
-@router.get("/index", response_model=PortfolioIndexResponse)
+@router.get("/index", response_model=PortfolioIndexResponse, summary="Get composite portfolio index")
 async def get_portfolio_index(period: str = "1y", db: AsyncSession = Depends(get_db)):
     """Compute equal-weight composite index of all watchlisted assets."""
     days = _PERIOD_DAYS.get(period, 365)
@@ -75,7 +75,7 @@ async def get_portfolio_index(period: str = "1y", db: AsyncSession = Depends(get
     )
 
 
-@router.get("/performers", response_model=list[AssetPerformance])
+@router.get("/performers", response_model=list[AssetPerformance], summary="Get top and bottom performers by return")
 async def get_performers(period: str = "1y", db: AsyncSession = Depends(get_db)):
     """Return watchlisted assets ranked by period return (best first)."""
     days = _PERIOD_DAYS.get(period, 365)

--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -97,7 +97,7 @@ async def _ensure_prices(db: AsyncSession, asset: Asset, period: str) -> list[Pr
     return prices
 
 
-@router.get("/prices", response_model=list[PriceResponse])
+@router.get("/prices", response_model=list[PriceResponse], summary="Get OHLCV price history")
 async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
     asset = await _find_asset(symbol, db)
 
@@ -124,7 +124,7 @@ async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depend
     return rows
 
 
-@router.get("/indicators", response_model=list[IndicatorResponse])
+@router.get("/indicators", response_model=list[IndicatorResponse], summary="Get technical indicators (RSI, SMA, MACD, Bollinger)")
 async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
     asset = await _find_asset(symbol, db)
     start = _display_start(period)
@@ -180,7 +180,7 @@ async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = De
     return rows
 
 
-@router.post("/refresh", status_code=200)
+@router.post("/refresh", status_code=200, summary="Force-refresh prices from Yahoo Finance")
 async def refresh_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
     asset = await _get_asset(symbol, db)
     count = await sync_asset_prices(db, asset, period=period)

--- a/backend/app/routers/pseudo_etfs.py
+++ b/backend/app/routers/pseudo_etfs.py
@@ -24,13 +24,13 @@ from app.services.yahoo import batch_fetch_history
 router = APIRouter(prefix="/api/pseudo-etfs", tags=["pseudo-etfs"])
 
 
-@router.get("", response_model=list[PseudoETFResponse])
+@router.get("", response_model=list[PseudoETFResponse], summary="List all pseudo-ETFs")
 async def list_pseudo_etfs(db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(PseudoETF).order_by(PseudoETF.name))
     return result.scalars().all()
 
 
-@router.post("", response_model=PseudoETFResponse, status_code=201)
+@router.post("", response_model=PseudoETFResponse, status_code=201, summary="Create a pseudo-ETF basket")
 async def create_pseudo_etf(data: PseudoETFCreate, db: AsyncSession = Depends(get_db)):
     existing = await db.execute(select(PseudoETF).where(PseudoETF.name == data.name))
     if existing.scalar_one_or_none():
@@ -48,7 +48,7 @@ async def create_pseudo_etf(data: PseudoETFCreate, db: AsyncSession = Depends(ge
     return etf
 
 
-@router.get("/{etf_id}", response_model=PseudoETFResponse)
+@router.get("/{etf_id}", response_model=PseudoETFResponse, summary="Get a pseudo-ETF by ID")
 async def get_pseudo_etf(etf_id: int, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -56,7 +56,7 @@ async def get_pseudo_etf(etf_id: int, db: AsyncSession = Depends(get_db)):
     return etf
 
 
-@router.put("/{etf_id}", response_model=PseudoETFResponse)
+@router.put("/{etf_id}", response_model=PseudoETFResponse, summary="Update a pseudo-ETF")
 async def update_pseudo_etf(etf_id: int, data: PseudoETFUpdate, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -70,7 +70,7 @@ async def update_pseudo_etf(etf_id: int, data: PseudoETFUpdate, db: AsyncSession
     return etf
 
 
-@router.delete("/{etf_id}", status_code=204)
+@router.delete("/{etf_id}", status_code=204, summary="Delete a pseudo-ETF")
 async def delete_pseudo_etf(etf_id: int, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -79,7 +79,7 @@ async def delete_pseudo_etf(etf_id: int, db: AsyncSession = Depends(get_db)):
     await db.commit()
 
 
-@router.post("/{etf_id}/constituents", response_model=PseudoETFResponse)
+@router.post("/{etf_id}/constituents", response_model=PseudoETFResponse, summary="Add constituent assets to a pseudo-ETF")
 async def add_constituents(
     etf_id: int, data: PseudoETFAddConstituents, db: AsyncSession = Depends(get_db)
 ):
@@ -100,7 +100,7 @@ async def add_constituents(
     return etf
 
 
-@router.delete("/{etf_id}/constituents/{asset_id}", response_model=PseudoETFResponse)
+@router.delete("/{etf_id}/constituents/{asset_id}", response_model=PseudoETFResponse, summary="Remove a constituent from a pseudo-ETF")
 async def remove_constituent(
     etf_id: int, asset_id: int, db: AsyncSession = Depends(get_db)
 ):
@@ -118,7 +118,7 @@ async def remove_constituent(
     return etf
 
 
-@router.get("/{etf_id}/performance", response_model=list[PerformanceBreakdownPoint])
+@router.get("/{etf_id}/performance", response_model=list[PerformanceBreakdownPoint], summary="Get indexed performance with per-constituent breakdown")
 async def get_performance(etf_id: int, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -144,7 +144,7 @@ def _bb_position(close: float, upper: float, middle: float, lower: float) -> str
         return "below"
 
 
-@router.get("/{etf_id}/constituents/indicators", response_model=list[ConstituentIndicatorResponse])
+@router.get("/{etf_id}/constituents/indicators", response_model=list[ConstituentIndicatorResponse], summary="Get technical indicators for each constituent")
 async def get_constituent_indicators(etf_id: int, db: AsyncSession = Depends(get_db)):
     """Return latest indicator snapshot for each constituent of a pseudo-ETF."""
     etf = await db.get(PseudoETF, etf_id)
@@ -217,7 +217,7 @@ async def get_constituent_indicators(etf_id: int, db: AsyncSession = Depends(get
 
 # --- Thesis ---
 
-@router.get("/{etf_id}/thesis", response_model=ThesisResponse)
+@router.get("/{etf_id}/thesis", response_model=ThesisResponse, summary="Get pseudo-ETF investment thesis")
 async def get_etf_thesis(etf_id: int, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -230,7 +230,7 @@ async def get_etf_thesis(etf_id: int, db: AsyncSession = Depends(get_db)):
     return thesis
 
 
-@router.put("/{etf_id}/thesis", response_model=ThesisResponse)
+@router.put("/{etf_id}/thesis", response_model=ThesisResponse, summary="Create or update pseudo-ETF thesis")
 async def update_etf_thesis(etf_id: int, data: ThesisUpdate, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -252,7 +252,7 @@ async def update_etf_thesis(etf_id: int, data: ThesisUpdate, db: AsyncSession = 
 
 # --- Annotations ---
 
-@router.get("/{etf_id}/annotations", response_model=list[AnnotationResponse])
+@router.get("/{etf_id}/annotations", response_model=list[AnnotationResponse], summary="List pseudo-ETF chart annotations")
 async def list_etf_annotations(etf_id: int, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -266,7 +266,7 @@ async def list_etf_annotations(etf_id: int, db: AsyncSession = Depends(get_db)):
     return result.scalars().all()
 
 
-@router.post("/{etf_id}/annotations", response_model=AnnotationResponse, status_code=201)
+@router.post("/{etf_id}/annotations", response_model=AnnotationResponse, status_code=201, summary="Create a pseudo-ETF chart annotation")
 async def create_etf_annotation(etf_id: int, data: AnnotationCreate, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:
@@ -285,7 +285,7 @@ async def create_etf_annotation(etf_id: int, data: AnnotationCreate, db: AsyncSe
     return annotation
 
 
-@router.delete("/{etf_id}/annotations/{annotation_id}", status_code=204)
+@router.delete("/{etf_id}/annotations/{annotation_id}", status_code=204, summary="Delete a pseudo-ETF chart annotation")
 async def delete_etf_annotation(etf_id: int, annotation_id: int, db: AsyncSession = Depends(get_db)):
     etf = await db.get(PseudoETF, etf_id)
     if not etf:

--- a/backend/app/routers/thesis.py
+++ b/backend/app/routers/thesis.py
@@ -9,7 +9,7 @@ from app.schemas.thesis import ThesisResponse, ThesisUpdate
 router = APIRouter(prefix="/api/assets/{symbol}/thesis", tags=["thesis"])
 
 
-@router.get("", response_model=ThesisResponse)
+@router.get("", response_model=ThesisResponse, summary="Get investment thesis for an asset")
 async def get_thesis(symbol: str, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
     asset = result.scalar_one_or_none()
@@ -24,7 +24,7 @@ async def get_thesis(symbol: str, db: AsyncSession = Depends(get_db)):
     return thesis
 
 
-@router.put("", response_model=ThesisResponse)
+@router.put("", response_model=ThesisResponse, summary="Create or update investment thesis")
 async def update_thesis(symbol: str, data: ThesisUpdate, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
     asset = result.scalar_one_or_none()


### PR DESCRIPTION
## Summary
- Add title, summary, description, and version to FastAPI app metadata so `/docs` and `/openapi.json` explain what Fibenchi is
- Add `openapi_tags` with descriptions for all 8 API domains (assets, prices, holdings, portfolio, groups, thesis, annotations, pseudo-etfs)
- Add `summary` to all 36 endpoints so each operation is self-documenting

Closes #25

## Test plan
- [x] All 51 backend tests pass
- [x] Verified OpenAPI spec output programmatically — all tags and summaries present

🤖 Generated with [Claude Code](https://claude.com/claude-code)