### PR TITLE
Add MACD chart panel to asset detail page

### DIFF
--- a/frontend/src/components/chart/chart-legends.tsx
+++ b/frontend/src/components/chart/chart-legends.tsx
@@ -8,6 +8,9 @@ export interface LegendValues {
   bbUpper?: number
   bbLower?: number
   rsi?: number
+  macd?: number
+  macdSignal?: number
+  macdHist?: number
 }
 
 export function Legend({ values, latest }: { values: LegendValues | null; latest: LegendValues }) {
@@ -49,6 +52,26 @@ export function RsiLegend({ values, latest }: { values: LegendValues | null; lat
     <div className="text-xs tabular-nums">
       <span className="text-muted-foreground">RSI(14) </span>
       {rsi !== undefined && <span className={color}>{rsi.toFixed(2)}</span>}
+    </div>
+  )
+}
+
+export function MacdLegend({ values, latest }: { values: LegendValues | null; latest: LegendValues }) {
+  const v = values ?? latest
+  const histColor = v.macdHist !== undefined
+    ? v.macdHist >= 0 ? "text-green-500" : "text-red-500"
+    : ""
+
+  return (
+    <div className="flex items-center gap-x-3 text-xs tabular-nums">
+      <span className="text-muted-foreground">MACD(12,26,9)</span>
+      {v.macd !== undefined && (
+        <>
+          <span><span className="inline-block w-2 h-0.5 bg-sky-400 mr-1 align-middle" />MACD <span className="text-sky-400">{v.macd.toFixed(2)}</span></span>
+          <span><span className="inline-block w-2 h-0.5 bg-orange-400 mr-1 align-middle" />Signal <span className="text-orange-400">{v.macdSignal!.toFixed(2)}</span></span>
+          <span className={histColor}>Hist {v.macdHist!.toFixed(2)}</span>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a third synced chart panel (MACD) below the RSI chart on the asset detail page
- Displays MACD line (sky blue), signal line (orange), and histogram bars (green/red)
- Includes zero reference line and interactive MACD legend with hover values
- Full crosshair and scroll sync across all 3 chart panels (price, RSI, MACD)

Closes #47

## Test plan
- [ ] Open any asset detail page — MACD panel appears below RSI
- [ ] Hover over charts — crosshair syncs across all 3 panels and legend values update
- [ ] Pan/zoom on any chart — all 3 stay in sync
- [ ] Reset view button resets all 3 charts
- [ ] Histogram bars are green for positive, red for negative
- [ ] MACD and signal lines render with correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)