### PR TITLE
fix: sparkline chart and price/% don't update when changing time scale (#53)

### DIFF
--- a/frontend/src/components/sparkline.tsx
+++ b/frontend/src/components/sparkline.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef } from "react"
 import { createChart, type IChartApi, ColorType, AreaSeries } from "lightweight-charts"
 import { usePrices } from "@/lib/queries"
-import { formatPrice } from "@/lib/format"
 
-export function SparklineChart({ symbol, currency = "USD", period = "3mo" }: { symbol: string; currency?: string; period?: string }) {
+export function SparklineChart({ symbol, period = "3mo" }: { symbol: string; period?: string }) {
   const { data: prices } = usePrices(symbol, period)
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
@@ -69,20 +68,5 @@ export function SparklineChart({ symbol, currency = "USD", period = "3mo" }: { s
     return <div className="h-[60px] flex items-center justify-center text-xs text-muted-foreground">No data</div>
   }
 
-  const last = prices[prices.length - 1]
-  const first = prices[0]
-  const change = ((last.close - first.close) / first.close) * 100
-
-  return (
-    <div>
-      <div ref={containerRef} className="w-full" />
-      <div className="flex items-center justify-between mt-1">
-        <span className="text-sm font-medium">{formatPrice(last.close, currency)}</span>
-        <span className={`text-xs font-medium ${change >= 0 ? "text-green-500" : "text-red-500"}`}>
-          {change >= 0 ? "+" : ""}
-          {change.toFixed(1)}%
-        </span>
-      </div>
-    </div>
-  )
+  return <div ref={containerRef} className="w-full" />
 }


### PR DESCRIPTION
## Summary

Fixes #53

- Replaced `useStaggeredQuotes` (real-time market data, period-agnostic) with `usePrices` (historical data, period-aware) in `AssetCard` so the card header price and change% now reflect the selected time period
- Removed redundant price/change display from `SparklineChart` bottom — the card header now shows the period-derived values
- React Query deduplicates the `usePrices` calls between `AssetCard` and `SparklineChart` (same cache key), so no extra network requests

## Changes
- `frontend/src/pages/dashboard.tsx`: `AssetCard` derives price/change from `usePrices` instead of quote data
- `frontend/src/components/sparkline.tsx`: Simplified to chart-only (removed bottom price/% text, removed unused `currency` prop)

## Test plan
- [ ] Switch between 3M/6M/1Y on dashboard — sparkline chart visual, price number, and change% should all update
- [ ] Top/bottom performers on portfolio page still work correctly
- [ ] No console errors or unnecessary refetches
- [ ] Cards show "No data" gracefully when prices haven't been fetched yet

Generated with [Claude Code](https://claude.com/claude-code)