### PR TITLE
feat: expose raw indicator values for ETF holdings

### DIFF
--- a/backend/app/routers/holdings.py
+++ b/backend/app/routers/holdings.py
@@ -95,7 +95,13 @@ async def get_holdings_indicators(symbol: str, db: AsyncSession = Depends(get_db
             rsi=round(latest["rsi"], 2) if pd.notna(latest["rsi"]) else None,
             sma_20=round(latest["sma_20"], 2) if pd.notna(latest["sma_20"]) else None,
             sma_50=round(latest["sma_50"], 2) if pd.notna(latest["sma_50"]) else None,
+            macd=round(latest["macd"], 4) if pd.notna(latest["macd"]) else None,
+            macd_signal=round(latest["macd_signal"], 4) if pd.notna(latest["macd_signal"]) else None,
+            macd_hist=round(latest["macd_hist"], 4) if pd.notna(latest["macd_hist"]) else None,
             macd_signal_dir=macd_dir,
+            bb_upper=round(latest["bb_upper"], 2) if pd.notna(latest["bb_upper"]) else None,
+            bb_middle=round(latest["bb_middle"], 2) if pd.notna(latest["bb_middle"]) else None,
+            bb_lower=round(latest["bb_lower"], 2) if pd.notna(latest["bb_lower"]) else None,
             bb_position=bb_pos,
         ))
 

--- a/backend/app/routers/pseudo_etfs.py
+++ b/backend/app/routers/pseudo_etfs.py
@@ -212,7 +212,13 @@ async def get_constituent_indicators(etf_id: int, db: AsyncSession = Depends(get
             rsi=round(latest["rsi"], 2) if pd.notna(latest["rsi"]) else None,
             sma_20=round(latest["sma_20"], 2) if pd.notna(latest["sma_20"]) else None,
             sma_50=round(latest["sma_50"], 2) if pd.notna(latest["sma_50"]) else None,
+            macd=round(latest["macd"], 4) if pd.notna(latest["macd"]) else None,
+            macd_signal=round(latest["macd_signal"], 4) if pd.notna(latest["macd_signal"]) else None,
+            macd_hist=round(latest["macd_hist"], 4) if pd.notna(latest["macd_hist"]) else None,
             macd_signal_dir=macd_dir,
+            bb_upper=round(latest["bb_upper"], 2) if pd.notna(latest["bb_upper"]) else None,
+            bb_middle=round(latest["bb_middle"], 2) if pd.notna(latest["bb_middle"]) else None,
+            bb_lower=round(latest["bb_lower"], 2) if pd.notna(latest["bb_lower"]) else None,
             bb_position=bb_pos,
         ))
 

--- a/backend/app/schemas/price.py
+++ b/backend/app/schemas/price.py
@@ -53,5 +53,11 @@ class HoldingIndicatorResponse(BaseModel):
     rsi: float | None = None
     sma_20: float | None = None
     sma_50: float | None = None
+    macd: float | None = None
+    macd_signal: float | None = None
+    macd_hist: float | None = None
     macd_signal_dir: str | None = None  # "bullish" | "bearish"
+    bb_upper: float | None = None
+    bb_middle: float | None = None
+    bb_lower: float | None = None
     bb_position: str | None = None  # "above" | "upper" | "middle" | "lower" | "below"

--- a/backend/app/schemas/pseudo_etf.py
+++ b/backend/app/schemas/pseudo_etf.py
@@ -55,5 +55,11 @@ class ConstituentIndicatorResponse(BaseModel):
     rsi: float | None = None
     sma_20: float | None = None
     sma_50: float | None = None
+    macd: float | None = None
+    macd_signal: float | None = None
+    macd_hist: float | None = None
     macd_signal_dir: str | None = None
+    bb_upper: float | None = None
+    bb_middle: float | None = None
+    bb_lower: float | None = None
     bb_position: str | None = None

