### PR TITLE
feat: watchlist type filter and sorting controls

### DIFF
--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -1,9 +1,16 @@
 import { createContext, useContext, useEffect, useState, useCallback, useRef, type ReactNode } from "react"
 
+export type AssetTypeFilter = "all" | "stock" | "etf"
+export type WatchlistSortBy = "name" | "price" | "change_pct" | "rsi" | "macd_hist"
+export type SortDir = "asc" | "desc"
+
 export interface AppSettings {
   watchlist_show_rsi: boolean
   watchlist_show_macd: boolean
   watchlist_show_sparkline: boolean
+  watchlist_type_filter: AssetTypeFilter
+  watchlist_sort_by: WatchlistSortBy
+  watchlist_sort_dir: SortDir
   detail_show_sma20: boolean
   detail_show_sma50: boolean
   detail_show_bollinger: boolean
@@ -21,6 +28,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
   watchlist_show_rsi: true,
   watchlist_show_macd: true,
   watchlist_show_sparkline: true,
+  watchlist_type_filter: "all",
+  watchlist_sort_by: "name",
+  watchlist_sort_dir: "asc",
   detail_show_sma20: true,
   detail_show_sma50: true,
   detail_show_bollinger: true,


### PR DESCRIPTION
## Summary
- Add asset type filter (All / Stocks / ETFs) as segmented control in watchlist header
- Add sort dropdown with options: Name, Price, Change %, RSI, MACD Histogram
- Both preferences persisted via settings system (localStorage + backend sync)
- Null values sort to end; filter combines with existing tag filter
- Closes #81, closes #91

## Test plan
- [x] Frontend lint clean
- [x] TypeScript build passes
- [x] Backend tests pass (107/107)
- [ ] Manual: verify type filter toggles correctly between All/Stocks/ETFs
- [ ] Manual: verify sort dropdown changes card order
- [ ] Manual: verify sort direction toggles on re-click
- [ ] Manual: verify preferences survive page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)