### PR TITLE
perf: increase staleTime for price/indicator queries to 5 min

### DIFF
--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -67,6 +67,7 @@ export function usePrices(symbol: string, period?: string) {
     queryKey: keys.prices(symbol, period),
     queryFn: () => api.prices.list(symbol, period),
     enabled: !!symbol,
+    staleTime: 5 * 60 * 1000, // 5 min — daily OHLCV data, SSE handles live quotes
   })
 }
 
@@ -75,6 +76,7 @@ export function useIndicators(symbol: string, period?: string) {
     queryKey: keys.indicators(symbol, period),
     queryFn: () => api.prices.indicators(symbol, period),
     enabled: !!symbol,
+    staleTime: 5 * 60 * 1000, // 5 min — computed from daily prices
   })
 }
 


### PR DESCRIPTION
## Summary
- Set `staleTime: 5 * 60 * 1000` (5 min) on `usePrices` and `useIndicators` query hooks
- Prevents React Query from refetching all 62+ watchlist data requests on navigation or window refocus
- SSE quote stream already provides live price updates for card display

## Test plan
- [ ] `pnpm build` passes
- [ ] Open watchlist → navigate away → come back within 5 min → no refetch in Network tab
- [ ] Window blur/focus within 5 min → no refetch
- [ ] After 5 min, navigation triggers fresh fetch

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)