### PR TITLE
feat: skeleton loaders for watchlist card prices

### DIFF
--- a/frontend/src/pages/watchlist.tsx
+++ b/frontend/src/pages/watchlist.tsx
@@ -11,6 +11,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useAssets, useCreateAsset, useDeleteAsset, useTags } from "@/lib/queries"
 import { useQuotes } from "@/lib/quote-stream"
 import { SparklineChart } from "@/components/sparkline"
@@ -195,19 +196,23 @@ function AssetCard({
             <Badge variant="secondary" className="text-xs">
               {type}
             </Badge>
-            {lastPrice != null && (
+            {lastPrice != null ? (
               <span ref={priceRef} className="ml-auto text-base font-semibold tabular-nums rounded px-1 -mx-1">
                 {formatPrice(lastPrice, currency)}
               </span>
+            ) : (
+              <Skeleton className="ml-auto h-5 w-16 rounded" />
             )}
           </div>
           <div className="flex items-center justify-between">
             <p className="text-xs text-muted-foreground truncate">{name}</p>
-            {changePct != null && (
+            {changePct != null ? (
               <span ref={pctRef} className={`text-xs font-medium tabular-nums rounded px-1 -mx-1 ${changeColor}`}>
                 {changePct >= 0 ? "+" : ""}
                 {changePct.toFixed(2)}%
               </span>
+            ) : (
+              <Skeleton className="h-3.5 w-12 rounded" />
             )}
           </div>
           {tags.length > 0 && (


### PR DESCRIPTION
## Summary
- Shows `<Skeleton>` placeholders for price and change% on watchlist cards while SSE quotes are loading
- Skeletons match the size/position of actual values to prevent layout shift
- Replaces silent omission with visible loading state

Closes #57

## Changes
- `frontend/src/pages/watchlist.tsx`: Import `Skeleton`, replace conditional null-renders with skeleton fallbacks for price (`h-5 w-16`) and change% (`h-3.5 w-12`)

## Test plan
- [ ] Fresh page load shows skeleton placeholders in price/change areas
- [ ] Skeletons replaced by real values once SSE delivers quotes
- [ ] No layout shift on transition
- [ ] `pnpm run build` clean, lint unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)