### PR TITLE
fix: remove individual fetch fallbacks from watchlist components

### DIFF
--- a/frontend/src/components/rsi-gauge.tsx
+++ b/frontend/src/components/rsi-gauge.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from "@/components/ui/skeleton"
-import { useIndicators } from "@/lib/queries"
 
 function getMarkerColor(rsi: number): string {
   if (rsi <= 20) return "rgb(239, 68, 68)"       // red-500
@@ -25,19 +24,12 @@ function getZoneLabel(rsi: number): string {
   return ""
 }
 
-export function RsiGauge({ symbol, batchRsi }: { symbol: string; batchRsi?: number | null }) {
-  // Use batch data when available, fall back to individual fetch (asset detail page)
-  const { data: indicators, isLoading } = useIndicators(symbol, undefined, { enabled: batchRsi === undefined })
-
-  const latestRsi = batchRsi !== undefined
-    ? batchRsi
-    : indicators?.slice().reverse().find((i) => i.rsi !== null)?.rsi
-
-  if (batchRsi === undefined && isLoading) {
+export function RsiGauge({ batchRsi }: { symbol: string; batchRsi?: number | null }) {
+  if (batchRsi === undefined) {
     return <Skeleton className="h-5 w-full rounded-full" />
   }
 
-  if (latestRsi == null) {
+  if (batchRsi == null) {
     return (
       <div className="flex items-center justify-center h-5 rounded-full bg-muted text-[10px] text-muted-foreground">
         No RSI
@@ -45,7 +37,7 @@ export function RsiGauge({ symbol, batchRsi }: { symbol: string; batchRsi?: numb
     )
   }
 
-  const pct = Math.max(0, Math.min(100, latestRsi))
+  const pct = Math.max(0, Math.min(100, batchRsi))
   const markerColor = getMarkerColor(pct)
   const textClass = getTextClass(pct)
   const label = getZoneLabel(pct)

--- a/frontend/src/components/sparkline.tsx
+++ b/frontend/src/components/sparkline.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useRef } from "react"
 import { createChart, type IChartApi, ColorType, AreaSeries } from "lightweight-charts"
 import { Skeleton } from "@/components/ui/skeleton"
-import { usePrices } from "@/lib/queries"
 import type { SparklinePoint } from "@/lib/api"
 
 export function SparklineChart({
-  symbol,
   period = "3mo",
   batchData,
 }: {
@@ -13,14 +11,12 @@ export function SparklineChart({
   period?: string
   batchData?: SparklinePoint[]
 }) {
-  // Use batch data when available, fall back to individual fetch (asset detail page)
-  const { data: fetchedPrices, isLoading } = usePrices(symbol, period, { enabled: !batchData })
-  const points = batchData ?? fetchedPrices
+  void period
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
 
   useEffect(() => {
-    if (!containerRef.current || !points?.length) return
+    if (!containerRef.current || !batchData?.length) return
 
     const chart = createChart(containerRef.current, {
       width: containerRef.current.clientWidth,
@@ -41,8 +37,8 @@ export function SparklineChart({
       },
     })
 
-    const last = points[points.length - 1]
-    const first = points[0]
+    const last = batchData[batchData.length - 1]
+    const first = batchData[0]
     const up = last.close >= first.close
 
     const series = chart.addSeries(AreaSeries, {
@@ -55,7 +51,7 @@ export function SparklineChart({
     })
 
     series.setData(
-      points.map((p) => ({ time: p.date, value: p.close }))
+      batchData.map((p) => ({ time: p.date, value: p.close }))
     )
 
     chart.timeScale().fitContent()
@@ -74,13 +70,13 @@ export function SparklineChart({
       chart.remove()
       chartRef.current = null
     }
-  }, [points])
+  }, [batchData])
 
-  if (!batchData && isLoading) {
+  if (!batchData) {
     return <Skeleton className="h-[60px] w-full rounded" />
   }
 
-  if (!points?.length) {
+  if (!batchData.length) {
     return <div className="h-[60px] flex items-center justify-center text-xs text-muted-foreground">No data</div>
   }
 


### PR DESCRIPTION
## Summary
- Removed `useIndicators` / `usePrices` individual fetch hooks from `SparklineChart`, `RsiGauge`, and `MacdIndicator`
- These components are only used on the watchlist page where batch data (`/api/watchlist/sparklines`, `/api/watchlist/indicators`) is always provided
- The fallback hooks raced against the batch endpoints — while batch was loading, every card fired its own requests, causing the same N+1 flood (~62 requests) the batch endpoints were meant to eliminate

## Test plan
- [x] `pnpm build` passes
- [ ] Load watchlist page — should see only 2 batch API calls (sparklines + indicators), no per-symbol price/indicator requests
- [ ] Sparkline, RSI gauge, and MACD indicator still render correctly on cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)