### PR TITLE
fix: resolve 500 on /api/tags endpoint

### DIFF
--- a/backend/app/routers/tags.py
+++ b/backend/app/routers/tags.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.database import get_db
 from app.models import Asset, Tag
@@ -13,7 +14,11 @@ asset_tag_router = APIRouter(prefix="/api/assets", tags=["tags"])
 
 @router.get("", response_model=list[TagResponse], summary="List all tags")
 async def list_tags(db: AsyncSession = Depends(get_db)):
-    result = await db.execute(select(Tag).order_by(Tag.name))
+    result = await db.execute(
+        select(Tag)
+        .options(selectinload(Tag.assets).selectinload(Asset.tags))
+        .order_by(Tag.name)
+    )
     return result.scalars().all()
 
 


### PR DESCRIPTION
## Summary
- `/api/tags` returned 500 with `MissingGreenlet` errors in production
- Root cause: `TagResponse` → `AssetResponse` → `TagBrief` requires two levels of relationship loading. SQLAlchemy's `lazy="selectin"` doesn't fire for the second level when assets are loaded as part of another selectin in async context
- Fix: explicitly chain `selectinload(Tag.assets).selectinload(Asset.tags)` in the query

## Test plan
- [x] Backend tests pass (20/20, excluding known DNS-dependent `test_holdings`)
- [x] Frontend builds clean
- [ ] Verify `/api/tags` returns 200 on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)