### PR TITLE
refactor: extract chart sync from price-chart.tsx (#94)

### DIFF
--- a/frontend/src/lib/use-chart-sync.ts
+++ b/frontend/src/lib/use-chart-sync.ts
@@ -1,0 +1,161 @@
+import { useRef, useState, useCallback } from "react"
+import type { IChartApi } from "lightweight-charts"
+import type { Price, Indicator } from "@/lib/api"
+import type { LegendValues } from "@/components/chart/chart-legends"
+
+export interface ChartEntry {
+  chart: IChartApi
+  series: ReturnType<IChartApi["addSeries"]>
+}
+
+export function useChartSync() {
+  const [hoverValues, setHoverValues] = useState<LegendValues | null>(null)
+
+  const closeByTime = useRef(new Map<string, number>())
+  const ohlcByTime = useRef(new Map<string, { o: number; h: number; l: number; c: number }>())
+  const sma20ByTime = useRef(new Map<string, number>())
+  const sma50ByTime = useRef(new Map<string, number>())
+  const bbUpperByTime = useRef(new Map<string, number>())
+  const bbLowerByTime = useRef(new Map<string, number>())
+  const rsiByTime = useRef(new Map<string, number>())
+  const macdByTime = useRef(new Map<string, number>())
+  const macdSignalByTime = useRef(new Map<string, number>())
+  const macdHistByTime = useRef(new Map<string, number>())
+
+  const syncingRef = useRef(false)
+
+  const buildLookupMaps = useCallback((prices: Price[], indicators: Indicator[]) => {
+    closeByTime.current.clear()
+    ohlcByTime.current.clear()
+    sma20ByTime.current.clear()
+    sma50ByTime.current.clear()
+    bbUpperByTime.current.clear()
+    bbLowerByTime.current.clear()
+    rsiByTime.current.clear()
+    macdByTime.current.clear()
+    macdSignalByTime.current.clear()
+    macdHistByTime.current.clear()
+
+    for (const p of prices) {
+      closeByTime.current.set(p.date, p.close)
+      ohlcByTime.current.set(p.date, { o: p.open, h: p.high, l: p.low, c: p.close })
+    }
+    for (const i of indicators) {
+      if (i.sma_20 !== null) sma20ByTime.current.set(i.date, i.sma_20)
+      if (i.sma_50 !== null) sma50ByTime.current.set(i.date, i.sma_50)
+      if (i.bb_upper !== null) bbUpperByTime.current.set(i.date, i.bb_upper)
+      if (i.bb_lower !== null) bbLowerByTime.current.set(i.date, i.bb_lower)
+      if (i.rsi !== null) rsiByTime.current.set(i.date, i.rsi)
+      if (i.macd !== null) macdByTime.current.set(i.date, i.macd)
+      if (i.macd_signal !== null) macdSignalByTime.current.set(i.date, i.macd_signal)
+      if (i.macd_hist !== null) macdHistByTime.current.set(i.date, i.macd_hist)
+    }
+  }, [])
+
+  const getValuesForTime = useCallback((key: string): LegendValues => {
+    const ohlc = ohlcByTime.current.get(key)
+    return {
+      o: ohlc?.o,
+      h: ohlc?.h,
+      l: ohlc?.l,
+      c: ohlc?.c,
+      sma20: sma20ByTime.current.get(key),
+      sma50: sma50ByTime.current.get(key),
+      bbUpper: bbUpperByTime.current.get(key),
+      bbLower: bbLowerByTime.current.get(key),
+      rsi: rsiByTime.current.get(key),
+      macd: macdByTime.current.get(key),
+      macdSignal: macdSignalByTime.current.get(key),
+      macdHist: macdHistByTime.current.get(key),
+    }
+  }, [])
+
+  const syncCharts = useCallback((chartEntries: ChartEntry[]) => {
+    const charts = chartEntries.map((e) => e.chart)
+
+    // Sync visible range across all charts
+    for (const source of charts) {
+      source.timeScale().subscribeVisibleLogicalRangeChange(() => {
+        if (syncingRef.current) return
+        syncingRef.current = true
+        const timeRange = source.timeScale().getVisibleRange()
+        if (timeRange) {
+          for (const target of charts) {
+            if (target !== source) target.timeScale().setVisibleRange(timeRange)
+          }
+        }
+        syncingRef.current = false
+      })
+    }
+
+    const snapCrosshair = (key: string, time: Parameters<IChartApi["setCrosshairPosition"]>[1]) => {
+      for (const entry of chartEntries) {
+        const closeVal = closeByTime.current.get(key)
+        const rsiVal = rsiByTime.current.get(key)
+        const macdVal = macdByTime.current.get(key)
+
+        if (entry === chartEntries[0] && closeVal !== undefined) {
+          entry.chart.setCrosshairPosition(closeVal, time, entry.series)
+        } else if (chartEntries.length > 1 && entry === chartEntries[1]) {
+          const val = rsiVal !== undefined ? rsiVal : macdVal
+          if (val !== undefined) entry.chart.setCrosshairPosition(val, time, entry.series)
+        } else if (chartEntries.length > 2 && entry === chartEntries[2] && macdVal !== undefined) {
+          entry.chart.setCrosshairPosition(macdVal, time, entry.series)
+        }
+      }
+    }
+
+    const clearOtherCrosshairs = (source: IChartApi) => {
+      for (const chart of charts) {
+        if (chart !== source) chart.clearCrosshairPosition()
+      }
+    }
+
+    for (const source of charts) {
+      source.subscribeCrosshairMove((param) => {
+        if (param.time) {
+          setHoverValues(getValuesForTime(String(param.time)))
+        } else {
+          setHoverValues(null)
+        }
+
+        if (syncingRef.current) return
+        syncingRef.current = true
+        if (param.time) {
+          snapCrosshair(String(param.time), param.time)
+        } else {
+          clearOtherCrosshairs(source)
+        }
+        syncingRef.current = false
+      })
+    }
+  }, [getValuesForTime])
+
+  const setupSingleChartCrosshair = useCallback((chart: IChartApi) => {
+    chart.subscribeCrosshairMove((param) => {
+      if (param.time) {
+        const key = String(param.time)
+        const ohlc = ohlcByTime.current.get(key)
+        setHoverValues({
+          o: ohlc?.o,
+          h: ohlc?.h,
+          l: ohlc?.l,
+          c: ohlc?.c,
+          sma20: sma20ByTime.current.get(key),
+          sma50: sma50ByTime.current.get(key),
+          bbUpper: bbUpperByTime.current.get(key),
+          bbLower: bbLowerByTime.current.get(key),
+        })
+      } else {
+        setHoverValues(null)
+      }
+    })
+  }, [])
+
+  return {
+    hoverValues,
+    buildLookupMaps,
+    syncCharts,
+    setupSingleChartCrosshair,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract chart sync logic (lookup maps, crosshair sync, hover values) into `use-chart-sync.ts` hook
- Use existing `baseChartOptions()` from `chart-utils.ts` instead of duplicating options inline
- Reduce `price-chart.tsx` from 581 to 363 lines (-37%)
- Deduplicate RSI threshold line options

Closes #94

## Test plan
- [x] Frontend lint clean
- [x] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)