### PR TITLE
feat: skeleton loaders for sparkline and RSI gauge

### DIFF
--- a/frontend/src/components/rsi-gauge.tsx
+++ b/frontend/src/components/rsi-gauge.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from "@/components/ui/skeleton"
 import { useIndicators } from "@/lib/queries"
 
 // Gradual color: center (50) is neutral, extremes get more intense
@@ -26,12 +27,21 @@ function getZoneLabel(rsi: number): string {
 }
 
 export function RsiGauge({ symbol }: { symbol: string }) {
-  const { data: indicators } = useIndicators(symbol)
+  const { data: indicators, isLoading } = useIndicators(symbol)
 
   const latestRsi = indicators
     ?.slice()
     .reverse()
     .find((i) => i.rsi !== null)?.rsi
+
+  if (isLoading) {
+    return (
+      <div className="mt-2 space-y-1">
+        <Skeleton className="h-1.5 w-full rounded-full" />
+        <Skeleton className="h-3 w-14 rounded" />
+      </div>
+    )
+  }
 
   if (latestRsi == null) {
     return (

--- a/frontend/src/components/sparkline.tsx
+++ b/frontend/src/components/sparkline.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from "react"
 import { createChart, type IChartApi, ColorType, AreaSeries } from "lightweight-charts"
+import { Skeleton } from "@/components/ui/skeleton"
 import { usePrices } from "@/lib/queries"
 
 export function SparklineChart({ symbol, period = "3mo" }: { symbol: string; period?: string }) {
-  const { data: prices } = usePrices(symbol, period)
+  const { data: prices, isLoading } = usePrices(symbol, period)
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
 
@@ -63,6 +64,10 @@ export function SparklineChart({ symbol, period = "3mo" }: { symbol: string; per
       chartRef.current = null
     }
   }, [prices])
+
+  if (isLoading) {
+    return <Skeleton className="h-[60px] w-full rounded" />
+  }
 
   if (!prices?.length) {
     return <div className="h-[60px] flex items-center justify-center text-xs text-muted-foreground">No data</div>


### PR DESCRIPTION
## Summary
- Shows `<Skeleton>` placeholders for sparkline chart (60px) and RSI gauge (bar + label) while data loads
- Distinguishes loading state from "no data" — skeletons during fetch, text fallback when empty
- Matches existing component dimensions to prevent layout shift

## Changes
- `frontend/src/components/sparkline.tsx`: Add `isLoading` check, show skeleton before "No data" fallback
- `frontend/src/components/rsi-gauge.tsx`: Add `isLoading` check, show skeleton gauge bar + label placeholder

## Test plan
- [ ] Fresh page load shows skeleton placeholders for charts and RSI
- [ ] Skeletons replaced by actual charts/gauges once data arrives
- [ ] "No data" / "No RSI" still shown when data is genuinely missing
- [ ] No layout shift on transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)