### PR TITLE
docs: update OpenAPI/Swagger documentation

### DIFF
--- a/backend/app/routers/holdings.py
+++ b/backend/app/routers/holdings.py
@@ -35,6 +35,10 @@ def _bb_position(close: float, upper: float, middle: float, lower: float) -> str
 
 @router.get("", response_model=EtfHoldingsResponse, summary="Get ETF top holdings")
 async def get_holdings(symbol: str, db: AsyncSession = Depends(get_db)):
+    """Return the top holdings and sector weightings for an ETF.
+
+    Only available for assets with `type=etf`. Data is fetched live from Yahoo Finance.
+    """
     asset = await _get_asset(symbol, db)
     if asset.type.value != "etf":
         raise HTTPException(400, f"{symbol} is not an ETF")

--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -99,6 +99,15 @@ async def _ensure_prices(db: AsyncSession, asset: Asset, period: str) -> list[Pr
 
 @router.get("/prices", response_model=list[PriceResponse], summary="Get OHLCV price history")
 async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
+    """Return daily OHLCV price history for a symbol.
+
+    For watchlisted assets, prices are read from the database (and auto-synced
+    from Yahoo Finance if the requested period isn't yet covered). For
+    non-watchlisted symbols, prices are fetched ephemerally from Yahoo without
+    persisting.
+
+    Supported periods: `1mo`, `3mo` (default), `6mo`, `1y`, `2y`, `5y`.
+    """
     asset = await _find_asset(symbol, db)
 
     if asset:
@@ -126,6 +135,14 @@ async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depend
 
 @router.get("/indicators", response_model=list[IndicatorResponse], summary="Get technical indicators (RSI, SMA, MACD, Bollinger)")
 async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
+    """Return daily indicator time series for a symbol.
+
+    Includes RSI (14), SMA 20/50, Bollinger Bands (20, 2σ), and MACD (12/26/9).
+    An extra 80-day warmup window is fetched internally so that the first
+    returned data point already has converged indicator values.
+
+    Supported periods: `1mo`, `3mo` (default), `6mo`, `1y`, `2y`, `5y`.
+    """
     asset = await _find_asset(symbol, db)
     start = _display_start(period)
 
@@ -182,6 +199,10 @@ async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = De
 
 @router.post("/refresh", status_code=200, summary="Force-refresh prices from Yahoo Finance")
 async def refresh_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
+    """Force a re-sync of price data from Yahoo Finance for a watchlisted asset.
+
+    Returns the number of price points upserted.
+    """
     asset = await _get_asset(symbol, db)
     count = await sync_asset_prices(db, asset, period=period)
     return {"symbol": asset.symbol, "synced": count}

--- a/backend/app/routers/quotes.py
+++ b/backend/app/routers/quotes.py
@@ -18,6 +18,11 @@ router = APIRouter(prefix="/api", tags=["quotes"])
 
 @router.get("/quotes", response_model=list[QuoteResponse], summary="Get real-time quotes for symbols")
 async def get_quotes(symbols: str = Query(..., description="Comma-separated list of symbols")):
+    """Fetch latest market quotes for one or more symbols via Yahoo Finance.
+
+    Pass a comma-separated list of ticker symbols (e.g. `AAPL,MSFT,GOOGL`).
+    Returns price, previous close, change, change percent, currency, and market state.
+    """
     symbol_list = [s.strip().upper() for s in symbols.split(",") if s.strip()]
     if not symbol_list:
         return []
@@ -90,8 +95,27 @@ async def _quote_event_generator():
             await asyncio.sleep(30)
 
 
-@router.get("/quotes/stream", summary="SSE stream of watchlisted quotes")
+@router.get(
+    "/quotes/stream",
+    summary="SSE stream of watchlisted quotes (delta compressed)",
+    responses={200: {"content": {"text/event-stream": {}}, "description": "Server-Sent Events stream. Each event has `event: quotes` with JSON data containing only the symbols whose quote changed since the last push. The first event contains all watchlisted symbols."}},
+)
 async def stream_quotes():
+    """Open a Server-Sent Events stream that pushes real-time quotes for all
+    watchlisted assets.
+
+    **Delta compression:** After the initial full payload, only symbols whose
+    data has changed since the previous push are included — reducing bandwidth
+    when prices are stable or markets are closed.
+
+    **Adaptive intervals:** The server adjusts the push frequency based on
+    market state:
+    - **15 s** during regular trading hours (`REGULAR`)
+    - **60 s** during pre/post-market sessions
+    - **300 s** when all markets are closed
+
+    Each SSE event uses `event: quotes` with a JSON object keyed by symbol.
+    """
     return StreamingResponse(
         _quote_event_generator(),
         media_type="text/event-stream",

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -11,6 +11,10 @@ router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 @router.get("", response_model=SettingsResponse, summary="Get user settings")
 async def get_settings(db: AsyncSession = Depends(get_db)):
+    """Return the current user settings as a JSON object.
+
+    Returns `{\"data\": {}}` if no settings have been saved yet.
+    """
     result = await db.execute(select(UserSettings).where(UserSettings.id == 1))
     row = result.scalar_one_or_none()
     if not row:
@@ -20,6 +24,9 @@ async def get_settings(db: AsyncSession = Depends(get_db)):
 
 @router.put("", response_model=SettingsResponse, summary="Update user settings")
 async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_db)):
