### PR TITLE
feat: add settings page with dual persistence (#76)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,3 +5,4 @@ from app.models.annotation import Annotation  # noqa: F401
 from app.models.thesis import Thesis  # noqa: F401
 from app.models.tag import Tag, tag_assets  # noqa: F401
 from app.models.pseudo_etf import PseudoETF, PseudoEtfAnnotation, PseudoEtfThesis, pseudo_etf_constituents  # noqa: F401
+from app.models.user_settings import UserSettings  # noqa: F401

--- a/backend/app/models/user_settings.py
+++ b/backend/app/models/user_settings.py
@@ -1,0 +1,11 @@
+from sqlalchemy import JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class UserSettings(Base):
+    __tablename__ = "user_settings"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    data: Mapped[dict] = mapped_column(JSON, default=dict)

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.user_settings import UserSettings
+from app.schemas.settings import SettingsResponse, SettingsUpdate
+
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+@router.get("", response_model=SettingsResponse, summary="Get user settings")
+async def get_settings(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(UserSettings).where(UserSettings.id == 1))
+    row = result.scalar_one_or_none()
+    if not row:
+        return SettingsResponse(data={})
+    return row
+
+
+@router.put("", response_model=SettingsResponse, summary="Update user settings")
+async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(UserSettings).where(UserSettings.id == 1))
+    row = result.scalar_one_or_none()
+    if row:
+        row.data = body.data
+    else:
+        row = UserSettings(id=1, data=body.data)
+        db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class SettingsResponse(BaseModel):
+    data: dict
+
+    model_config = {"from_attributes": True}
+
+
+class SettingsUpdate(BaseModel):
+    data: dict

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.anyio
+async def test_get_empty(client):
+    resp = await client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json() == {"data": {}}
+
+
+@pytest.mark.anyio
+async def test_put(client):
+    payload = {"data": {"theme": "dark", "compact_mode": True}}
+    resp = await client.put("/api/settings", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["theme"] == "dark"
+    assert resp.json()["data"]["compact_mode"] is True
+
+
+@pytest.mark.anyio
+async def test_put_get_roundtrip(client):
+    payload = {"data": {"chart_type": "line", "decimal_places": 4}}
+    await client.put("/api/settings", json=payload)
+    resp = await client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == {"chart_type": "line", "decimal_places": 4}
+
+
+@pytest.mark.anyio
+async def test_put_overwrites(client):
+    await client.put("/api/settings", json={"data": {"theme": "dark"}})
+    await client.put("/api/settings", json={"data": {"theme": "light", "extra": 1}})
+    resp = await client.get("/api/settings")
+    assert resp.json()["data"] == {"theme": "light", "extra": 1}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { AssetDetailPage } from "@/pages/asset-detail"
 import { GroupsPage } from "@/pages/groups"
 import { PseudoEtfsPage } from "@/pages/pseudo-etfs"
 import { PseudoEtfDetailPage } from "@/pages/pseudo-etf-detail"
+import { SettingsPage } from "@/pages/settings"
 
 export default function App() {
   return (
@@ -17,6 +18,7 @@ export default function App() {
         <Route path="/groups" element={<GroupsPage />} />
         <Route path="/pseudo-etfs" element={<PseudoEtfsPage />} />
         <Route path="/pseudo-etf/:id" element={<PseudoEtfDetailPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
       </Route>
     </Routes>
   )

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,7 +1,5 @@
 import { Link, Outlet, useLocation } from "react-router-dom"
-import { LayoutDashboard, FolderOpen, LineChart, List, Sun, Moon } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { useEffect, useState } from "react"
+import { LayoutDashboard, FolderOpen, LineChart, List, Settings } from "lucide-react"
 
 const navItems = [
   { to: "/", label: "Overview", icon: LayoutDashboard },
@@ -9,24 +7,6 @@ const navItems = [
   { to: "/groups", label: "Groups", icon: FolderOpen },
   { to: "/pseudo-etfs", label: "Pseudo-ETFs", icon: LineChart },
 ]
-
-function ThemeToggle() {
-  const [dark, setDark] = useState(() => {
-    const saved = localStorage.getItem("theme")
-    return saved === "dark" || (!saved && window.matchMedia("(prefers-color-scheme: dark)").matches)
-  })
-
-  useEffect(() => {
-    document.documentElement.classList.toggle("dark", dark)
-    localStorage.setItem("theme", dark ? "dark" : "light")
-  }, [dark])
-
-  return (
-    <Button variant="ghost" size="icon" onClick={() => setDark((d) => !d)}>
-      {dark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-    </Button>
-  )
-}
 
 export function Layout() {
   const location = useLocation()
@@ -59,7 +39,17 @@ export function Layout() {
           })}
         </nav>
         <div className="border-t p-2">
-          <ThemeToggle />
+          <Link
+            to="/settings"
+            className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+              location.pathname === "/settings"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground"
+            }`}
+          >
+            <Settings className="h-4 w-4" />
+            Settings
+          </Link>
         </div>
       </aside>
       <main className="flex-1 overflow-auto">

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -17,9 +17,25 @@ interface PriceChartProps {
   prices: Price[]
   indicators: Indicator[]
   annotations: Annotation[]
+  showSma20?: boolean
+  showSma50?: boolean
+  showBollinger?: boolean
+  showRsiChart?: boolean
+  showMacdChart?: boolean
+  chartType?: "candle" | "line"
 }
 
-export function PriceChart({ prices, indicators, annotations }: PriceChartProps) {
+export function PriceChart({
+  prices,
+  indicators,
+  annotations,
+  showSma20 = true,
+  showSma50 = true,
+  showBollinger = true,
+  showRsiChart = true,
+  showMacdChart = true,
+  chartType = "candle",
+}: PriceChartProps) {
   const mainRef = useRef<HTMLDivElement>(null)
   const rsiRef = useRef<HTMLDivElement>(null)
   const macdRef = useRef<HTMLDivElement>(null)
@@ -51,30 +67,25 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
       h: lastPrice.high,
       l: lastPrice.low,
       c: lastPrice.close,
-      sma20: lastIndicators.find((i) => i.sma_20 !== null)?.sma_20 ?? undefined,
-      sma50: lastIndicators.find((i) => i.sma_50 !== null)?.sma_50 ?? undefined,
-      bbUpper: lastIndicators.find((i) => i.bb_upper !== null)?.bb_upper ?? undefined,
-      bbLower: lastIndicators.find((i) => i.bb_lower !== null)?.bb_lower ?? undefined,
-      rsi: lastIndicators.find((i) => i.rsi !== null)?.rsi ?? undefined,
-      macd: lastIndicators.find((i) => i.macd !== null)?.macd ?? undefined,
-      macdSignal: lastIndicators.find((i) => i.macd_signal !== null)?.macd_signal ?? undefined,
-      macdHist: lastIndicators.find((i) => i.macd_hist !== null)?.macd_hist ?? undefined,
+      sma20: showSma20 ? (lastIndicators.find((i) => i.sma_20 !== null)?.sma_20 ?? undefined) : undefined,
+      sma50: showSma50 ? (lastIndicators.find((i) => i.sma_50 !== null)?.sma_50 ?? undefined) : undefined,
+      bbUpper: showBollinger ? (lastIndicators.find((i) => i.bb_upper !== null)?.bb_upper ?? undefined) : undefined,
+      bbLower: showBollinger ? (lastIndicators.find((i) => i.bb_lower !== null)?.bb_lower ?? undefined) : undefined,
+      rsi: showRsiChart ? (lastIndicators.find((i) => i.rsi !== null)?.rsi ?? undefined) : undefined,
+      macd: showMacdChart ? (lastIndicators.find((i) => i.macd !== null)?.macd ?? undefined) : undefined,
+      macdSignal: showMacdChart ? (lastIndicators.find((i) => i.macd_signal !== null)?.macd_signal ?? undefined) : undefined,
+      macdHist: showMacdChart ? (lastIndicators.find((i) => i.macd_hist !== null)?.macd_hist ?? undefined) : undefined,
     }
-  }, [prices, indicators])
+  }, [prices, indicators, showSma20, showSma50, showBollinger, showRsiChart, showMacdChart])
 
   const syncingRef = useRef(false)
 
   const syncCharts = useCallback((
-    mainChart: IChartApi,
-    rsiChart: IChartApi,
-    macdChart: IChartApi,
-    candleSeries: ReturnType<IChartApi["addSeries"]>,
-    rsiSeries: ReturnType<IChartApi["addSeries"]>,
-    macdLineSeries: ReturnType<IChartApi["addSeries"]>,
+    chartEntries: { chart: IChartApi; series: ReturnType<IChartApi["addSeries"]> }[],
   ) => {
-    const charts = [mainChart, rsiChart, macdChart]
+    const charts = chartEntries.map((e) => e.chart)
 
-    // Sync visible range across all 3 charts
+    // Sync visible range across all charts
     for (const source of charts) {
       source.timeScale().subscribeVisibleLogicalRangeChange(() => {
         if (syncingRef.current) return
@@ -109,12 +120,23 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
 
     // Snap crosshair on all charts to actual data values
     const snapCrosshair = (key: string, time: Parameters<IChartApi["setCrosshairPosition"]>[1]) => {
-      const closeVal = closeByTime.current.get(key)
-      if (closeVal !== undefined) mainChart.setCrosshairPosition(closeVal, time, candleSeries)
-      const rsiVal = rsiByTime.current.get(key)
-      if (rsiVal !== undefined) rsiChart.setCrosshairPosition(rsiVal, time, rsiSeries)
-      const macdVal = macdByTime.current.get(key)
-      if (macdVal !== undefined) macdChart.setCrosshairPosition(macdVal, time, macdLineSeries)
+      for (const entry of chartEntries) {
+        // Find the value for this chart's series from lookup maps
+        const closeVal = closeByTime.current.get(key)
+        const rsiVal = rsiByTime.current.get(key)
+        const macdVal = macdByTime.current.get(key)
+
+        // Determine which value to use based on which chart this is
+        if (entry === chartEntries[0] && closeVal !== undefined) {
+          entry.chart.setCrosshairPosition(closeVal, time, entry.series)
+        } else if (chartEntries.length > 1 && entry === chartEntries[1]) {
+          // Second chart could be RSI or MACD depending on what's enabled
+          const val = rsiVal !== undefined ? rsiVal : macdVal
+          if (val !== undefined) entry.chart.setCrosshairPosition(val, time, entry.series)
+        } else if (chartEntries.length > 2 && entry === chartEntries[2] && macdVal !== undefined) {
+          entry.chart.setCrosshairPosition(macdVal, time, entry.series)
+        }
+      }
     }
 
     const clearOtherCrosshairs = (source: IChartApi) => {
@@ -146,7 +168,9 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
   }, [])
 
   useEffect(() => {
-    if (!mainRef.current || !rsiRef.current || !macdRef.current || !prices.length) return
+    if (!mainRef.current || !prices.length) return
+    if (showRsiChart && !rsiRef.current) return
+    if (showMacdChart && !macdRef.current) return
 
     // Build lookup maps
     closeByTime.current.clear()
@@ -177,22 +201,17 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
 
     const theme = getChartTheme()
 
-    // Main chart
-    const mainChart = createChart(mainRef.current, {
-      width: mainRef.current.clientWidth,
-      height: 400,
+    const subChartOpts = {
       layout: {
-        background: { type: ColorType.Solid, color: theme.bg },
+        background: { type: ColorType.Solid as const, color: theme.bg },
         textColor: theme.text,
-        attributionLogo: false,
+        attributionLogo: false as const,
       },
       grid: {
         vertLines: { color: theme.grid },
         horzLines: { color: theme.grid },
       },
-      rightPriceScale: { borderColor: theme.border },
-      timeScale: { borderColor: theme.border, visible: false },
-      crosshair: { mode: 0 },
+      crosshair: { mode: 0 as const },
       handleScroll: {
         horzTouchDrag: true,
         vertTouchDrag: false,
@@ -205,79 +224,104 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
         axisPressedMouseMove: false,
         axisDoubleClickReset: { time: true, price: false },
       },
+    }
+
+    // Main chart — hide time axis only when sub-charts exist below
+    const hideMainTimeAxis = showRsiChart || showMacdChart
+    const mainChart = createChart(mainRef.current, {
+      width: mainRef.current.clientWidth,
+      height: 400,
+      ...subChartOpts,
+      rightPriceScale: { borderColor: theme.border },
+      timeScale: { borderColor: theme.border, visible: !hideMainTimeAxis },
     })
 
-    const candleSeries = mainChart.addSeries(CandlestickSeries, {
-      upColor: "#22c55e",
-      downColor: "#ef4444",
-      borderUpColor: "#22c55e",
-      borderDownColor: "#ef4444",
-      wickUpColor: "#22c55e",
-      wickDownColor: "#ef4444",
-    })
-
-    candleSeries.setData(
-      prices.map((p) => ({
-        time: p.date,
-        open: p.open,
-        high: p.high,
-        low: p.low,
-        close: p.close,
-      }))
-    )
+    // Main series: candle or line
+    let mainSeries: ReturnType<IChartApi["addSeries"]>
+    if (chartType === "line") {
+      mainSeries = mainChart.addSeries(LineSeries, {
+        color: "#3b82f6",
+        lineWidth: 2,
+        priceLineVisible: false,
+      })
+      mainSeries.setData(
+        prices.map((p) => ({ time: p.date, value: p.close }))
+      )
+    } else {
+      mainSeries = mainChart.addSeries(CandlestickSeries, {
+        upColor: "#22c55e",
+        downColor: "#ef4444",
+        borderUpColor: "#22c55e",
+        borderDownColor: "#ef4444",
+        wickUpColor: "#22c55e",
+        wickDownColor: "#ef4444",
+      })
+      mainSeries.setData(
+        prices.map((p) => ({
+          time: p.date,
+          open: p.open,
+          high: p.high,
+          low: p.low,
+          close: p.close,
+        }))
+      )
+    }
 
     // Overlay indicators
     if (indicators.length) {
-      // Bollinger Bands — line series for borders + custom primitive for band fill
-      const bbData = indicators.filter((i) => i.bb_upper !== null && i.bb_lower !== null)
+      if (showBollinger) {
+        const bbData = indicators.filter((i) => i.bb_upper !== null && i.bb_lower !== null)
 
-      const bbUpperLine = mainChart.addSeries(LineSeries, {
-        color: "rgba(96, 165, 250, 0.4)",
-        lineWidth: 1,
-        priceLineVisible: false,
-        crosshairMarkerVisible: false,
-      })
-      bbUpperLine.setData(bbData.map((i) => ({ time: i.date, value: i.bb_upper! })))
+        const bbUpperLine = mainChart.addSeries(LineSeries, {
+          color: "rgba(96, 165, 250, 0.4)",
+          lineWidth: 1,
+          priceLineVisible: false,
+          crosshairMarkerVisible: false,
+        })
+        bbUpperLine.setData(bbData.map((i) => ({ time: i.date, value: i.bb_upper! })))
 
-      const bbLowerLine = mainChart.addSeries(LineSeries, {
-        color: "rgba(96, 165, 250, 0.4)",
-        lineWidth: 1,
-        priceLineVisible: false,
-        crosshairMarkerVisible: false,
-      })
-      bbLowerLine.setData(bbData.map((i) => ({ time: i.date, value: i.bb_lower! })))
+        const bbLowerLine = mainChart.addSeries(LineSeries, {
+          color: "rgba(96, 165, 250, 0.4)",
+          lineWidth: 1,
+          priceLineVisible: false,
+          crosshairMarkerVisible: false,
+        })
+        bbLowerLine.setData(bbData.map((i) => ({ time: i.date, value: i.bb_lower! })))
 
-      // Attach band fill primitive to the upper BB line series
-      const bandFill = new BandFillPrimitive(
-        bbData.map((i) => ({ time: i.date, upper: i.bb_upper!, lower: i.bb_lower! }))
-      )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- lightweight-charts plugin API type mismatch
-      bbUpperLine.attachPrimitive(bandFill as any)
+        const bandFill = new BandFillPrimitive(
+          bbData.map((i) => ({ time: i.date, upper: i.bb_upper!, lower: i.bb_lower! }))
+        )
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- lightweight-charts plugin API type mismatch
+        bbUpperLine.attachPrimitive(bandFill as any)
+      }
 
-      // SMA lines
-      const sma20 = mainChart.addSeries(LineSeries, {
-        color: "#14b8a6",
-        lineWidth: 1,
-        priceLineVisible: false,
-        crosshairMarkerVisible: false,
-      })
-      sma20.setData(
-        indicators
-          .filter((i) => i.sma_20 !== null)
-          .map((i) => ({ time: i.date, value: i.sma_20! }))
-      )
+      if (showSma20) {
+        const sma20 = mainChart.addSeries(LineSeries, {
+          color: "#14b8a6",
+          lineWidth: 1,
+          priceLineVisible: false,
+          crosshairMarkerVisible: false,
+        })
+        sma20.setData(
+          indicators
+            .filter((i) => i.sma_20 !== null)
+            .map((i) => ({ time: i.date, value: i.sma_20! }))
+        )
+      }
 
-      const sma50 = mainChart.addSeries(LineSeries, {
-        color: "#8b5cf6",
-        lineWidth: 1,
-        priceLineVisible: false,
-        crosshairMarkerVisible: false,
-      })
-      sma50.setData(
-        indicators
-          .filter((i) => i.sma_50 !== null)
-          .map((i) => ({ time: i.date, value: i.sma_50! }))
-      )
+      if (showSma50) {
+        const sma50 = mainChart.addSeries(LineSeries, {
+          color: "#8b5cf6",
+          lineWidth: 1,
+          priceLineVisible: false,
+          crosshairMarkerVisible: false,
+        })
+        sma50.setData(
+          indicators
+            .filter((i) => i.sma_50 !== null)
+            .map((i) => ({ time: i.date, value: i.sma_50! }))
+        )
+      }
     }
 
     // Annotation markers
@@ -292,198 +336,199 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
         }))
         .sort((a, b) => (a.time < b.time ? -1 : 1))
 
-      createSeriesMarkers(candleSeries, markers)
+      createSeriesMarkers(mainSeries, markers)
     }
 
     mainChart.timeScale().fitContent()
     mainChartRef.current = mainChart
 
+    // Collect chart entries for sync
+    const chartEntries: { chart: IChartApi; series: ReturnType<IChartApi["addSeries"]> }[] = [
+      { chart: mainChart, series: mainSeries },
+    ]
+    const createdCharts: IChartApi[] = [mainChart]
+
     // RSI chart
-    const rsiChart = createChart(rsiRef.current, {
-      width: rsiRef.current.clientWidth,
-      height: 120,
-      layout: {
-        background: { type: ColorType.Solid, color: theme.bg },
-        textColor: theme.text,
-        attributionLogo: false,
-      },
-      grid: {
-        vertLines: { color: theme.grid },
-        horzLines: { color: theme.grid },
-      },
-      rightPriceScale: {
-        borderColor: theme.border,
-        autoScale: false,
-        scaleMargins: { top: 0.05, bottom: 0.05 },
-      },
-      timeScale: { borderColor: theme.border, timeVisible: false },
-      crosshair: { mode: 0 },
-      handleScroll: {
-        horzTouchDrag: true,
-        vertTouchDrag: false,
-        mouseWheel: false,
-        pressedMouseMove: true,
-      },
-      handleScale: {
-        mouseWheel: true,
-        pinch: true,
-        axisPressedMouseMove: false,
-        axisDoubleClickReset: { time: true, price: false },
-      },
-    })
+    let rsiSeries: ReturnType<IChartApi["addSeries"]> | null = null
+    if (showRsiChart && rsiRef.current) {
+      const rsiChart = createChart(rsiRef.current, {
+        width: rsiRef.current.clientWidth,
+        height: 120,
+        ...subChartOpts,
+        rightPriceScale: {
+          borderColor: theme.border,
+          autoScale: false,
+          scaleMargins: { top: 0.05, bottom: 0.05 },
+        },
+        timeScale: { borderColor: theme.border, timeVisible: false },
+      })
 
-    const rsiSeries = rsiChart.addSeries(LineSeries, {
-      color: "#8b5cf6",
-      lineWidth: 2,
-      priceLineVisible: false,
-      autoscaleInfoProvider: () => ({
-        priceRange: { minValue: 0, maxValue: 100 },
-      }),
-    })
+      rsiSeries = rsiChart.addSeries(LineSeries, {
+        color: "#8b5cf6",
+        lineWidth: 2,
+        priceLineVisible: false,
+        autoscaleInfoProvider: () => ({
+          priceRange: { minValue: 0, maxValue: 100 },
+        }),
+      })
 
-    rsiSeries.setData(
-      indicators
-        .filter((i) => i.rsi !== null)
-        .map((i) => ({ time: i.date, value: i.rsi! }))
-    )
+      rsiSeries.setData(
+        indicators
+          .filter((i) => i.rsi !== null)
+          .map((i) => ({ time: i.date, value: i.rsi! }))
+      )
 
-    // RSI threshold lines
-    const overbought = rsiChart.addSeries(LineSeries, {
-      color: "rgba(239, 68, 68, 0.5)",
-      lineWidth: 1,
-      lineStyle: 2,
-      priceLineVisible: false,
-      crosshairMarkerVisible: false,
-      autoscaleInfoProvider: () => ({
-        priceRange: { minValue: 0, maxValue: 100 },
-      }),
-    })
-    const oversold = rsiChart.addSeries(LineSeries, {
-      color: "rgba(34, 197, 94, 0.5)",
-      lineWidth: 1,
-      lineStyle: 2,
-      priceLineVisible: false,
-      crosshairMarkerVisible: false,
-      autoscaleInfoProvider: () => ({
-        priceRange: { minValue: 0, maxValue: 100 },
-      }),
-    })
-
-    const rsiDates = indicators.filter((i) => i.rsi !== null).map((i) => i.date)
-    if (rsiDates.length) {
-      overbought.setData(rsiDates.map((d) => ({ time: d, value: 70 })))
-      oversold.setData(rsiDates.map((d) => ({ time: d, value: 30 })))
-    }
-
-    rsiChart.timeScale().fitContent()
-    rsiChartRef.current = rsiChart
-
-    // MACD chart
-    const macdChart = createChart(macdRef.current, {
-      width: macdRef.current.clientWidth,
-      height: 120,
-      layout: {
-        background: { type: ColorType.Solid, color: theme.bg },
-        textColor: theme.text,
-        attributionLogo: false,
-      },
-      grid: {
-        vertLines: { color: theme.grid },
-        horzLines: { color: theme.grid },
-      },
-      rightPriceScale: { borderColor: theme.border },
-      timeScale: { borderColor: theme.border, timeVisible: false },
-      crosshair: { mode: 0 },
-      handleScroll: {
-        horzTouchDrag: true,
-        vertTouchDrag: false,
-        mouseWheel: false,
-        pressedMouseMove: true,
-      },
-      handleScale: {
-        mouseWheel: true,
-        pinch: true,
-        axisPressedMouseMove: false,
-        axisDoubleClickReset: { time: true, price: false },
-      },
-    })
-
-    const macdData = indicators.filter((i) => i.macd !== null)
-
-    // MACD histogram (rendered first so lines draw on top)
-    const macdHistSeries = macdChart.addSeries(HistogramSeries, {
-      priceLineVisible: false,
-      base: 0,
-    })
-    macdHistSeries.setData(
-      macdData.map((i) => ({
-        time: i.date,
-        value: i.macd_hist!,
-        color: i.macd_hist! >= 0 ? "rgba(34, 197, 94, 0.6)" : "rgba(239, 68, 68, 0.6)",
-      }))
-    )
-
-    // MACD line
-    const macdLineSeries = macdChart.addSeries(LineSeries, {
-      color: "#38bdf8",
-      lineWidth: 2,
-      priceLineVisible: false,
-      crosshairMarkerVisible: false,
-    })
-    macdLineSeries.setData(
-      macdData.map((i) => ({ time: i.date, value: i.macd! }))
-    )
-
-    // Signal line
-    const macdSignalSeries = macdChart.addSeries(LineSeries, {
-      color: "#fb923c",
-      lineWidth: 2,
-      priceLineVisible: false,
-      crosshairMarkerVisible: false,
-    })
-    macdSignalSeries.setData(
-      indicators
-        .filter((i) => i.macd_signal !== null)
-        .map((i) => ({ time: i.date, value: i.macd_signal! }))
-    )
-
-    // Zero line
-    if (macdData.length) {
-      const zeroLine = macdChart.addSeries(LineSeries, {
-        color: "rgba(161, 161, 170, 0.3)",
+      // RSI threshold lines
+      const overbought = rsiChart.addSeries(LineSeries, {
+        color: "rgba(239, 68, 68, 0.5)",
         lineWidth: 1,
         lineStyle: 2,
         priceLineVisible: false,
         crosshairMarkerVisible: false,
+        autoscaleInfoProvider: () => ({
+          priceRange: { minValue: 0, maxValue: 100 },
+        }),
       })
-      zeroLine.setData(macdData.map((i) => ({ time: i.date, value: 0 })))
+      const oversold = rsiChart.addSeries(LineSeries, {
+        color: "rgba(34, 197, 94, 0.5)",
+        lineWidth: 1,
+        lineStyle: 2,
+        priceLineVisible: false,
+        crosshairMarkerVisible: false,
+        autoscaleInfoProvider: () => ({
+          priceRange: { minValue: 0, maxValue: 100 },
+        }),
+      })
+
+      const rsiDates = indicators.filter((i) => i.rsi !== null).map((i) => i.date)
+      if (rsiDates.length) {
+        overbought.setData(rsiDates.map((d) => ({ time: d, value: 70 })))
+        oversold.setData(rsiDates.map((d) => ({ time: d, value: 30 })))
+      }
+
+      rsiChart.timeScale().fitContent()
+      rsiChartRef.current = rsiChart
+      chartEntries.push({ chart: rsiChart, series: rsiSeries })
+      createdCharts.push(rsiChart)
+    } else {
+      rsiChartRef.current = null
     }
 
-    macdChart.timeScale().fitContent()
-    macdChartRef.current = macdChart
+    // MACD chart
+    let macdLineSeries: ReturnType<IChartApi["addSeries"]> | null = null
+    if (showMacdChart && macdRef.current) {
+      const macdChart = createChart(macdRef.current, {
+        width: macdRef.current.clientWidth,
+        height: 120,
+        ...subChartOpts,
+        rightPriceScale: { borderColor: theme.border },
+        timeScale: { borderColor: theme.border, timeVisible: false },
+      })
 
-    syncCharts(mainChart, rsiChart, macdChart, candleSeries, rsiSeries, macdLineSeries)
+      const macdData = indicators.filter((i) => i.macd !== null)
+
+      // MACD histogram (rendered first so lines draw on top)
+      const macdHistSeries = macdChart.addSeries(HistogramSeries, {
+        priceLineVisible: false,
+        base: 0,
+      })
+      macdHistSeries.setData(
+        macdData.map((i) => ({
+          time: i.date,
+          value: i.macd_hist!,
+          color: i.macd_hist! >= 0 ? "rgba(34, 197, 94, 0.6)" : "rgba(239, 68, 68, 0.6)",
+        }))
+      )
+
+      // MACD line
+      macdLineSeries = macdChart.addSeries(LineSeries, {
+        color: "#38bdf8",
+        lineWidth: 2,
+        priceLineVisible: false,
+        crosshairMarkerVisible: false,
+      })
+      macdLineSeries.setData(
+        macdData.map((i) => ({ time: i.date, value: i.macd! }))
+      )
+
+      // Signal line
+      const macdSignalSeries = macdChart.addSeries(LineSeries, {
+        color: "#fb923c",
+        lineWidth: 2,
+        priceLineVisible: false,
+        crosshairMarkerVisible: false,
+      })
+      macdSignalSeries.setData(
+        indicators
+          .filter((i) => i.macd_signal !== null)
+          .map((i) => ({ time: i.date, value: i.macd_signal! }))
+      )
+
+      // Zero line
+      if (macdData.length) {
+        const zeroLine = macdChart.addSeries(LineSeries, {
+          color: "rgba(161, 161, 170, 0.3)",
+          lineWidth: 1,
+          lineStyle: 2,
+          priceLineVisible: false,
+          crosshairMarkerVisible: false,
+        })
+        zeroLine.setData(macdData.map((i) => ({ time: i.date, value: 0 })))
+      }
+
+      macdChart.timeScale().fitContent()
+      macdChartRef.current = macdChart
+      chartEntries.push({ chart: macdChart, series: macdLineSeries })
+      createdCharts.push(macdChart)
+    } else {
+      macdChartRef.current = null
+    }
+
+    // Sync all created charts
+    if (chartEntries.length > 1) {
+      syncCharts(chartEntries)
+    } else if (chartEntries.length === 1) {
+      // Single chart — still need crosshair legend updates
+      mainChart.subscribeCrosshairMove((param) => {
+        if (param.time) {
+          const key = String(param.time)
+          const ohlc = ohlcByTime.current.get(key)
+          setHoverValues({
+            o: ohlc?.o,
+            h: ohlc?.h,
+            l: ohlc?.l,
+            c: ohlc?.c,
+            sma20: sma20ByTime.current.get(key),
+            sma50: sma50ByTime.current.get(key),
+            bbUpper: bbUpperByTime.current.get(key),
+            bbLower: bbLowerByTime.current.get(key),
+          })
+        } else {
+          setHoverValues(null)
+        }
+      })
+    }
 
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const w = entry.contentRect.width
-        mainChart.applyOptions({ width: w })
-        rsiChart.applyOptions({ width: w })
-        macdChart.applyOptions({ width: w })
+        for (const chart of createdCharts) {
+          chart.applyOptions({ width: w })
+        }
       }
     })
     resizeObserver.observe(mainRef.current)
 
     return () => {
       resizeObserver.disconnect()
-      mainChart.remove()
-      rsiChart.remove()
-      macdChart.remove()
+      for (const chart of createdCharts) {
+        chart.remove()
+      }
       mainChartRef.current = null
       rsiChartRef.current = null
       macdChartRef.current = null
     }
-  }, [prices, indicators, annotations, syncCharts])
+  }, [prices, indicators, annotations, syncCharts, showSma20, showSma50, showBollinger, showRsiChart, showMacdChart, chartType])
 
   // Apply theme changes without recreating charts
   useEffect(() => {
@@ -499,6 +544,9 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
     macdChartRef.current?.timeScale().fitContent()
   }, [])
 
+  // Determine rounding class for main chart
+  const mainRoundClass = !showRsiChart && !showMacdChart ? "rounded-md" : "rounded-t-md"
+
   return (
     <div className="mb-4">
       <div className="flex items-center justify-between px-1 py-1">
@@ -511,15 +559,23 @@ export function PriceChart({ prices, indicators, annotations }: PriceChartProps)
           Reset view
         </button>
       </div>
-      <div ref={mainRef} className="w-full rounded-t-md overflow-hidden" />
-      <div className="px-1 py-1">
-        <RsiLegend values={hoverValues} latest={latestValues} />
-      </div>
-      <div ref={rsiRef} className="w-full overflow-hidden" />
-      <div className="px-1 py-1">
-        <MacdLegend values={hoverValues} latest={latestValues} />
-      </div>
-      <div ref={macdRef} className="w-full rounded-b-md overflow-hidden" />
+      <div ref={mainRef} className={`w-full ${mainRoundClass} overflow-hidden`} />
+      {showRsiChart && (
+        <>
+          <div className="px-1 py-1">
+            <RsiLegend values={hoverValues} latest={latestValues} />
+          </div>
+          <div ref={rsiRef} className="w-full overflow-hidden" />
+        </>
+      )}
+      {showMacdChart && (
+        <>
+          <div className="px-1 py-1">
+            <MacdLegend values={hoverValues} latest={latestValues} />
+          </div>
+          <div ref={macdRef} className={`w-full ${!showRsiChart && !showMacdChart ? "" : "rounded-b-md"} overflow-hidden`} />
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -304,6 +304,14 @@ export const api = {
     delete: (symbol: string, id: number) =>
       request<void>(`/assets/${symbol}/annotations/${id}`, { method: "DELETE" }),
   },
+  settings: {
+    get: () => request<{ data: Record<string, unknown> }>("/settings"),
+    update: (data: Record<string, unknown>) =>
+      request<{ data: Record<string, unknown> }>("/settings", {
+        method: "PUT",
+        body: JSON.stringify({ data }),
+      }),
+  },
   pseudoEtfs: {
     list: () => request<PseudoETF[]>("/pseudo-etfs"),
     create: (data: PseudoETFCreate) =>

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -1,0 +1,139 @@
+import { createContext, useContext, useEffect, useState, useCallback, useRef, type ReactNode } from "react"
+
+export interface AppSettings {
+  watchlist_show_rsi: boolean
+  watchlist_show_macd: boolean
+  watchlist_show_sparkline: boolean
+  detail_show_sma20: boolean
+  detail_show_sma50: boolean
+  detail_show_bollinger: boolean
+  detail_show_rsi_chart: boolean
+  detail_show_macd_chart: boolean
+  chart_default_period: string
+  chart_type: "candle" | "line"
+  theme: "dark" | "light" | "system"
+  compact_mode: boolean
+  decimal_places: number
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const DEFAULT_SETTINGS: AppSettings = {
+  watchlist_show_rsi: true,
+  watchlist_show_macd: true,
+  watchlist_show_sparkline: true,
+  detail_show_sma20: true,
+  detail_show_sma50: true,
+  detail_show_bollinger: true,
+  detail_show_rsi_chart: true,
+  detail_show_macd_chart: true,
+  chart_default_period: "1y",
+  chart_type: "candle",
+  theme: "system",
+  compact_mode: false,
+  decimal_places: 2,
+}
+
+const STORAGE_KEY = "fibenchi-settings"
+const OLD_THEME_KEY = "theme"
+
+function loadFromStorage(): AppSettings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+    }
+  } catch {
+    // ignore corrupt storage
+  }
+
+  // Migrate old theme key
+  const oldTheme = localStorage.getItem(OLD_THEME_KEY)
+  if (oldTheme === "dark" || oldTheme === "light") {
+    const migrated = { ...DEFAULT_SETTINGS, theme: oldTheme as "dark" | "light" }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(migrated))
+    localStorage.removeItem(OLD_THEME_KEY)
+    return migrated
+  }
+
+  return { ...DEFAULT_SETTINGS }
+}
+
+function saveToStorage(settings: AppSettings) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+}
+
+interface SettingsContextValue {
+  settings: AppSettings
+  updateSettings: (patch: Partial<AppSettings>) => void
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null)
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<AppSettings>(loadFromStorage)
+  const initializedRef = useRef(false)
+
+  // On mount: fetch from backend and merge (backend wins)
+  useEffect(() => {
+    if (initializedRef.current) return
+    initializedRef.current = true
+
+    fetch("/api/settings")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body) => {
+        if (body?.data && Object.keys(body.data).length > 0) {
+          setSettings((prev) => {
+            const merged = { ...prev, ...body.data }
+            saveToStorage(merged)
+            return merged
+          })
+        }
+      })
+      .catch(() => {
+        // backend unavailable — use local settings
+      })
+  }, [])
+
+  // Apply theme
+  useEffect(() => {
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)")
+    const apply = () => {
+      const isDark =
+        settings.theme === "dark" || (settings.theme === "system" && prefersDark.matches)
+      document.documentElement.classList.toggle("dark", isDark)
+    }
+    apply()
+
+    if (settings.theme === "system") {
+      prefersDark.addEventListener("change", apply)
+      return () => prefersDark.removeEventListener("change", apply)
+    }
+  }, [settings.theme])
+
+  const updateSettings = useCallback((patch: Partial<AppSettings>) => {
+    setSettings((prev) => {
+      const next = { ...prev, ...patch }
+      saveToStorage(next)
+      // Fire-and-forget backend sync
+      fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: next }),
+      }).catch(() => {})
+      return next
+    })
+  }, [])
+
+  return (
+    <SettingsContext.Provider value={{ settings, updateSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useSettings() {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) throw new Error("useSettings must be used within SettingsProvider")
+  return ctx
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import "./index.css"
 import App from "./App.tsx"
 import { QuoteStreamProvider } from "./lib/quote-stream.tsx"
+import { SettingsProvider } from "./lib/settings.tsx"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,12 +16,14 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <QuoteStreamProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </QuoteStreamProvider>
-    </QueryClientProvider>
+    <SettingsProvider>
+      <QueryClientProvider client={queryClient}>
+        <QuoteStreamProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </QuoteStreamProvider>
+      </QueryClientProvider>
+    </SettingsProvider>
   </StrictMode>
 )

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -26,12 +26,14 @@ import {
   useThesis,
   useUpdateThesis,
 } from "@/lib/queries"
+import { useSettings } from "@/lib/settings"
 
 const PERIODS = ["1mo", "3mo", "6mo", "1y", "2y", "5y"] as const
 
 export function AssetDetailPage() {
   const { symbol } = useParams<{ symbol: string }>()
-  const [period, setPeriod] = useState<string>("1y")
+  const { settings } = useSettings()
+  const [period, setPeriod] = useState<string>(settings.chart_default_period)
   const { data: assets } = useAssets()
   const asset = assets?.find((a) => a.symbol === symbol?.toUpperCase())
   const isWatchlisted = !!asset
@@ -42,7 +44,16 @@ export function AssetDetailPage() {
   return (
     <div className="p-6 space-y-6">
       <Header symbol={symbol} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isWatchlisted={isWatchlisted} />
-      <ChartSection symbol={symbol} period={period} />
+      <ChartSection
+        symbol={symbol}
+        period={period}
+        showSma20={settings.detail_show_sma20}
+        showSma50={settings.detail_show_sma50}
+        showBollinger={settings.detail_show_bollinger}
+        showRsiChart={settings.detail_show_rsi_chart}
+        showMacdChart={settings.detail_show_macd_chart}
+        chartType={settings.chart_type}
+      />
       {isEtf && <HoldingsSection symbol={symbol} />}
       {isWatchlisted && (
         <>
@@ -153,7 +164,25 @@ function Header({
   )
 }
 
-function ChartSection({ symbol, period }: { symbol: string; period: string }) {
+function ChartSection({
+  symbol,
+  period,
+  showSma20,
+  showSma50,
+  showBollinger,
+  showRsiChart,
+  showMacdChart,
+  chartType,
+}: {
+  symbol: string
+  period: string
+  showSma20: boolean
+  showSma50: boolean
+  showBollinger: boolean
+  showRsiChart: boolean
+  showMacdChart: boolean
+  chartType: "candle" | "line"
+}) {
   const { data: prices, isLoading: pricesLoading } = usePrices(symbol, period)
   const { data: indicators, isLoading: indicatorsLoading } = useIndicators(symbol, period)
   const { data: annotations } = useAnnotations(symbol)
@@ -175,7 +204,19 @@ function ChartSection({ symbol, period }: { symbol: string; period: string }) {
     )
   }
 
-  return <PriceChart prices={prices} indicators={indicators ?? []} annotations={annotations ?? []} />
+  return (
+    <PriceChart
+      prices={prices}
+      indicators={indicators ?? []}
+      annotations={annotations ?? []}
+      showSma20={showSma20}
+      showSma50={showSma50}
+      showBollinger={showBollinger}
+      showRsiChart={showRsiChart}
+      showMacdChart={showMacdChart}
+      chartType={chartType}
+    />
+  )
 }
 
 function ThesisSection({ symbol }: { symbol: string }) {

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useSettings, type AppSettings } from "@/lib/settings"
+
+function SettingSwitch({
+  id,
+  label,
+  settingKey,
+  draft,
+  onChange,
+}: {
+  id: string
+  label: string
+  settingKey: keyof AppSettings
+  draft: AppSettings
+  onChange: (patch: Partial<AppSettings>) => void
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <Label htmlFor={id}>{label}</Label>
+      <Switch
+        id={id}
+        checked={draft[settingKey] as boolean}
+        onCheckedChange={(v) => onChange({ [settingKey]: v })}
+      />
+    </div>
+  )
+}
+
+export function SettingsPage() {
+  const { settings, updateSettings } = useSettings()
+  const [draft, setDraft] = useState<AppSettings>(settings)
+
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(settings)
+
+  const change = (patch: Partial<AppSettings>) => {
+    setDraft((prev) => ({ ...prev, ...patch }))
+  }
+
+  const apply = () => {
+    updateSettings(draft)
+  }
+
+  const discard = () => {
+    setDraft(settings)
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-2xl">
+      <h1 className="text-2xl font-bold">Settings</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Watchlist Card Indicators</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <SettingSwitch id="wl-sparkline" label="Sparkline Chart" settingKey="watchlist_show_sparkline" draft={draft} onChange={change} />
+          <SettingSwitch id="wl-rsi" label="RSI Gauge" settingKey="watchlist_show_rsi" draft={draft} onChange={change} />
+          <SettingSwitch id="wl-macd" label="MACD Indicator" settingKey="watchlist_show_macd" draft={draft} onChange={change} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Detail Page Chart</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <SettingSwitch id="dt-sma20" label="SMA 20" settingKey="detail_show_sma20" draft={draft} onChange={change} />
+          <SettingSwitch id="dt-sma50" label="SMA 50" settingKey="detail_show_sma50" draft={draft} onChange={change} />
+          <SettingSwitch id="dt-bb" label="Bollinger Bands" settingKey="detail_show_bollinger" draft={draft} onChange={change} />
+          <SettingSwitch id="dt-rsi" label="RSI Chart" settingKey="detail_show_rsi_chart" draft={draft} onChange={change} />
+          <SettingSwitch id="dt-macd" label="MACD Chart" settingKey="detail_show_macd_chart" draft={draft} onChange={change} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Chart Preferences</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <Label>Default Period</Label>
+            <Select
+              value={draft.chart_default_period}
+              onValueChange={(v) => change({ chart_default_period: v })}
+            >
+              <SelectTrigger className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1mo">1M</SelectItem>
+                <SelectItem value="3mo">3M</SelectItem>
+                <SelectItem value="6mo">6M</SelectItem>
+                <SelectItem value="1y">1Y</SelectItem>
+                <SelectItem value="2y">2Y</SelectItem>
+                <SelectItem value="5y">5Y</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center justify-between">
+            <Label>Chart Type</Label>
+            <Select
+              value={draft.chart_type}
+              onValueChange={(v) => change({ chart_type: v as "candle" | "line" })}
+            >
+              <SelectTrigger className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="candle">Candlestick</SelectItem>
+                <SelectItem value="line">Line</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Display</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <Label>Theme</Label>
+            <Select
+              value={draft.theme}
+              onValueChange={(v) => change({ theme: v as "dark" | "light" | "system" })}
+            >
+              <SelectTrigger className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="system">System</SelectItem>
+                <SelectItem value="light">Light</SelectItem>
+                <SelectItem value="dark">Dark</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <SettingSwitch id="compact" label="Compact Mode" settingKey="compact_mode" draft={draft} onChange={change} />
+          <div className="flex items-center justify-between">
+            <Label>Decimal Places</Label>
+            <Select
+              value={String(draft.decimal_places)}
+              onValueChange={(v) => change({ decimal_places: Number(v) })}
+            >
+              <SelectTrigger className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">0</SelectItem>
+                <SelectItem value="1">1</SelectItem>
+                <SelectItem value="2">2</SelectItem>
+                <SelectItem value="3">3</SelectItem>
+                <SelectItem value="4">4</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-end gap-2">
+        {isDirty && (
+          <Button variant="outline" onClick={discard}>
+            Discard
+          </Button>
+        )}
+        <Button onClick={apply} disabled={!isDirty}>
+          Save
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/watchlist.tsx
+++ b/frontend/src/pages/watchlist.tsx
@@ -21,6 +21,7 @@ import { TagBadge } from "@/components/tag-badge"
 import type { Quote, TagBrief } from "@/lib/api"
 import { formatPrice } from "@/lib/format"
 import { usePriceFlash } from "@/lib/use-price-flash"
+import { useSettings } from "@/lib/settings"
 
 export function WatchlistPage() {
   const { data: allAssets, isLoading } = useAssets()
@@ -30,6 +31,7 @@ export function WatchlistPage() {
   const [symbol, setSymbol] = useState("")
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
+  const { settings } = useSettings()
 
   const watchlisted = allAssets?.filter((a) => a.watchlisted)
   const quotes = useQuotes()
@@ -119,7 +121,11 @@ export function WatchlistPage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <div className={`grid gap-4 ${
+        settings.compact_mode
+          ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5"
+          : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+      }`}>
         {assets?.map((asset) => (
           <AssetCard
             key={asset.id}
@@ -131,6 +137,9 @@ export function WatchlistPage() {
             quote={quotes[asset.symbol]}
             sparklinePeriod={sparklinePeriod}
             onDelete={() => deleteAsset.mutate(asset.symbol)}
+            showSparkline={settings.watchlist_show_sparkline}
+            showRsi={settings.watchlist_show_rsi}
+            showMacd={settings.watchlist_show_macd}
           />
         ))}
       </div>
@@ -147,6 +156,9 @@ function AssetCard({
   quote,
   sparklinePeriod,
   onDelete,
+  showSparkline,
+  showRsi,
+  showMacd,
 }: {
   symbol: string
   name: string
@@ -156,6 +168,9 @@ function AssetCard({
   quote?: Quote
   sparklinePeriod: string
   onDelete: () => void
+  showSparkline: boolean
+  showRsi: boolean
+  showMacd: boolean
 }) {
   const lastPrice = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
@@ -225,11 +240,13 @@ function AssetCard({
           )}
         </CardHeader>
         <CardContent className="pt-0 space-y-2">
-          <SparklineChart symbol={symbol} period={sparklinePeriod} />
-          <div className="flex gap-1.5 mt-1">
-            <RsiGauge symbol={symbol} />
-            <MacdIndicator symbol={symbol} />
-          </div>
+          {showSparkline && <SparklineChart symbol={symbol} period={sparklinePeriod} />}
+          {(showRsi || showMacd) && (
+            <div className="flex gap-1.5 mt-1">
+              {showRsi && <RsiGauge symbol={symbol} />}
+              {showMacd && <MacdIndicator symbol={symbol} />}
+            </div>
+          )}
         </CardContent>
       </Link>
     </Card>


### PR DESCRIPTION
## Summary
- Add full settings page for indicator visibility, chart preferences, and display options
- Backend: singleton `UserSettings` model with JSON column, `GET/PUT /api/settings` endpoints
- Frontend: `SettingsProvider` context with dual persistence (localStorage + backend API), draft/apply pattern with permanent Save button
- Conditional rendering of watchlist indicators (sparkline, RSI, MACD) and detail chart overlays (SMA20/50, Bollinger, RSI/MACD sub-charts)
- Line chart support as alternative to candlestick
- Theme control (dark/light/system) replaces old toggle in sidebar

Closes #76

## Test plan
- [x] Backend: 4 new tests (get empty, put, roundtrip, overwrite) — all pass
- [x] Frontend: lint clean, build succeeds
- [ ] Manual: toggle settings → verify indicators hide/show on watchlist + detail page
- [ ] Manual: theme switch persists across refresh
- [ ] Manual: Save/Discard buttons behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)