### PR TITLE
feat: replace frontend quote polling with backend SSE stream

### DIFF
--- a/backend/app/routers/quotes.py
+++ b/backend/app/routers/quotes.py
@@ -1,7 +1,17 @@
-from fastapi import APIRouter, Query
+import asyncio
+import json
+import logging
 
+from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+
+from app.database import async_session
+from app.models.asset import Asset
 from app.schemas.quote import QuoteResponse
 from app.services.yahoo import batch_fetch_quotes
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["quotes"])
 
@@ -12,3 +22,59 @@ async def get_quotes(symbols: str = Query(..., description="Comma-separated list
     if not symbol_list:
         return []
     return batch_fetch_quotes(symbol_list)
+
+
+async def _quote_event_generator():
+    """Yield SSE events with watchlisted quotes, adapting interval to market state."""
+    while True:
+        try:
+            async with async_session() as db:
+                result = await db.execute(
+                    select(Asset.symbol).where(Asset.watchlisted.is_(True))
+                )
+                symbols = [row[0] for row in result.all()]
+
+            if not symbols:
+                yield "event: quotes\ndata: {}\n\n"
+                await asyncio.sleep(60)
+                continue
+
+            quotes = await asyncio.to_thread(batch_fetch_quotes, symbols)
+
+            # Build keyed payload
+            payload = {}
+            market_states = set()
+            for q in quotes:
+                payload[q["symbol"]] = q
+                if q.get("market_state"):
+                    market_states.add(q["market_state"])
+
+            yield f"event: quotes\ndata: {json.dumps(payload)}\n\n"
+
+            # Adapt interval based on market state
+            if "REGULAR" in market_states:
+                interval = 15
+            elif market_states & {"PRE", "POST", "PREPRE", "POSTPOST"}:
+                interval = 60
+            else:
+                interval = 300
+
+            await asyncio.sleep(interval)
+
+        except asyncio.CancelledError:
+            break
+        except Exception:
+            logger.exception("Quote stream error")
+            await asyncio.sleep(30)
+
+
+@router.get("/quotes/stream", summary="SSE stream of watchlisted quotes")
+async def stream_quotes():
+    return StreamingResponse(
+        _quote_event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -129,3 +129,14 @@
     @apply font-sans;
     }
 }
+
+@keyframes flash-green {
+  0%   { background-color: oklch(0.87 0.15 155 / 45%); }
+  100% { background-color: transparent; }
+}
+@keyframes flash-red {
+  0%   { background-color: oklch(0.70 0.19 25 / 45%); }
+  100% { background-color: transparent; }
+}
+.flash-green { animation: flash-green 1.8s ease-out; }
+.flash-red   { animation: flash-red 1.8s ease-out; }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -257,10 +257,6 @@ export const api = {
     holdingsIndicators: (symbol: string) =>
       request<HoldingIndicator[]>(`/assets/${symbol}/holdings/indicators`),
   },
-  quotes: {
-    list: (symbols: string[]) =>
-      request<Quote[]>(`/quotes?symbols=${symbols.join(",")}`),
-  },
   tags: {
     list: () => request<Tag[]>("/tags"),
     create: (data: TagCreate) =>

--- a/frontend/src/lib/quote-stream.tsx
+++ b/frontend/src/lib/quote-stream.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useEffect, useRef, useState } from "react"
+import type { Quote } from "./api"
+
+type QuoteMap = Record<string, Quote>
+
+const QuoteStreamContext = createContext<QuoteMap>({})
+
+export function QuoteStreamProvider({ children }: { children: React.ReactNode }) {
+  const [quotes, setQuotes] = useState<QuoteMap>({})
+  const esRef = useRef<EventSource | null>(null)
+
+  useEffect(() => {
+    const es = new EventSource("/api/quotes/stream")
+    esRef.current = es
+
+    es.addEventListener("quotes", (e) => {
+      try {
+        const data = JSON.parse(e.data) as QuoteMap
+        setQuotes(data)
+      } catch {
+        // ignore malformed events
+      }
+    })
+
+    return () => {
+      es.close()
+      esRef.current = null
+    }
+  }, [])
+
+  return (
+    <QuoteStreamContext.Provider value={quotes}>
+      {children}
+    </QuoteStreamContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useQuotes(): QuoteMap {
+  return useContext(QuoteStreamContext)
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 import "./index.css"
 import App from "./App.tsx"
+import { QuoteStreamProvider } from "./lib/quote-stream.tsx"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,9 +16,11 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <QuoteStreamProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QuoteStreamProvider>
     </QueryClientProvider>
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- Add `GET /api/quotes/stream` SSE endpoint that pushes watchlisted quotes to all connected clients, with adaptive polling interval based on market state (15s regular, 60s pre/post, 300s closed)
- Replace per-tab `useStaggeredQuotes` frontend polling with a shared `QuoteStreamProvider` context backed by `EventSource`
- Add green/red flash animation on price and change-percent elements when quotes update

## Test plan
- [x] Backend tests pass (69/69)
- [x] Frontend TypeScript build passes
- [x] Frontend lint — no new errors
- [ ] Manual: open watchlist, verify single EventSource connection in Network tab instead of periodic XHR
- [ ] Manual: verify price/change flash animation on update

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)