### PR TITLE
feat: production Docker build (combined frontend+backend image) (#70)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+**/__pycache__
+**/*.pyc
+**/node_modules
+frontend/dist
+backend/.pytest_cache
+**/.venv
+*.md
+.claude
+examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: Build frontend
+FROM node:22-alpine AS frontend-build
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /build
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY frontend/ .
+RUN pnpm build
+
+# Stage 2: Production image
+FROM python:3.12-slim
+WORKDIR /app
+
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ .
+COPY --from=frontend-build /build/dist ./static
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: fibenchi
+      POSTGRES_PASSWORD: fibenchi
+      POSTGRES_DB: fibenchi
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fibenchi"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build: .
+    environment:
+      DATABASE_URL: postgresql+asyncpg://fibenchi:fibenchi@db:5432/fibenchi
+      REFRESH_CRON: ${REFRESH_CRON:-0 23 * * *}
+    ports:
+      - "18000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Multi-stage `Dockerfile` at project root: Node builds the SPA, Python serves everything
- `docker-compose.prod.yaml`: 2 services (db + app) on port 18000
- FastAPI serves static assets and SPA fallback (only when `static/` dir exists — no impact on dev)
- `.dockerignore` to keep build context clean

## Verified
- `docker compose -f docker-compose.prod.yaml build` — succeeds
- `/api/health` — JSON response
- `/` — serves index.html
- `/asset/AAPL` — SPA fallback (client-side routing works)
- `/assets/*.js` — static files served
- Backend tests: 92/92 passed (SPA mount skipped in test/dev)

## Test plan
- [x] Production build succeeds
- [x] API + SPA + static assets all served from single container
- [x] Dev workflow unchanged (docker compose up still works)
- [x] Backend tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)