### PR TITLE
refactor: extract shared frontend components and reduce duplication

### DIFF
--- a/frontend/src/components/add-constituent-picker.tsx
+++ b/frontend/src/components/add-constituent-picker.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react"
+import { Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import {
+  useAssets,
+  useAddPseudoEtfConstituents,
+  useCreateAsset,
+} from "@/lib/queries"
+
+export function AddConstituentPicker({
+  etfId,
+  existingIds,
+  onClose,
+}: {
+  etfId: number
+  existingIds: number[]
+  onClose: () => void
+}) {
+  const { data: allAssets } = useAssets()
+  const addConstituents = useAddPseudoEtfConstituents()
+  const createAsset = useCreateAsset()
+  const available = allAssets?.filter((a) => !existingIds.includes(a.id)) ?? []
+  const [selected, setSelected] = useState<number[]>([])
+  const [newTicker, setNewTicker] = useState("")
+  const [tickerError, setTickerError] = useState("")
+
+  const toggle = (id: number) => {
+    setSelected((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  }
+
+  const handleAdd = () => {
+    if (!selected.length) return
+    addConstituents.mutate({ etfId, assetIds: selected }, { onSuccess: () => onClose() })
+  }
+
+  const handleNewTicker = () => {
+    const sym = newTicker.trim().toUpperCase()
+    if (!sym) return
+    setTickerError("")
+    createAsset.mutate(
+      { symbol: sym, watchlisted: false },
+      {
+        onSuccess: (asset) => {
+          addConstituents.mutate(
+            { etfId, assetIds: [asset.id] },
+            { onSuccess: () => { setNewTicker(""); onClose() } }
+          )
+        },
+        onError: (err) => setTickerError(err.message),
+      }
+    )
+  }
+
+  return (
+    <div className="p-3 rounded-md border bg-muted/30 space-y-3">
+      <div className="flex gap-2 items-center">
+        <Input
+          placeholder="New ticker (e.g. AAPL)"
+          value={newTicker}
+          onChange={(e) => { setNewTicker(e.target.value); setTickerError("") }}
+          onKeyDown={(e) => e.key === "Enter" && handleNewTicker()}
+          className="w-48"
+        />
+        <Button size="sm" onClick={handleNewTicker} disabled={!newTicker.trim() || createAsset.isPending}>
+          <Plus className="h-3.5 w-3.5 mr-1" />
+          {createAsset.isPending ? "Adding..." : "Add new"}
+        </Button>
+        {tickerError && <span className="text-xs text-destructive">{tickerError}</span>}
+      </div>
+
+      {available.length > 0 && (
+        <>
+          <p className="text-xs text-muted-foreground">Or pick existing assets:</p>
+          <div className="flex flex-wrap gap-1.5">
+            {available.map((a) => (
+              <Badge
+                key={a.id}
+                variant={selected.includes(a.id) ? "default" : "outline"}
+                className="cursor-pointer"
+                onClick={() => toggle(a.id)}
+              >
+                {a.symbol}
+              </Badge>
+            ))}
+          </div>
+        </>
+      )}
+
+      <div className="flex justify-end gap-1">
+        <Button size="sm" variant="ghost" onClick={onClose}>Cancel</Button>
+        {selected.length > 0 && (
+          <Button size="sm" onClick={handleAdd} disabled={addConstituents.isPending}>
+            Add ({selected.length})
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chart/pseudo-etf-charts.tsx
+++ b/frontend/src/components/chart/pseudo-etf-charts.tsx
@@ -1,0 +1,326 @@
+import { useState, useEffect, useRef, useMemo } from "react"
+import { Link } from "react-router-dom"
+import {
+  createChart,
+  type IChartApi,
+  AreaSeries,
+  LineSeries,
+  HistogramSeries,
+} from "lightweight-charts"
+import { baseChartOptions, getChartTheme, STACK_COLORS } from "@/lib/chart-utils"
+import type { PerformanceBreakdownPoint } from "@/lib/api"
+
+interface SharedChartProps {
+  data: PerformanceBreakdownPoint[]
+  sortedSymbols: string[]
+  symbolColorMap: Map<string, string>
+}
+
+export function StackedAreaChart({
+  data,
+  baseValue,
+  sortedSymbols,
+  symbolColorMap,
+}: SharedChartProps & { baseValue: number }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const topSeriesRef = useRef<ReturnType<IChartApi["addSeries"]> | null>(null)
+  const [hoverData, setHoverData] = useState<{ total: number; breakdown: Record<string, number> } | null>(null)
+
+  const totalByTime = useRef(new Map<string, number>())
+  const breakdownByTime = useRef(new Map<string, Record<string, number>>())
+
+  useEffect(() => {
+    if (!ref.current || !data.length || !sortedSymbols.length) return
+
+    totalByTime.current.clear()
+    breakdownByTime.current.clear()
+    for (const point of data) {
+      totalByTime.current.set(point.date, point.value)
+      breakdownByTime.current.set(point.date, point.breakdown)
+    }
+
+    const chart = createChart(ref.current, baseChartOptions(ref.current, 440))
+
+    // Build cumulative series: for position i, value = sum of symbols 0..i
+    const cumulativeData: { symbol: string; points: { time: string; value: number }[] }[] = []
+
+    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
+      const points = data.map((point) => {
+        let cumValue = 0
+        for (let j = 0; j <= i; j++) {
+          cumValue += point.breakdown[sortedSymbols[j]] ?? 0
+        }
+        return { time: point.date, value: cumValue }
+      })
+      cumulativeData.push({ symbol: sortedSymbols[i], points })
+    }
+
+    let topSeries: ReturnType<IChartApi["addSeries"]> | null = null
+    for (let idx = 0; idx < cumulativeData.length; idx++) {
+      const { symbol, points } = cumulativeData[idx]
+      const color = symbolColorMap.get(symbol) ?? STACK_COLORS[0]
+      const isTop = idx === 0
+      const series = chart.addSeries(AreaSeries, {
+        lineColor: color,
+        topColor: color,
+        bottomColor: color,
+        lineWidth: 1,
+        priceLineVisible: false,
+        crosshairMarkerVisible: isTop,
+      })
+      series.setData(points)
+      if (isTop) topSeries = series
+    }
+    topSeriesRef.current = topSeries
+
+    // Base value reference line
+    const theme = getChartTheme()
+    const baseLine = chart.addSeries(LineSeries, {
+      color: theme.dark ? "rgba(161, 161, 170, 0.5)" : "rgba(113, 113, 122, 0.5)",
+      lineWidth: 1,
+      lineStyle: 2,
+      priceLineVisible: false,
+      crosshairMarkerVisible: false,
+    })
+    baseLine.setData(data.map((p) => ({ time: p.date, value: baseValue })))
+
+    // Crosshair snap + legend update
+    let snapping = false
+    chart.subscribeCrosshairMove((param) => {
+      if (param.time) {
+        const key = String(param.time)
+        const total = totalByTime.current.get(key)
+        const breakdown = breakdownByTime.current.get(key)
+        if (total !== undefined && breakdown) {
+          setHoverData({ total, breakdown })
+        }
+        if (!snapping && total !== undefined && topSeries) {
+          snapping = true
+          chart.setCrosshairPosition(total, param.time, topSeries)
+          snapping = false
+        }
+      } else {
+        setHoverData(null)
+      }
+    })
+
+    chart.timeScale().fitContent()
+    chartRef.current = chart
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        chart.applyOptions({ width: entry.contentRect.width })
+      }
+    })
+    resizeObserver.observe(ref.current)
+
+    return () => {
+      resizeObserver.disconnect()
+      chart.remove()
+      chartRef.current = null
+      topSeriesRef.current = null
+    }
+  }, [data, baseValue, sortedSymbols, symbolColorMap])
+
+  const lastPoint = data[data.length - 1]
+  const displayData = hoverData ?? (lastPoint ? { total: lastPoint.value, breakdown: lastPoint.breakdown } : null)
+
+  return (
+    <div className="space-y-2">
+      <div ref={ref} className="w-full rounded-md overflow-hidden" />
+      <SymbolLegend
+        sortedSymbols={sortedSymbols}
+        symbolColorMap={symbolColorMap}
+        values={displayData ? sortedSymbols.map((sym) => displayData.breakdown[sym]?.toFixed(2)) : undefined}
+        suffix={displayData ? <span className="text-xs font-medium ml-auto">Total: {displayData.total.toFixed(2)}</span> : undefined}
+      />
+    </div>
+  )
+}
+
+export function DailyContributionChart({ data, sortedSymbols, symbolColorMap }: SharedChartProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const [hoverData, setHoverData] = useState<{ date: string; deltas: Record<string, number>; total: number } | null>(null)
+
+  const deltasByTime = useRef(new Map<string, Record<string, number>>())
+
+  useEffect(() => {
+    if (!ref.current || data.length < 2 || !sortedSymbols.length) return
+
+    deltasByTime.current.clear()
+
+    // Compute daily deltas per symbol
+    const dailyData: { date: string; deltas: Record<string, number> }[] = []
+    for (let d = 1; d < data.length; d++) {
+      const deltas: Record<string, number> = {}
+      for (const sym of sortedSymbols) {
+        deltas[sym] = (data[d].breakdown[sym] ?? 0) - (data[d - 1].breakdown[sym] ?? 0)
+      }
+      dailyData.push({ date: data[d].date, deltas })
+      deltasByTime.current.set(data[d].date, deltas)
+    }
+
+    // Compute positive and negative cumulative stacks per day
+    const posCum: number[][] = []
+    const negCum: number[][] = []
+    for (const { deltas } of dailyData) {
+      const pos: number[] = []
+      const neg: number[] = []
+      let posSum = 0
+      let negSum = 0
+      for (const sym of sortedSymbols) {
+        const delta = deltas[sym]
+        if (delta > 0) posSum += delta
+        if (delta < 0) negSum += delta
+        pos.push(posSum)
+        neg.push(negSum)
+      }
+      posCum.push(pos)
+      negCum.push(neg)
+    }
+
+    const chart = createChart(ref.current, baseChartOptions(ref.current, 250))
+
+    // Draw positive stack: outermost first (i = N-1 -> 0)
+    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
+      const sym = sortedSymbols[i]
+      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
+      const series = chart.addSeries(HistogramSeries, {
+        color,
+        priceLineVisible: false,
+        base: 0,
+      })
+      series.setData(
+        dailyData.map((d, dayIdx) => ({
+          time: d.date,
+          value: posCum[dayIdx][i],
+        }))
+      )
+    }
+
+    // Draw negative stack: outermost first (i = N-1 -> 0)
+    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
+      const sym = sortedSymbols[i]
+      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
+      const series = chart.addSeries(HistogramSeries, {
+        color,
+        priceLineVisible: false,
+        base: 0,
+      })
+      series.setData(
+        dailyData.map((d, dayIdx) => ({
+          time: d.date,
+          value: negCum[dayIdx][i],
+        }))
+      )
+    }
+
+    // Crosshair
+    chart.subscribeCrosshairMove((param) => {
+      if (param.time) {
+        const key = String(param.time)
+        const deltas = deltasByTime.current.get(key)
+        if (deltas) {
+          const total = Object.values(deltas).reduce((s, v) => s + v, 0)
+          setHoverData({ date: key, deltas, total })
+        }
+      } else {
+        setHoverData(null)
+      }
+    })
+
+    chart.timeScale().fitContent()
+    chartRef.current = chart
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        chart.applyOptions({ width: entry.contentRect.width })
+      }
+    })
+    resizeObserver.observe(ref.current)
+
+    return () => {
+      resizeObserver.disconnect()
+      chart.remove()
+      chartRef.current = null
+    }
+  }, [data, sortedSymbols, symbolColorMap])
+
+  // Default to latest day
+  const latestDeltas = useMemo(() => {
+    if (data.length < 2 || !sortedSymbols.length) return null
+    const last = data[data.length - 1]
+    const prev = data[data.length - 2]
+    const deltas: Record<string, number> = {}
+    for (const sym of sortedSymbols) {
+      deltas[sym] = (last.breakdown[sym] ?? 0) - (prev.breakdown[sym] ?? 0)
+    }
+    const total = Object.values(deltas).reduce((s, v) => s + v, 0)
+    return { date: last.date, deltas, total }
+  }, [data, sortedSymbols])
+  const displayData = hoverData ?? latestDeltas
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold px-1">Daily Contribution</h3>
+      <div ref={ref} className="w-full rounded-md overflow-hidden" />
+      <SymbolLegend
+        sortedSymbols={sortedSymbols}
+        symbolColorMap={symbolColorMap}
+        values={displayData ? sortedSymbols.map((sym) => {
+          const v = displayData.deltas[sym]
+          return v !== undefined ? `${v >= 0 ? "+" : ""}${v.toFixed(2)}` : undefined
+        }) : undefined}
+        valueColors={displayData ? sortedSymbols.map((sym) => {
+          const v = displayData.deltas[sym]
+          return v !== undefined ? (v >= 0 ? "text-emerald-500" : "text-red-500") : undefined
+        }) : undefined}
+        suffix={displayData ? (
+          <span className="text-xs font-medium ml-auto">
+            Net: <span className={displayData.total >= 0 ? "text-emerald-500" : "text-red-500"}>
+              {displayData.total >= 0 ? "+" : ""}{displayData.total.toFixed(2)}
+            </span>
+          </span>
+        ) : undefined}
+      />
+    </div>
+  )
+}
+
+function SymbolLegend({
+  sortedSymbols,
+  symbolColorMap,
+  values,
+  valueColors,
+  suffix,
+}: {
+  sortedSymbols: string[]
+  symbolColorMap: Map<string, string>
+  values?: (string | undefined)[]
+  valueColors?: (string | undefined)[]
+  suffix?: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 px-1 items-center">
+      {sortedSymbols.map((sym, idx) => (
+        <div key={sym} className="flex items-center gap-1.5 text-xs">
+          <div
+            className="w-3 h-3 rounded-sm flex-shrink-0"
+            style={{ backgroundColor: symbolColorMap.get(sym) }}
+          />
+          <Link to={`/asset/${sym}`} className="hover:underline text-muted-foreground hover:text-foreground">
+            {sym}
+          </Link>
+          {values?.[idx] !== undefined && (
+            <span className={`font-mono ${valueColors?.[idx] ?? "text-muted-foreground"}`}>
+              {values[idx]}
+            </span>
+          )}
+        </div>
+      ))}
+      {suffix}
+    </div>
+  )
+}

