### PR TITLE
refactor: extract reusable usePriceFlash hook

### DIFF
--- a/frontend/src/lib/use-price-flash.ts
+++ b/frontend/src/lib/use-price-flash.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react"
+
+/**
+ * Flashes attached DOM elements green or red when the price changes.
+ * Returns refs to attach to the elements that should flash.
+ *
+ * @example
+ * const flashRefs = usePriceFlash(quote?.price ?? null)
+ * <span ref={flashRefs[0]} className="rounded px-1 -mx-1">{price}</span>
+ * <span ref={flashRefs[1]} className="rounded px-1 -mx-1">{changePct}%</span>
+ */
+export function usePriceFlash(price: number | null) {
+  const prevRef = useRef<number | null>(null)
+  const ref1 = useRef<HTMLElement>(null)
+  const ref2 = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    if (price == null || prevRef.current == null || price === prevRef.current) {
+      prevRef.current = price
+      return
+    }
+    const cls = price > prevRef.current ? "flash-green" : "flash-red"
+    for (const el of [ref1.current, ref2.current]) {
+      if (!el) continue
+      el.classList.remove("flash-green", "flash-red")
+      // force reflow so re-adding the same class restarts the animation
+      void el.offsetWidth
+      el.classList.add(cls)
+    }
+    prevRef.current = price
+  }, [price])
+
+  return [ref1, ref2] as const
+}

--- a/frontend/src/pages/watchlist.tsx
+++ b/frontend/src/pages/watchlist.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 import { Link } from "react-router-dom"
 import { MoreVertical, Plus, Trash2, TrendingUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -18,6 +18,7 @@ import { RsiGauge } from "@/components/rsi-gauge"
 import { TagBadge } from "@/components/tag-badge"
 import type { Quote, TagBrief } from "@/lib/api"
 import { formatPrice } from "@/lib/format"
+import { usePriceFlash } from "@/lib/use-price-flash"
 
 export function WatchlistPage() {
   const { data: allAssets, isLoading } = useAssets()
@@ -159,26 +160,7 @@ function AssetCard({
   const changeColor =
     changePct != null ? (changePct >= 0 ? "text-green-500" : "text-red-500") : "text-muted-foreground"
 
-  // Flash on price change
-  const prevPriceRef = useRef<number | null>(null)
-  const priceRef = useRef<HTMLSpanElement>(null)
-  const pctRef = useRef<HTMLSpanElement>(null)
-
-  useEffect(() => {
-    if (lastPrice == null || prevPriceRef.current == null || lastPrice === prevPriceRef.current) {
-      prevPriceRef.current = lastPrice
-      return
-    }
-    const cls = lastPrice > prevPriceRef.current ? "flash-green" : "flash-red"
-    for (const el of [priceRef.current, pctRef.current]) {
-      if (!el) continue
-      el.classList.remove("flash-green", "flash-red")
-      // force reflow so re-adding the same class restarts the animation
-      void el.offsetWidth
-      el.classList.add(cls)
-    }
-    prevPriceRef.current = lastPrice
-  }, [lastPrice])
+  const [priceRef, pctRef] = usePriceFlash(lastPrice)
 
   return (
     <Card className="group relative hover:border-primary/50 transition-colors">


### PR DESCRIPTION
## Summary
- Extract price flash animation logic from `AssetCard` into a reusable `usePriceFlash(price)` hook in `frontend/src/lib/use-price-flash.ts`
- Hook accepts `number | null`, returns `[ref1, ref2]` to attach to elements that should flash
- `AssetCard` refactored to use the hook — no visual change

## Test plan
- [x] Frontend TypeScript build passes
- [x] Frontend lint — no new errors
- [ ] Manual: verify flash animation still works on watchlist

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)