### PR TITLE
feat: SSE quote stream delta-only payloads

### DIFF
--- a/frontend/src/lib/quote-stream.tsx
+++ b/frontend/src/lib/quote-stream.tsx
@@ -16,7 +16,7 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
     es.addEventListener("quotes", (e) => {
       try {
         const data = JSON.parse(e.data) as QuoteMap
-        setQuotes(data)
+        setQuotes((prev) => ({ ...prev, ...data }))
       } catch {
         // ignore malformed events
       }


### PR DESCRIPTION
## Summary
- Backend tracks last-sent payload and only emits symbols whose quote data changed since previous push
- First SSE event sends the full set; subsequent events contain only deltas
- Frontend merges deltas into existing state (`{...prev, ...data}`) instead of replacing
- When nothing changed, no event is emitted at all

Reduces SSE bandwidth significantly — from sending ~17 symbols every tick to typically 0-3 changed symbols, especially when US markets are closed and only a few EU symbols trade.

## Test plan
- [x] Backend tests pass (97/97)
- [x] Frontend TypeScript build clean
- [ ] Manual: open watchlist, verify prices still update in real-time
- [ ] Manual: check browser DevTools Network tab — SSE payloads should be much smaller after first event

🤖 Generated with [Claude Code](https://claude.com/claude-code)