### PR TITLE
fix: hide TradingView attribution logo from all charts

### DIFF
--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -188,6 +188,7 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
       layout: {
         background: { type: ColorType.Solid, color: theme.bg },
         textColor: theme.text,
+        attributionLogo: false,
       },
       grid: {
         vertLines: { color: theme.grid },
@@ -295,6 +296,7 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
       layout: {
         background: { type: ColorType.Solid, color: theme.bg },
         textColor: theme.text,
+        attributionLogo: false,
       },
       grid: {
         vertLines: { color: theme.grid },

--- a/frontend/src/components/sparkline.tsx
+++ b/frontend/src/components/sparkline.tsx
@@ -16,6 +16,7 @@ export function SparklineChart({ symbol }: { symbol: string }) {
       layout: {
         background: { type: ColorType.Solid, color: "transparent" },
         textColor: "transparent",
+        attributionLogo: false,
       },
       grid: { vertLines: { visible: false }, horzLines: { visible: false } },
       rightPriceScale: { visible: false },

--- a/frontend/src/pages/portfolio.tsx
+++ b/frontend/src/pages/portfolio.tsx
@@ -75,6 +75,7 @@ function PortfolioChart({ dates, values, up }: { dates: string[]; values: number
       layout: {
         background: { type: ColorType.Solid, color: theme.bg },
         textColor: theme.text,
+        attributionLogo: false,
       },
       grid: { vertLines: { visible: false }, horzLines: { visible: false } },
       rightPriceScale: { visible: false },

--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -150,6 +150,7 @@ function StackedAreaChart({
       layout: {
         background: { type: ColorType.Solid, color: dark ? "#18181b" : "#ffffff" },
         textColor: dark ? "#a1a1aa" : "#71717a",
+        attributionLogo: false,
       },
       grid: {
         vertLines: { color: dark ? "#27272a" : "#f4f4f5" },


### PR DESCRIPTION
## Summary
- Add `attributionLogo: false` to all 5 `createChart` layout options across the frontend
- Affected files: `price-chart.tsx` (2 charts), `sparkline.tsx`, `portfolio.tsx`, `pseudo-etf-detail.tsx`

Closes #27

## Test plan
- [x] `pnpm run build` passes (TypeScript + Vite)
- [ ] Visual check: no TradingView logo on any chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)