--- a/frontend/src/components/holdings-grid.tsx
+++ b/frontend/src/components/holdings-grid.tsx
@@ -1,0 +1,114 @@
+import { Link } from "react-router-dom"
+import { X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { IndicatorCell } from "@/components/indicator-cell"
+import { formatPrice, formatChangePct } from "@/lib/format"
+
+export interface IndicatorData {
+  currency: string
+  close: number | null
+  change_pct: number | null
+  rsi: number | null
+  sma_20: number | null
+  macd_signal_dir: string | null
+  bb_position: string | null
+}
+
+export interface HoldingsGridRow {
+  key: string | number
+  symbol: string
+  name: string
+  percent: number | null
+}
+
+interface HoldingsGridProps {
+  rows: HoldingsGridRow[]
+  indicatorMap: ReadonlyMap<string, IndicatorData>
+  indicatorsLoading: boolean
+  onRemove?: (key: string | number) => void
+  linkTarget?: "_blank"
+}
+
+const GRID_COLS = "grid-cols-[4rem_1fr_3.5rem_5rem_4rem_3.5rem_3.5rem_4rem_3.5rem]"
+const GRID_COLS_REMOVABLE = "grid-cols-[4rem_1fr_3.5rem_5rem_4rem_3.5rem_3.5rem_4rem_3.5rem_2rem]"
+
+export function HoldingsGrid({ rows, indicatorMap, indicatorsLoading, onRemove, linkTarget }: HoldingsGridProps) {
+  const hasRemove = !!onRemove
+  const gridCols = hasRemove ? GRID_COLS_REMOVABLE : GRID_COLS
+
+  return (
+    <div className="overflow-x-auto">
+      <div className={`${hasRemove ? "min-w-[750px]" : "min-w-[700px]"} space-y-0`}>
+        <div className={`grid ${gridCols} text-xs text-muted-foreground border-b border-border pb-1 mb-1 gap-x-2`}>
+          <span>Symbol</span>
+          <span>Name</span>
+          <span className="text-right">%</span>
+          <span className="text-right">Price</span>
+          <span className="text-right">Chg%</span>
+          <span className="text-right">RSI</span>
+          <span className="text-right">SMA20</span>
+          <span className="text-right">MACD</span>
+          <span className="text-right">BB</span>
+          {hasRemove && <span></span>}
+        </div>
+        {rows.map((row) => {
+          const ind = indicatorMap.get(row.symbol)
+          const chg = formatChangePct(ind?.change_pct ?? null)
+          const rsiVal = ind?.rsi
+          const rsiColor = rsiVal != null ? (rsiVal > 70 ? "text-red-500" : rsiVal < 30 ? "text-emerald-500" : "") : ""
+          const smaAbove = ind?.sma_20 != null && ind?.close != null ? ind.close > ind.sma_20 : null
+          const macdDir = ind?.macd_signal_dir
+          const bbPos = ind?.bb_position
+
+          return (
+            <div
+              key={row.key}
+              className={`grid ${gridCols} text-sm py-1 hover:bg-muted/50 rounded gap-x-2 items-center${hasRemove ? " group/row" : ""}`}
+            >
+              <Link
+                to={`/asset/${row.symbol}`}
+                {...(linkTarget === "_blank" ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                className="font-mono text-xs text-primary hover:underline"
+              >
+                {row.symbol}
+              </Link>
+              <span className="text-muted-foreground truncate text-xs">{row.name}</span>
+              <IndicatorCell value={row.percent != null ? `${row.percent.toFixed(1)}%` : null} />
+              {indicatorsLoading ? (
+                <span className="col-span-6 text-right text-xs text-muted-foreground animate-pulse">Loading...</span>
+              ) : (
+                <>
+                  <IndicatorCell value={ind?.close != null ? formatPrice(ind.close, ind.currency, 0) : null} />
+                  <IndicatorCell value={chg.text} className={chg.className} />
+                  <IndicatorCell value={rsiVal != null ? rsiVal.toFixed(0) : null} className={rsiColor} />
+                  <IndicatorCell
+                    value={smaAbove !== null ? (smaAbove ? "Above" : "Below") : null}
+                    className={smaAbove === true ? "text-emerald-500" : smaAbove === false ? "text-red-500" : ""}
+                  />
+                  <IndicatorCell
+                    value={macdDir != null ? (macdDir === "bullish" ? "Bull" : "Bear") : null}
+                    className={macdDir === "bullish" ? "text-emerald-500" : macdDir === "bearish" ? "text-red-500" : ""}
+                  />
+                  <IndicatorCell
+                    value={bbPos != null ? bbPos.charAt(0).toUpperCase() + bbPos.slice(1) : null}
+                    className={bbPos === "above" ? "text-red-500" : bbPos === "below" ? "text-emerald-500" : ""}
+                  />
+                </>
+              )}
+              {hasRemove && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5 opacity-0 group-hover/row:opacity-100 transition-opacity"
+                  onClick={() => onRemove!(row.key)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/indicator-cell.tsx
+++ b/frontend/src/components/indicator-cell.tsx
@@ -1,0 +1,7 @@
+export function IndicatorCell({ value, className = "" }: { value: string | null; className?: string }) {
+  return (
+    <span className={`text-right text-xs ${value === null ? "text-muted-foreground" : className}`}>
+      {value ?? "\u2014"}
+    </span>
+  )
+}

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -9,6 +9,7 @@ import {
   HistogramSeries,
 } from "lightweight-charts"
 import type { Price, Indicator, Annotation } from "@/lib/api"
+import { getChartTheme } from "@/lib/chart-utils"
 import { BandFillPrimitive } from "./chart/bollinger-band-fill"
 import { Legend, RsiLegend, MacdLegend, type LegendValues } from "./chart/chart-legends"
 
@@ -16,16 +17,6 @@ interface PriceChartProps {
   prices: Price[]
   indicators: Indicator[]
   annotations: Annotation[]
-}
-
-function getThemeColors() {
-  const dark = document.documentElement.classList.contains("dark")
-  return {
-    bg: dark ? "#18181b" : "#ffffff",
-    text: dark ? "#a1a1aa" : "#71717a",
-    grid: dark ? "#27272a" : "#f4f4f5",
-    border: dark ? "#3f3f46" : "#e4e4e7",
-  }
 }
 
 export function PriceChart({ prices, indicators, annotations }: PriceChartProps) {
@@ -183,7 +174,7 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
       macdHist: lastIndicators.find((i) => i.macd_hist !== null)?.macd_hist ?? undefined,
     }
 
-    const theme = getThemeColors()
+    const theme = getChartTheme()
 
     // Main chart
     const mainChart = createChart(mainRef.current, {

--- a/frontend/src/lib/chart-utils.ts
+++ b/frontend/src/lib/chart-utils.ts
@@ -1,0 +1,51 @@
+import { ColorType } from "lightweight-charts"
+
+export const STACK_COLORS = [
+  "#2563eb", "#dc2626", "#16a34a", "#d97706", "#9333ea",
+  "#0891b2", "#e11d48", "#65a30d", "#c026d3", "#0d9488",
+  "#ea580c", "#4f46e5", "#059669", "#db2777", "#ca8a04",
+  "#7c3aed", "#0284c7", "#be123c", "#15803d", "#a21caf",
+]
+
+export function getChartTheme() {
+  const dark = document.documentElement.classList.contains("dark")
+  return {
+    bg: dark ? "#18181b" : "#ffffff",
+    text: dark ? "#a1a1aa" : "#71717a",
+    grid: dark ? "#27272a" : "#f4f4f5",
+    border: dark ? "#3f3f46" : "#e4e4e7",
+    dark,
+  }
+}
+
+export function baseChartOptions(container: HTMLElement, height: number) {
+  const theme = getChartTheme()
+  return {
+    width: container.clientWidth,
+    height,
+    layout: {
+      background: { type: ColorType.Solid, color: theme.bg },
+      textColor: theme.text,
+      attributionLogo: false,
+    },
+    grid: {
+      vertLines: { color: theme.grid },
+      horzLines: { color: theme.grid },
+    },
+    rightPriceScale: { borderColor: theme.border },
+    timeScale: { borderColor: theme.border, timeVisible: false },
+    crosshair: { mode: 0 as const },
+    handleScroll: {
+      horzTouchDrag: true,
+      vertTouchDrag: false,
+      mouseWheel: false,
+      pressedMouseMove: true,
+    },
+    handleScale: {
+      mouseWheel: true,
+      pinch: true,
+      axisPressedMouseMove: false as const,
+      axisDoubleClickReset: { time: true, price: false },
+    },
+  }
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -14,6 +14,15 @@ export function formatPrice(value: number, currency: string, decimals = 2): stri
   return `${currencySymbol(currency)}${value.toFixed(decimals)}`
 }
 
+export function formatChangePct(v: number | null): { text: string | null; className: string } {
+  if (v === null) return { text: null, className: "" }
+  const sign = v >= 0 ? "+" : ""
+  return {
+    text: `${sign}${v.toFixed(2)}%`,
+    className: v >= 0 ? "text-emerald-500" : "text-red-500",
+  }
+}
+
 /**
  * Build a Yahoo Finance advanced chart URL with pre-configured indicators.
  * Config includes: candlestick + volume, Bollinger Bands (20,2), RSI (14), MACD (12,26,9), 1Y daily.

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -7,8 +7,9 @@ import { PriceChart } from "@/components/price-chart"
 import { ThesisEditor } from "@/components/thesis-editor"
 import { AnnotationsList } from "@/components/annotations-list"
 import { TagInput } from "@/components/tag-input"
-import { formatPrice, buildYahooFinanceUrl } from "@/lib/format"
-import type { EtfHoldings, HoldingIndicator } from "@/lib/api"
+import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
+import { buildYahooFinanceUrl } from "@/lib/format"
+import type { EtfHoldings } from "@/lib/api"
 import {
   useAssets,
   useCreateAsset,
@@ -206,92 +207,33 @@ function HoldingsSection({ symbol }: { symbol: string }) {
   )
 }
 
-function IndicatorCell({ value, className = "" }: { value: string | null; className?: string }) {
-  return (
-    <span className={`text-right text-xs ${value === null ? "text-muted-foreground" : className}`}>
-      {value ?? "—"}
-    </span>
-  )
-}
-
-function formatChangePct(v: number | null): { text: string | null; className: string } {
-  if (v === null) return { text: null, className: "" }
-  const sign = v >= 0 ? "+" : ""
-  return {
-    text: `${sign}${v.toFixed(2)}%`,
-    className: v >= 0 ? "text-emerald-500" : "text-red-500",
-  }
-}
-
 function TopHoldingsCard({
   data,
   indicatorMap,
   indicatorsLoading,
 }: {
   data: EtfHoldings
-  indicatorMap: Map<string, HoldingIndicator>
+  indicatorMap: ReadonlyMap<string, { currency: string; close: number | null; change_pct: number | null; rsi: number | null; sma_20: number | null; macd_signal_dir: string | null; bb_position: string | null }>
   indicatorsLoading: boolean
 }) {
+  const rows: HoldingsGridRow[] = data.top_holdings.map((h) => ({
+    key: h.symbol,
+    symbol: h.symbol,
+    name: h.name,
+    percent: h.percent,
+  }))
+
   return (
     <Card className="p-4">
       <h3 className="text-sm font-semibold mb-3">
         Top {data.top_holdings.length} Holdings ({data.total_percent}% of Total Assets)
       </h3>
-      <div className="overflow-x-auto">
-        <div className="min-w-[700px] space-y-0">
-          <div className="grid grid-cols-[4rem_1fr_3.5rem_5rem_4rem_3.5rem_3.5rem_4rem_3.5rem] text-xs text-muted-foreground border-b border-border pb-1 mb-1 gap-x-2">
-            <span>Symbol</span>
-            <span>Company</span>
-            <span className="text-right">%</span>
-            <span className="text-right">Price</span>
-            <span className="text-right">Chg%</span>
-            <span className="text-right">RSI</span>
-            <span className="text-right">SMA20</span>
-            <span className="text-right">MACD</span>
-            <span className="text-right">BB</span>
-          </div>
-          {data.top_holdings.map((h) => {
-            const ind = indicatorMap.get(h.symbol)
-            const chg = formatChangePct(ind?.change_pct ?? null)
-            const rsiVal = ind?.rsi
-            const rsiColor = rsiVal != null ? (rsiVal > 70 ? "text-red-500" : rsiVal < 30 ? "text-emerald-500" : "") : ""
-            const smaAbove = ind?.sma_20 != null && ind?.close != null ? ind.close > ind.sma_20 : null
-            const macdDir = ind?.macd_signal_dir
-            const bbPos = ind?.bb_position
-
-            return (
-              <div key={h.symbol} className="grid grid-cols-[4rem_1fr_3.5rem_5rem_4rem_3.5rem_3.5rem_4rem_3.5rem] text-sm py-1 hover:bg-muted/50 rounded gap-x-2 items-center">
-                <a href={`/asset/${h.symbol}`} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-primary hover:underline">{h.symbol}</a>
-                <span className="text-muted-foreground truncate text-xs">{h.name}</span>
-                <span className="text-right font-medium text-xs">{h.percent.toFixed(1)}%</span>
-                {indicatorsLoading ? (
-                  <span className="col-span-6 text-right text-xs text-muted-foreground animate-pulse">Loading...</span>
-                ) : (
-                  <>
-                    <IndicatorCell value={ind?.close != null ? formatPrice(ind.close, ind.currency, 0) : null} />
-                    <IndicatorCell value={chg.text} className={chg.className} />
-                    <IndicatorCell value={rsiVal != null ? rsiVal.toFixed(0) : null} className={rsiColor} />
-                    <IndicatorCell
-                      value={smaAbove !== null ? (smaAbove ? "Above" : "Below") : null}
-                      className={smaAbove === true ? "text-emerald-500" : smaAbove === false ? "text-red-500" : ""}
-                    />
-                    <IndicatorCell
-                      value={macdDir != null ? (macdDir === "bullish" ? "Bull" : "Bear") : null}
-                      className={macdDir === "bullish" ? "text-emerald-500" : macdDir === "bearish" ? "text-red-500" : ""}
-                    />
-                    <IndicatorCell
-                      value={bbPos != null ? bbPos.charAt(0).toUpperCase() + bbPos.slice(1) : null}
-                      className={
-                        bbPos === "above" ? "text-red-500" : bbPos === "below" ? "text-emerald-500" : ""
-                      }
-                    />
-                  </>
-                )}
-              </div>
-            )
-          })}
-        </div>
-      </div>
+      <HoldingsGrid
+        rows={rows}
+        indicatorMap={indicatorMap}
+        indicatorsLoading={indicatorsLoading}
+        linkTarget="_blank"
+      />
     </Card>
   )
 }

--- a/frontend/src/pages/portfolio.tsx
+++ b/frontend/src/pages/portfolio.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react"
+import { useEffect, useRef, useState } from "react"
 import { createChart, type IChartApi, ColorType, AreaSeries } from "lightweight-charts"
 import { Link } from "react-router-dom"
 import { Loader2, TrendingUp, TrendingDown } from "lucide-react"
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { usePortfolioIndex, usePortfolioPerformers } from "@/lib/queries"
+import { getChartTheme } from "@/lib/chart-utils"
 import type { AssetPerformance } from "@/lib/api"
 
 const PERIODS = ["1mo", "3mo", "6mo", "1y", "2y", "5y"] as const
@@ -56,18 +57,10 @@ function PortfolioChart({ dates, values, up }: { dates: string[]; values: number
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
 
-  const getThemeColors = useCallback(() => {
-    const dark = document.documentElement.classList.contains("dark")
-    return {
-      bg: dark ? "#18181b" : "#ffffff",
-      text: dark ? "#a1a1aa" : "#71717a",
-    }
-  }, [])
-
   useEffect(() => {
     if (!containerRef.current || !dates.length) return
 
-    const theme = getThemeColors()
+    const theme = getChartTheme()
 
     const chart = createChart(containerRef.current, {
       width: containerRef.current.clientWidth,
@@ -126,7 +119,7 @@ function PortfolioChart({ dates, values, up }: { dates: string[]; values: number
       chart.remove()
       chartRef.current = null
     }
-  }, [dates, values, up, getThemeColors])
+  }, [dates, values, up])
 
   return <div ref={containerRef} className="w-full rounded-md overflow-hidden" />
 }

--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -1,92 +1,29 @@
-import { useState, useEffect, useRef, useMemo } from "react"
+import { useState, useMemo } from "react"
 import { useParams, Link } from "react-router-dom"
-import { ArrowLeft, UserPlus, X, Plus, Loader2 } from "lucide-react"
-import { formatPrice } from "@/lib/format"
+import { ArrowLeft, UserPlus, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ThesisEditor } from "@/components/thesis-editor"
 import { AnnotationsList } from "@/components/annotations-list"
+import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
+import { AddConstituentPicker } from "@/components/add-constituent-picker"
 import {
-  createChart,
-  type IChartApi,
-  ColorType,
-  AreaSeries,
-  LineSeries,
-  HistogramSeries,
-} from "lightweight-charts"
+  StackedAreaChart,
+  DailyContributionChart,
+} from "@/components/chart/pseudo-etf-charts"
+import { STACK_COLORS } from "@/lib/chart-utils"
 import type { PerformanceBreakdownPoint } from "@/lib/api"
 import {
   usePseudoEtf,
   usePseudoEtfPerformance,
   usePseudoEtfConstituentsIndicators,
-  useAssets,
-  useAddPseudoEtfConstituents,
   useRemovePseudoEtfConstituent,
-  useCreateAsset,
   usePseudoEtfThesis,
   useUpdatePseudoEtfThesis,
   usePseudoEtfAnnotations,
   useCreatePseudoEtfAnnotation,
   useDeletePseudoEtfAnnotation,
 } from "@/lib/queries"
-
-const STACK_COLORS = [
-  "#2563eb", "#dc2626", "#16a34a", "#d97706", "#9333ea",
-  "#0891b2", "#e11d48", "#65a30d", "#c026d3", "#0d9488",
-  "#ea580c", "#4f46e5", "#059669", "#db2777", "#ca8a04",
-  "#7c3aed", "#0284c7", "#be123c", "#15803d", "#a21caf",
-]
-
-function getChartTheme() {
-  const dark = document.documentElement.classList.contains("dark")
-  return {
-    bg: dark ? "#18181b" : "#ffffff",
-    text: dark ? "#a1a1aa" : "#71717a",
-    grid: dark ? "#27272a" : "#f4f4f5",
-    border: dark ? "#3f3f46" : "#e4e4e7",
-    dark,
-  }
-}
-
-function baseChartOptions(container: HTMLElement, height: number) {
-  const theme = getChartTheme()
-  return {
-    width: container.clientWidth,
-    height,
-    layout: {
-      background: { type: ColorType.Solid, color: theme.bg },
-      textColor: theme.text,
-      attributionLogo: false,
-    },
-    grid: {
-      vertLines: { color: theme.grid },
-      horzLines: { color: theme.grid },
-    },
-    rightPriceScale: { borderColor: theme.border },
-    timeScale: { borderColor: theme.border, timeVisible: false },
-    crosshair: { mode: 0 as const },
-    handleScroll: {
-      horzTouchDrag: true,
-      vertTouchDrag: false,
-      mouseWheel: false,
-      pressedMouseMove: true,
-    },
-    handleScale: {
-      mouseWheel: true,
-      pinch: true,
-      axisPressedMouseMove: false as const,
-      axisDoubleClickReset: { time: true, price: false },
-    },
-  }
-}
-
-interface SharedChartProps {
-  data: PerformanceBreakdownPoint[]
-  sortedSymbols: string[]
-  symbolColorMap: Map<string, string>
-}
 
 export function PseudoEtfDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -159,320 +96,8 @@ export function PseudoEtfDetailPage() {
       )}
 
       <HoldingsTable etfId={etfId} />
-
       <AnnotationsSection etfId={etfId} />
       <ThesisSection etfId={etfId} />
-    </div>
-  )
-}
-
-function StackedAreaChart({
-  data,
-  baseValue,
-  sortedSymbols,
-  symbolColorMap,
-}: SharedChartProps & { baseValue: number }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const chartRef = useRef<IChartApi | null>(null)
-  const topSeriesRef = useRef<ReturnType<IChartApi["addSeries"]> | null>(null)
-  const [hoverData, setHoverData] = useState<{ total: number; breakdown: Record<string, number> } | null>(null)
-
-  const totalByTime = useRef(new Map<string, number>())
-  const breakdownByTime = useRef(new Map<string, Record<string, number>>())
-
-  useEffect(() => {
-    if (!ref.current || !data.length || !sortedSymbols.length) return
-
-    totalByTime.current.clear()
-    breakdownByTime.current.clear()
-    for (const point of data) {
-      totalByTime.current.set(point.date, point.value)
-      breakdownByTime.current.set(point.date, point.breakdown)
-    }
-
-    const chart = createChart(ref.current, baseChartOptions(ref.current, 440))
-
-    // Build cumulative series: for position i, value = sum of symbols 0..i
-    const cumulativeData: { symbol: string; points: { time: string; value: number }[] }[] = []
-
-    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
-      const points = data.map((point) => {
-        let cumValue = 0
-        for (let j = 0; j <= i; j++) {
-          cumValue += point.breakdown[sortedSymbols[j]] ?? 0
-        }
-        return { time: point.date, value: cumValue }
-      })
-      cumulativeData.push({ symbol: sortedSymbols[i], points })
-    }
-
-    let topSeries: ReturnType<IChartApi["addSeries"]> | null = null
-    for (let idx = 0; idx < cumulativeData.length; idx++) {
-      const { symbol, points } = cumulativeData[idx]
-      const color = symbolColorMap.get(symbol) ?? STACK_COLORS[0]
-      const isTop = idx === 0
-      const series = chart.addSeries(AreaSeries, {
-        lineColor: color,
-        topColor: color,
-        bottomColor: color,
-        lineWidth: 1,
-        priceLineVisible: false,
-        crosshairMarkerVisible: isTop,
-      })
-      series.setData(points)
-      if (isTop) topSeries = series
-    }
-    topSeriesRef.current = topSeries
-
-    // Base value reference line
-    const theme = getChartTheme()
-    const baseLine = chart.addSeries(LineSeries, {
-      color: theme.dark ? "rgba(161, 161, 170, 0.5)" : "rgba(113, 113, 122, 0.5)",
-      lineWidth: 1,
-      lineStyle: 2,
-      priceLineVisible: false,
-      crosshairMarkerVisible: false,
-    })
-    baseLine.setData(data.map((p) => ({ time: p.date, value: baseValue })))
-
-    // Crosshair snap + legend update
-    let snapping = false
-    chart.subscribeCrosshairMove((param) => {
-      if (param.time) {
-        const key = String(param.time)
-        const total = totalByTime.current.get(key)
-        const breakdown = breakdownByTime.current.get(key)
-        if (total !== undefined && breakdown) {
-          setHoverData({ total, breakdown })
-        }
-        if (!snapping && total !== undefined && topSeries) {
-          snapping = true
-          chart.setCrosshairPosition(total, param.time, topSeries)
-          snapping = false
-        }
-      } else {
-        setHoverData(null)
-      }
-    })
-
-    chart.timeScale().fitContent()
-    chartRef.current = chart
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        chart.applyOptions({ width: entry.contentRect.width })
-      }
-    })
-    resizeObserver.observe(ref.current)
-
-    return () => {
-      resizeObserver.disconnect()
-      chart.remove()
-      chartRef.current = null
-      topSeriesRef.current = null
-    }
-  }, [data, baseValue, sortedSymbols, symbolColorMap])
-
-  const lastPoint = data[data.length - 1]
-  const displayData = hoverData ?? (lastPoint ? { total: lastPoint.value, breakdown: lastPoint.breakdown } : null)
-
-  return (
-    <div className="space-y-2">
-      <div ref={ref} className="w-full rounded-md overflow-hidden" />
-      <SymbolLegend
-        sortedSymbols={sortedSymbols}
-        symbolColorMap={symbolColorMap}
-        values={displayData ? sortedSymbols.map((sym) => displayData.breakdown[sym]?.toFixed(2)) : undefined}
-        suffix={displayData ? <span className="text-xs font-medium ml-auto">Total: {displayData.total.toFixed(2)}</span> : undefined}
-      />
-    </div>
-  )
-}
-
-function DailyContributionChart({ data, sortedSymbols, symbolColorMap }: SharedChartProps) {
-  const ref = useRef<HTMLDivElement>(null)
-  const chartRef = useRef<IChartApi | null>(null)
-  const [hoverData, setHoverData] = useState<{ date: string; deltas: Record<string, number>; total: number } | null>(null)
-
-  const deltasByTime = useRef(new Map<string, Record<string, number>>())
-
-  useEffect(() => {
-    if (!ref.current || data.length < 2 || !sortedSymbols.length) return
-
-    deltasByTime.current.clear()
-
-    // Compute daily deltas per symbol
-    const dailyData: { date: string; deltas: Record<string, number> }[] = []
-    for (let d = 1; d < data.length; d++) {
-      const deltas: Record<string, number> = {}
-      for (const sym of sortedSymbols) {
-        deltas[sym] = (data[d].breakdown[sym] ?? 0) - (data[d - 1].breakdown[sym] ?? 0)
-      }
-      dailyData.push({ date: data[d].date, deltas })
-      deltasByTime.current.set(data[d].date, deltas)
-    }
-
-    // Compute positive and negative cumulative stacks per day
-    // posCum[day][i] = running sum of max(0, delta) for symbols 0..i
-    // negCum[day][i] = running sum of min(0, delta) for symbols 0..i
-    const posCum: number[][] = []
-    const negCum: number[][] = []
-    for (const { deltas } of dailyData) {
-      const pos: number[] = []
-      const neg: number[] = []
-      let posSum = 0
-      let negSum = 0
-      for (const sym of sortedSymbols) {
-        const delta = deltas[sym]
-        if (delta > 0) posSum += delta
-        if (delta < 0) negSum += delta
-        pos.push(posSum)
-        neg.push(negSum)
-      }
-      posCum.push(pos)
-      negCum.push(neg)
-    }
-
-    const chart = createChart(ref.current, baseChartOptions(ref.current, 250))
-
-    // Draw positive stack: outermost first (i = N-1 → 0)
-    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
-      const sym = sortedSymbols[i]
-      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
-      const series = chart.addSeries(HistogramSeries, {
-        color,
-        priceLineVisible: false,
-        base: 0,
-      })
-      series.setData(
-        dailyData.map((d, dayIdx) => ({
-          time: d.date,
-          value: posCum[dayIdx][i],
-        }))
-      )
-    }
-
-    // Draw negative stack: outermost first (i = N-1 → 0)
-    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
-      const sym = sortedSymbols[i]
-      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
-      const series = chart.addSeries(HistogramSeries, {
-        color,
-        priceLineVisible: false,
-        base: 0,
-      })
-      series.setData(
-        dailyData.map((d, dayIdx) => ({
-          time: d.date,
-          value: negCum[dayIdx][i],
-        }))
-      )
-    }
-
-    // Crosshair
-    chart.subscribeCrosshairMove((param) => {
-      if (param.time) {
-        const key = String(param.time)
-        const deltas = deltasByTime.current.get(key)
-        if (deltas) {
-          const total = Object.values(deltas).reduce((s, v) => s + v, 0)
-          setHoverData({ date: key, deltas, total })
-        }
-      } else {
-        setHoverData(null)
-      }
-    })
-
-    chart.timeScale().fitContent()
-    chartRef.current = chart
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        chart.applyOptions({ width: entry.contentRect.width })
-      }
-    })
-    resizeObserver.observe(ref.current)
-
-    return () => {
-      resizeObserver.disconnect()
-      chart.remove()
-      chartRef.current = null
-    }
-  }, [data, sortedSymbols, symbolColorMap])
-
-  // Default to latest day (computed from props, not refs)
-  const latestDeltas = useMemo(() => {
-    if (data.length < 2 || !sortedSymbols.length) return null
-    const last = data[data.length - 1]
-    const prev = data[data.length - 2]
-    const deltas: Record<string, number> = {}
-    for (const sym of sortedSymbols) {
-      deltas[sym] = (last.breakdown[sym] ?? 0) - (prev.breakdown[sym] ?? 0)
-    }
-    const total = Object.values(deltas).reduce((s, v) => s + v, 0)
-    return { date: last.date, deltas, total }
-  }, [data, sortedSymbols])
-  const displayData = hoverData ?? latestDeltas
-
-  return (
-    <div className="space-y-2">
-      <h3 className="text-sm font-semibold px-1">Daily Contribution</h3>
-      <div ref={ref} className="w-full rounded-md overflow-hidden" />
-      <SymbolLegend
-        sortedSymbols={sortedSymbols}
-        symbolColorMap={symbolColorMap}
-        values={displayData ? sortedSymbols.map((sym) => {
-          const v = displayData.deltas[sym]
-          return v !== undefined ? `${v >= 0 ? "+" : ""}${v.toFixed(2)}` : undefined
-        }) : undefined}
-        valueColors={displayData ? sortedSymbols.map((sym) => {
-          const v = displayData.deltas[sym]
-          return v !== undefined ? (v >= 0 ? "text-emerald-500" : "text-red-500") : undefined
-        }) : undefined}
-        suffix={displayData ? (
-          <span className="text-xs font-medium ml-auto">
-            Net: <span className={displayData.total >= 0 ? "text-emerald-500" : "text-red-500"}>
-              {displayData.total >= 0 ? "+" : ""}{displayData.total.toFixed(2)}
-            </span>
-          </span>
-        ) : undefined}
-      />
-    </div>
-  )
-}
-
-function SymbolLegend({
-  sortedSymbols,
-  symbolColorMap,
-  values,
-  valueColors,
-  suffix,
-}: {
-  sortedSymbols: string[]
-  symbolColorMap: Map<string, string>
-  values?: (string | undefined)[]
-  valueColors?: (string | undefined)[]
-  suffix?: React.ReactNode
-}) {
-  return (
-    <div className="flex flex-wrap gap-x-4 gap-y-1 px-1 items-center">
-      {sortedSymbols.map((sym, idx) => (
-        <div key={sym} className="flex items-center gap-1.5 text-xs">
-          <div
-            className="w-3 h-3 rounded-sm flex-shrink-0"
-            style={{ backgroundColor: symbolColorMap.get(sym) }}
-          />
-          <Link to={`/asset/${sym}`} className="hover:underline text-muted-foreground hover:text-foreground">
-            {sym}
-          </Link>
-          {values?.[idx] !== undefined && (
-            <span className={`font-mono ${valueColors?.[idx] ?? "text-muted-foreground"}`}>
-              {values[idx]}
-            </span>
-          )}
-        </div>
-      ))}
-      {suffix}
     </div>
   )
 }
@@ -503,23 +128,6 @@ function PerformanceStats({ data, baseValue }: { data: PerformanceBreakdownPoint
   )
 }
 
-function IndicatorCell({ value, className = "" }: { value: string | null; className?: string }) {
-  return (
-    <span className={`text-right text-xs ${value === null ? "text-muted-foreground" : className}`}>
-      {value ?? "\u2014"}
-    </span>
-  )
-}
-
-function formatChangePct(v: number | null): { text: string | null; className: string } {
-  if (v === null) return { text: null, className: "" }
-  const sign = v >= 0 ? "+" : ""
-  return {
-    text: `${sign}${v.toFixed(2)}%`,
-    className: v >= 0 ? "text-emerald-500" : "text-red-500",
-  }
-}
-
 function HoldingsTable({ etfId }: { etfId: number }) {
   const { data: etf } = usePseudoEtf(etfId)
   const { data: indicators, isLoading: indicatorsLoading } = usePseudoEtfConstituentsIndicators(
@@ -532,6 +140,16 @@ function HoldingsTable({ etfId }: { etfId: number }) {
   if (!etf) return null
 
   const indicatorMap = new Map((indicators ?? []).map((i) => [i.symbol, i]))
+
+  const rows: HoldingsGridRow[] = etf.constituents.map((a) => {
+    const ind = indicatorMap.get(a.symbol)
+    return {
+      key: a.id,
+      symbol: a.symbol,
+      name: ind?.name ?? a.name,
+      percent: ind?.weight_pct ?? null,
+    }
+  })
 
   return (
     <Card>
@@ -556,164 +174,15 @@ function HoldingsTable({ etfId }: { etfId: number }) {
         )}
 
         {etf.constituents.length > 0 && (
-          <div className="overflow-x-auto">
-            <div className="min-w-[750px] space-y-0">
-              <div className="grid grid-cols-[4rem_1fr_3.5rem_5rem_4rem_3.5rem_3.5rem_4rem_3.5rem_2rem] text-xs text-muted-foreground border-b border-border pb-1 mb-1 gap-x-2">
-                <span>Symbol</span>
-                <span>Name</span>
-                <span className="text-right">Wt%</span>
-                <span className="text-right">Price</span>
-                <span className="text-right">Chg%</span>
-                <span className="text-right">RSI</span>
-                <span className="text-right">SMA20</span>
-                <span className="text-right">MACD</span>
-                <span className="text-right">BB</span>
-                <span></span>
-              </div>
-              {etf.constituents.map((asset) => {
-                const ind = indicatorMap.get(asset.symbol)
-                const chg = formatChangePct(ind?.change_pct ?? null)
-                const rsiVal = ind?.rsi
-                const rsiColor = rsiVal != null ? (rsiVal > 70 ? "text-red-500" : rsiVal < 30 ? "text-emerald-500" : "") : ""
-                const smaAbove = ind?.sma_20 != null && ind?.close != null ? ind.close > ind.sma_20 : null
-                const macdDir = ind?.macd_signal_dir
-                const bbPos = ind?.bb_position
-
-                return (
-                  <div key={asset.id} className="grid grid-cols-[4rem_1fr_3.5rem_5rem_4rem_3.5rem_3.5rem_4rem_3.5rem_2rem] text-sm py-1 hover:bg-muted/50 rounded gap-x-2 items-center group/row">
-                    <Link to={`/asset/${asset.symbol}`} className="font-mono text-xs text-primary hover:underline">
-                      {asset.symbol}
-                    </Link>
-                    <span className="text-muted-foreground truncate text-xs">{ind?.name ?? asset.name}</span>
-                    <IndicatorCell value={ind?.weight_pct != null ? `${ind.weight_pct.toFixed(1)}%` : null} />
-                    {indicatorsLoading ? (
-                      <span className="col-span-6 text-right text-xs text-muted-foreground animate-pulse">Loading...</span>
-                    ) : (
-                      <>
-                        <IndicatorCell value={ind?.close != null ? formatPrice(ind.close, ind.currency, 0) : null} />
-                        <IndicatorCell value={chg.text} className={chg.className} />
-                        <IndicatorCell value={rsiVal != null ? rsiVal.toFixed(0) : null} className={rsiColor} />
-                        <IndicatorCell
-                          value={smaAbove !== null ? (smaAbove ? "Above" : "Below") : null}
-                          className={smaAbove === true ? "text-emerald-500" : smaAbove === false ? "text-red-500" : ""}
-                        />
-                        <IndicatorCell
-                          value={macdDir != null ? (macdDir === "bullish" ? "Bull" : "Bear") : null}
-                          className={macdDir === "bullish" ? "text-emerald-500" : macdDir === "bearish" ? "text-red-500" : ""}
-                        />
-                        <IndicatorCell
-                          value={bbPos != null ? bbPos.charAt(0).toUpperCase() + bbPos.slice(1) : null}
-                          className={bbPos === "above" ? "text-red-500" : bbPos === "below" ? "text-emerald-500" : ""}
-                        />
-                      </>
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-5 w-5 opacity-0 group-hover/row:opacity-100 transition-opacity"
-                      onClick={() => removeConstituent.mutate({ etfId, assetId: asset.id })}
-                    >
-                      <X className="h-3 w-3" />
-                    </Button>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
+          <HoldingsGrid
+            rows={rows}
+            indicatorMap={indicatorMap}
+            indicatorsLoading={indicatorsLoading}
+            onRemove={(key) => removeConstituent.mutate({ etfId, assetId: key as number })}
+          />
         )}
       </CardContent>
     </Card>
-  )
-}
-
-function AddConstituentPicker({
-  etfId,
-  existingIds,
-  onClose,
-}: {
-  etfId: number
-  existingIds: number[]
-  onClose: () => void
-}) {
-  const { data: allAssets } = useAssets()
-  const addConstituents = useAddPseudoEtfConstituents()
-  const createAsset = useCreateAsset()
-  const available = allAssets?.filter((a) => !existingIds.includes(a.id)) ?? []
-  const [selected, setSelected] = useState<number[]>([])
-  const [newTicker, setNewTicker] = useState("")
-  const [tickerError, setTickerError] = useState("")
-
-  const toggle = (id: number) => {
-    setSelected((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
-  }
-
-  const handleAdd = () => {
-    if (!selected.length) return
-    addConstituents.mutate({ etfId, assetIds: selected }, { onSuccess: () => onClose() })
-  }
-
-  const handleNewTicker = () => {
-    const sym = newTicker.trim().toUpperCase()
-    if (!sym) return
-    setTickerError("")
-    createAsset.mutate(
-      { symbol: sym, watchlisted: false },
-      {
-        onSuccess: (asset) => {
-          addConstituents.mutate(
-            { etfId, assetIds: [asset.id] },
-            { onSuccess: () => { setNewTicker(""); onClose() } }
-          )
-        },
-        onError: (err) => setTickerError(err.message),
-      }
-    )
-  }
-
-  return (
-    <div className="p-3 rounded-md border bg-muted/30 space-y-3">
-      <div className="flex gap-2 items-center">
-        <Input
-          placeholder="New ticker (e.g. AAPL)"
-          value={newTicker}
-          onChange={(e) => { setNewTicker(e.target.value); setTickerError("") }}
-          onKeyDown={(e) => e.key === "Enter" && handleNewTicker()}
-          className="w-48"
-        />
-        <Button size="sm" onClick={handleNewTicker} disabled={!newTicker.trim() || createAsset.isPending}>
-          <Plus className="h-3.5 w-3.5 mr-1" />
-          {createAsset.isPending ? "Adding..." : "Add new"}
-        </Button>
-        {tickerError && <span className="text-xs text-destructive">{tickerError}</span>}
-      </div>
-
-      {available.length > 0 && (
-        <>
-          <p className="text-xs text-muted-foreground">Or pick existing assets:</p>
-          <div className="flex flex-wrap gap-1.5">
-            {available.map((a) => (
-              <Badge
-                key={a.id}
-                variant={selected.includes(a.id) ? "default" : "outline"}
-                className="cursor-pointer"
-                onClick={() => toggle(a.id)}
-              >
-                {a.symbol}
-              </Badge>
-            ))}
-          </div>
-        </>
-      )}
-
-      <div className="flex justify-end gap-1">
-        <Button size="sm" variant="ghost" onClick={onClose}>Cancel</Button>
-        {selected.length > 0 && (
-          <Button size="sm" onClick={handleAdd} disabled={addConstituents.isPending}>
-            Add ({selected.length})
-          </Button>
-        )}
-      </div>
-    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Extract `IndicatorCell` component and `formatChangePct` utility shared by asset-detail and pseudo-etf-detail pages
- Extract `HoldingsGrid` component replacing duplicated indicator table rendering in both pages
- Extract chart theme (`getChartTheme`) and base options (`baseChartOptions`) to shared `lib/chart-utils.ts`, used by 4 chart files
- Split `pseudo-etf-detail.tsx` from **746 lines to 215 lines** by extracting `StackedAreaChart`, `DailyContributionChart`, `SymbolLegend`, and `AddConstituentPicker` into separate component files

Closes #49, closes #50, closes #51

## Test plan
- [ ] Verify asset detail page renders ETF holdings table correctly (link opens in new tab)
- [ ] Verify pseudo-ETF detail page renders holdings with add/remove functionality
- [ ] Verify pseudo-ETF charts (stacked area + daily contribution) render correctly
- [ ] Verify portfolio chart renders correctly
- [ ] Verify price chart (candlestick + RSI + MACD) renders correctly
- [ ] TypeScript check passes: `tsc --noEmit --skipLibCheck`
- [ ] No new lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)