+    """Replace the user settings object. The `data` field is a free-form JSON
+    object storing preferences like `watchlist_show_rsi`, `compact_mode`, etc.
+    """
     result = await db.execute(select(UserSettings).where(UserSettings.id == 1))
     row = result.scalar_one_or_none()
     if row:

--- a/backend/app/schemas/annotation.py
+++ b/backend/app/schemas/annotation.py
@@ -1,21 +1,21 @@
-from datetime import date, datetime
+import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class AnnotationCreate(BaseModel):
-    date: date
-    title: str
-    body: str | None = None
-    color: str = "#3b82f6"
+    date: datetime.date = Field(description="Date the annotation refers to (shown as a marker on the chart)")
+    title: str = Field(description="Short annotation title")
+    body: str | None = Field(default=None, description="Optional extended body text (Markdown supported)")
+    color: str = Field(default="#3b82f6", description="Marker colour as a hex code")
 
 
 class AnnotationResponse(BaseModel):
-    id: int
-    date: date
-    title: str
-    body: str | None
-    color: str
-    created_at: datetime
+    id: int = Field(description="Annotation ID")
+    date: datetime.date = Field(description="Annotation date")
+    title: str = Field(description="Short annotation title")
+    body: str | None = Field(description="Extended body text")
+    color: str = Field(description="Marker colour hex code")
+    created_at: datetime.datetime = Field(description="Creation timestamp")
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -1,33 +1,33 @@
-from datetime import datetime
+import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.models.asset import AssetType
 
 
 class AssetCreate(BaseModel):
-    symbol: str
-    name: str | None = None
-    type: AssetType = AssetType.STOCK
-    watchlisted: bool = True
+    symbol: str = Field(description="Ticker symbol (e.g. AAPL, VOO). Validated against Yahoo Finance.")
+    name: str | None = Field(default=None, description="Display name. Auto-detected from Yahoo Finance if omitted.")
+    type: AssetType = Field(default=AssetType.STOCK, description="Asset type: stock or etf. Auto-detected if name is omitted.")
+    watchlisted: bool = Field(default=True, description="Whether the asset appears on the watchlist")
 
 
 class TagBrief(BaseModel):
-    id: int
-    name: str
-    color: str
+    id: int = Field(description="Tag ID")
+    name: str = Field(description="Tag label (e.g. 'tech', 'growth')")
+    color: str = Field(description="Hex colour code (e.g. '#3b82f6')")
 
     model_config = {"from_attributes": True}
 
 
 class AssetResponse(BaseModel):
-    id: int
-    symbol: str
-    name: str
-    type: AssetType
-    watchlisted: bool
-    currency: str = "USD"
-    created_at: datetime
-    tags: list[TagBrief] = []
+    id: int = Field(description="Internal asset ID")
+    symbol: str = Field(description="Ticker symbol")
+    name: str = Field(description="Display name")
+    type: AssetType = Field(description="Asset type: stock or etf")
+    watchlisted: bool = Field(description="Whether the asset is currently on the watchlist")
+    currency: str = Field(default="USD", description="ISO 4217 currency code")
+    created_at: datetime.datetime = Field(description="Timestamp when the asset was first added")
+    tags: list[TagBrief] = Field(default=[], description="Tags attached to this asset")
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/group.py
+++ b/backend/app/schemas/group.py
@@ -1,29 +1,29 @@
-from datetime import datetime
+import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.schemas.asset import AssetResponse
 
 
 class GroupCreate(BaseModel):
-    name: str
-    description: str | None = None
+    name: str = Field(description="Unique group name")
+    description: str | None = Field(default=None, description="Optional group description")
 
 
 class GroupUpdate(BaseModel):