--- a/backend/tests/test_holdings.py
+++ b/backend/tests/test_holdings.py
@@ -79,6 +79,25 @@ async def test_holdings_indicators_success(client):
     assert data[0]["close"] is not None
     assert data[1]["symbol"] == "MSFT"
 
+    # Verify raw numeric indicator fields are present
+    for item in data:
+        assert "macd" in item
+        assert "macd_signal" in item
+        assert "macd_hist" in item
+        assert "bb_upper" in item
+        assert "bb_middle" in item
+        assert "bb_lower" in item
+        # With 100 data points, all indicators should have values
+        assert isinstance(item["macd"], float)
+        assert isinstance(item["macd_signal"], float)
+        assert isinstance(item["macd_hist"], float)
+        assert isinstance(item["bb_upper"], float)
+        assert isinstance(item["bb_middle"], float)
+        assert isinstance(item["bb_lower"], float)
+        # Classified fields still present
+        assert "macd_signal_dir" in item
+        assert "bb_position" in item
+
 
 async def test_holdings_indicators_not_etf(client):
     """Holdings indicators endpoint returns 400 for stock assets."""

--- a/frontend/src/components/holdings-grid.tsx
+++ b/frontend/src/components/holdings-grid.tsx
@@ -10,7 +10,13 @@ export interface IndicatorData {
   change_pct: number | null
   rsi: number | null
   sma_20: number | null
+  macd: number | null
+  macd_signal: number | null
+  macd_hist: number | null
   macd_signal_dir: string | null
+  bb_upper: number | null
+  bb_middle: number | null
+  bb_lower: number | null
   bb_position: string | null
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -136,7 +136,13 @@ export interface HoldingIndicator {
   rsi: number | null
   sma_20: number | null
   sma_50: number | null
+  macd: number | null
+  macd_signal: number | null
+  macd_hist: number | null
   macd_signal_dir: string | null
+  bb_upper: number | null
+  bb_middle: number | null
+  bb_lower: number | null
   bb_position: string | null
 }
 
@@ -199,7 +205,13 @@ export interface ConstituentIndicator {
   rsi: number | null
   sma_20: number | null
   sma_50: number | null
+  macd: number | null
+  macd_signal: number | null
+  macd_hist: number | null
   macd_signal_dir: string | null
+  bb_upper: number | null
+  bb_middle: number | null
+  bb_lower: number | null
   bb_position: string | null
 }
 

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -279,7 +279,7 @@ function TopHoldingsCard({
   indicatorsLoading,
 }: {
   data: EtfHoldings
-  indicatorMap: ReadonlyMap<string, { currency: string; close: number | null; change_pct: number | null; rsi: number | null; sma_20: number | null; macd_signal_dir: string | null; bb_position: string | null }>
+  indicatorMap: ReadonlyMap<string, { currency: string; close: number | null; change_pct: number | null; rsi: number | null; sma_20: number | null; macd: number | null; macd_signal: number | null; macd_hist: number | null; macd_signal_dir: string | null; bb_upper: number | null; bb_middle: number | null; bb_lower: number | null; bb_position: string | null }>
   indicatorsLoading: boolean
 }) {
   const rows: HoldingsGridRow[] = data.top_holdings.map((h) => ({


### PR DESCRIPTION
## Summary
- Add raw numeric indicator fields (`macd`, `macd_signal`, `macd_hist`, `bb_upper`, `bb_middle`, `bb_lower`) to both ETF holdings and pseudo-ETF constituent indicator API responses
- Existing classified fields (`macd_signal_dir`, `bb_position`) preserved for backwards compatibility
- Frontend types updated to match new API contract

## Test plan
- [x] All 97 backend tests pass (including new assertions for numeric fields)
- [x] Frontend lint clean
- [x] Frontend build succeeds
- [ ] Manual: verify `/api/assets/{etf}/holdings/indicators` returns numeric fields

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)