-    name: str | None = None
-    description: str | None = None
+    name: str | None = Field(default=None, description="New group name")
+    description: str | None = Field(default=None, description="New description")
 
 
 class GroupAddAssets(BaseModel):
-    asset_ids: list[int]
+    asset_ids: list[int] = Field(description="List of asset IDs to add to the group")
 
 
 class GroupResponse(BaseModel):
-    id: int
-    name: str
-    description: str | None
-    created_at: datetime
-    assets: list[AssetResponse] = []
+    id: int = Field(description="Group ID")
+    name: str = Field(description="Group name")
+    description: str | None = Field(description="Group description")
+    created_at: datetime.datetime = Field(description="Creation timestamp")
+    assets: list[AssetResponse] = Field(default=[], description="Assets in this group")
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/price.py
+++ b/backend/app/schemas/price.py
@@ -1,63 +1,63 @@
-from datetime import date
+import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class PriceResponse(BaseModel):
-    date: date
-    open: float
-    high: float
-    low: float
-    close: float
-    volume: int
+    date: datetime.date = Field(description="Trading date")
+    open: float = Field(description="Opening price")
+    high: float = Field(description="Highest price of the day")
+    low: float = Field(description="Lowest price of the day")
+    close: float = Field(description="Closing price")
+    volume: int = Field(description="Trading volume")
 
     model_config = {"from_attributes": True}
 
 
 class IndicatorResponse(BaseModel):
-    date: date
-    close: float
-    rsi: float | None = None
-    sma_20: float | None = None
-    sma_50: float | None = None
-    bb_upper: float | None = None
-    bb_middle: float | None = None
-    bb_lower: float | None = None
-    macd: float | None = None
-    macd_signal: float | None = None
-    macd_hist: float | None = None
+    date: datetime.date = Field(description="Trading date")
+    close: float = Field(description="Closing price")
+    rsi: float | None = Field(default=None, description="Relative Strength Index (14-period)")
+    sma_20: float | None = Field(default=None, description="20-day Simple Moving Average")
+    sma_50: float | None = Field(default=None, description="50-day Simple Moving Average")
+    bb_upper: float | None = Field(default=None, description="Upper Bollinger Band (20-day, 2 std dev)")
+    bb_middle: float | None = Field(default=None, description="Middle Bollinger Band (20-day SMA)")
+    bb_lower: float | None = Field(default=None, description="Lower Bollinger Band (20-day, 2 std dev)")
+    macd: float | None = Field(default=None, description="MACD line (12-period EMA minus 26-period EMA)")
+    macd_signal: float | None = Field(default=None, description="MACD signal line (9-period EMA of MACD)")
+    macd_hist: float | None = Field(default=None, description="MACD histogram (MACD minus signal)")
 
 
 class HoldingResponse(BaseModel):
-    symbol: str
-    name: str
-    percent: float
+    symbol: str = Field(description="Holding ticker symbol")
+    name: str = Field(description="Holding company name")
+    percent: float = Field(description="Holding weight as a percentage of the ETF")
 
 
 class SectorWeighting(BaseModel):
-    sector: str
-    percent: float
+    sector: str = Field(description="Sector name")
+    percent: float = Field(description="Sector weight as a percentage")
 
 
 class EtfHoldingsResponse(BaseModel):
-    top_holdings: list[HoldingResponse]
-    sector_weightings: list[SectorWeighting]
-    total_percent: float
+    top_holdings: list[HoldingResponse] = Field(description="Top holdings by weight")
+    sector_weightings: list[SectorWeighting] = Field(description="Sector allocation breakdown")
+    total_percent: float = Field(description="Sum of top holding weights (may be < 100%)")
 
 
 class HoldingIndicatorResponse(BaseModel):
-    symbol: str
-    currency: str = "USD"
-    close: float | None = None
-    change_pct: float | None = None
-    rsi: float | None = None
-    sma_20: float | None = None
-    sma_50: float | None = None
-    macd: float | None = None
-    macd_signal: float | None = None
-    macd_hist: float | None = None
-    macd_signal_dir: str | None = None  # "bullish" | "bearish"
-    bb_upper: float | None = None
-    bb_middle: float | None = None
-    bb_lower: float | None = None
-    bb_position: str | None = None  # "above" | "upper" | "middle" | "lower" | "below"
+    symbol: str = Field(description="Holding ticker symbol")
+    currency: str = Field(default="USD", description="ISO 4217 currency code")
+    close: float | None = Field(default=None, description="Latest closing price")
+    change_pct: float | None = Field(default=None, description="1-day percentage change")
+    rsi: float | None = Field(default=None, description="RSI (14-period)")
+    sma_20: float | None = Field(default=None, description="20-day SMA")
+    sma_50: float | None = Field(default=None, description="50-day SMA")
+    macd: float | None = Field(default=None, description="MACD line")
+    macd_signal: float | None = Field(default=None, description="MACD signal line")
+    macd_hist: float | None = Field(default=None, description="MACD histogram")
+    macd_signal_dir: str | None = Field(default=None, description="MACD signal direction: 'bullish' or 'bearish'")
+    bb_upper: float | None = Field(default=None, description="Upper Bollinger Band")
+    bb_middle: float | None = Field(default=None, description="Middle Bollinger Band")
+    bb_lower: float | None = Field(default=None, description="Lower Bollinger Band")
+    bb_position: str | None = Field(default=None, description="Price position vs Bollinger Bands: 'above', 'upper', 'lower', or 'below'")

--- a/backend/app/schemas/pseudo_etf.py
+++ b/backend/app/schemas/pseudo_etf.py
@@ -1,65 +1,65 @@
-from datetime import date, datetime
+import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.schemas.asset import AssetResponse
 
 
 class PseudoETFCreate(BaseModel):
-    name: str
-    description: str | None = None
-    base_date: date
-    base_value: float = 100.0
+    name: str = Field(description="Unique basket name")
+    description: str | None = Field(default=None, description="Optional description")
+    base_date: datetime.date = Field(description="Start date for performance indexing")
+    base_value: float = Field(default=100.0, description="Starting index value (default 100)")
 
 
 class PseudoETFUpdate(BaseModel):
-    name: str | None = None
-    description: str | None = None
-    base_date: date | None = None
+    name: str | None = Field(default=None, description="New name")
+    description: str | None = Field(default=None, description="New description")
+    base_date: datetime.date | None = Field(default=None, description="New base date")
 
 
 class PseudoETFAddConstituents(BaseModel):
-    asset_ids: list[int]
+    asset_ids: list[int] = Field(description="Asset IDs to add as constituents")
 
 
 class PseudoETFResponse(BaseModel):
-    id: int
-    name: str
-    description: str | None
-    base_date: date
-    base_value: float
-    created_at: datetime
-    constituents: list[AssetResponse] = []
+    id: int = Field(description="Pseudo-ETF ID")
+    name: str = Field(description="Basket name")
+    description: str | None = Field(description="Description")
+    base_date: datetime.date = Field(description="Performance index start date")
+    base_value: float = Field(description="Starting index value")
+    created_at: datetime.datetime = Field(description="Creation timestamp")
+    constituents: list[AssetResponse] = Field(default=[], description="Assets in this basket")
 
     model_config = {"from_attributes": True}
 
 
 class PerformancePoint(BaseModel):
-    date: date
-    value: float
+    date: datetime.date = Field(description="Trading date")
+    value: float = Field(description="Composite index value")
 
 
 class PerformanceBreakdownPoint(BaseModel):
-    date: date
-    value: float
-    breakdown: dict[str, float] = {}
+    date: datetime.date = Field(description="Trading date")
+    value: float = Field(description="Composite index value")
+    breakdown: dict[str, float] = Field(default={}, description="Per-symbol contribution to the index value")
 
 
 class ConstituentIndicatorResponse(BaseModel):
-    symbol: str
-    name: str | None = None
-    currency: str = "USD"
-    weight_pct: float | None = None
-    close: float | None = None
-    change_pct: float | None = None
-    rsi: float | None = None
-    sma_20: float | None = None
-    sma_50: float | None = None
-    macd: float | None = None
-    macd_signal: float | None = None
-    macd_hist: float | None = None
-    macd_signal_dir: str | None = None
-    bb_upper: float | None = None
-    bb_middle: float | None = None
-    bb_lower: float | None = None
-    bb_position: str | None = None
+    symbol: str = Field(description="Constituent ticker symbol")
+    name: str | None = Field(default=None, description="Company name")
+    currency: str = Field(default="USD", description="ISO 4217 currency code")
+    weight_pct: float | None = Field(default=None, description="Current portfolio weight percentage")
+    close: float | None = Field(default=None, description="Latest closing price")
+    change_pct: float | None = Field(default=None, description="1-day percentage change")
+    rsi: float | None = Field(default=None, description="RSI (14-period)")
+    sma_20: float | None = Field(default=None, description="20-day SMA")
+    sma_50: float | None = Field(default=None, description="50-day SMA")
+    macd: float | None = Field(default=None, description="MACD line")
+    macd_signal: float | None = Field(default=None, description="MACD signal line")
+    macd_hist: float | None = Field(default=None, description="MACD histogram")
+    macd_signal_dir: str | None = Field(default=None, description="MACD direction: 'bullish' or 'bearish'")
+    bb_upper: float | None = Field(default=None, description="Upper Bollinger Band")
+    bb_middle: float | None = Field(default=None, description="Middle Bollinger Band")
+    bb_lower: float | None = Field(default=None, description="Lower Bollinger Band")
+    bb_position: str | None = Field(default=None, description="Price vs Bollinger Bands: 'above', 'upper', 'lower', or 'below'")

--- a/backend/app/schemas/quote.py
+++ b/backend/app/schemas/quote.py
@@ -1,11 +1,11 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class QuoteResponse(BaseModel):
-    symbol: str
-    price: float | None = None
-    previous_close: float | None = None
-    change: float | None = None
-    change_percent: float | None = None
-    currency: str = "USD"
-    market_state: str | None = None
+    symbol: str = Field(description="Ticker symbol (e.g. AAPL)")
+    price: float | None = Field(default=None, description="Latest traded price")
+    previous_close: float | None = Field(default=None, description="Previous session close price")
+    change: float | None = Field(default=None, description="Absolute price change from previous close")
+    change_percent: float | None = Field(default=None, description="Percentage change from previous close")
+    currency: str = Field(default="USD", description="ISO 4217 currency code")
+    market_state: str | None = Field(default=None, description="Market state: REGULAR, PRE, POST, PREPRE, POSTPOST, or CLOSED")

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,11 +1,11 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SettingsResponse(BaseModel):
-    data: dict
+    data: dict = Field(description="Free-form settings object (e.g. watchlist_show_rsi, compact_mode)")
 
     model_config = {"from_attributes": True}
 
 
 class SettingsUpdate(BaseModel):
-    data: dict
+    data: dict = Field(description="Complete settings object — replaces the existing value")

--- a/backend/app/schemas/tag.py
+++ b/backend/app/schemas/tag.py
@@ -1,25 +1,25 @@
-from datetime import datetime
+import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.schemas.asset import AssetResponse
 
 
 class TagCreate(BaseModel):
-    name: str
-    color: str = "#3b82f6"
+    name: str = Field(description="Unique tag label (e.g. 'tech', 'dividend')")
+    color: str = Field(default="#3b82f6", description="Hex colour code for the badge")
 
 
 class TagUpdate(BaseModel):
-    name: str | None = None
-    color: str | None = None
+    name: str | None = Field(default=None, description="New tag label")
+    color: str | None = Field(default=None, description="New hex colour code")
 
 
 class TagResponse(BaseModel):
-    id: int
-    name: str
-    color: str
-    created_at: datetime
-    assets: list[AssetResponse] = []
+    id: int = Field(description="Tag ID")
+    name: str = Field(description="Tag label")
+    color: str = Field(description="Hex colour code")
+    created_at: datetime.datetime = Field(description="Creation timestamp")
+    assets: list[AssetResponse] = Field(default=[], description="Assets that have this tag")
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/thesis.py
+++ b/backend/app/schemas/thesis.py
@@ -1,14 +1,14 @@
-from datetime import datetime
+import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ThesisUpdate(BaseModel):
-    content: str
+    content: str = Field(description="Investment thesis text (Markdown supported)")
 
 
 class ThesisResponse(BaseModel):
-    content: str
-    updated_at: datetime
+    content: str = Field(description="Investment thesis text (Markdown)")
+    updated_at: datetime.datetime = Field(description="Last modification timestamp")
 
     model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- Bump API version to 1.1.0
- Add missing `openapi_tags` for `watchlist` and `system` tag groups
- Update `quotes` tag description to document SSE delta compression and adaptive push intervals
- Add docstrings to all endpoint functions across all routers
- Add `Field(description=...)` to every Pydantic schema field for rich Swagger docs
- Fix Pydantic v2.12 field name clash (`date` field vs `date` type) by switching to `import datetime`

## Test plan
- [x] All 107 backend tests pass
- [x] Frontend build clean
- [ ] Visit `/docs` to verify Swagger UI shows descriptions on all endpoints and schema fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)