### PR TITLE
refactor: consolidate duplicated indicator helpers and asset lookups

### DIFF
--- a/backend/app/routers/deps.py
+++ b/backend/app/routers/deps.py
@@ -1,0 +1,21 @@
+"""Shared router dependencies and helpers."""
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Asset
+
+
+async def find_asset(symbol: str, db: AsyncSession) -> Asset | None:
+    """Look up asset in DB, returning None if not found."""
+    result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
+    return result.scalar_one_or_none()
+
+
+async def get_asset(symbol: str, db: AsyncSession) -> Asset:
+    """Look up asset in DB, raising 404 if not found."""
+    asset = await find_asset(symbol, db)
+    if not asset:
+        raise HTTPException(404, f"Asset {symbol} not found")
+    return asset

--- a/backend/app/routers/holdings.py
+++ b/backend/app/routers/holdings.py
@@ -1,36 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import pandas as pd
-
 from app.database import get_db
-from app.models import Asset
+from app.routers.deps import get_asset
 from app.schemas.price import EtfHoldingsResponse, HoldingIndicatorResponse
-from app.services.indicators import compute_indicators
+from app.services.indicators import compute_indicators, build_indicator_snapshot
 from app.services.yahoo import batch_fetch_currencies, batch_fetch_history, fetch_etf_holdings
 
 router = APIRouter(prefix="/api/assets/{symbol}/holdings", tags=["holdings"])
-
-
-async def _get_asset(symbol: str, db: AsyncSession) -> Asset:
-    result = await db.execute(select(Asset).where(Asset.symbol == symbol.upper()))
-    asset = result.scalar_one_or_none()
-    if not asset:
-        raise HTTPException(404, f"Asset {symbol} not found")
-    return asset
-
-
-def _bb_position(close: float, upper: float, middle: float, lower: float) -> str:
-    """Classify where price sits relative to Bollinger Bands."""
-    if close > upper:
-        return "above"
-    elif close > middle:
-        return "upper"
-    elif close > lower:
-        return "lower"
-    else:
-        return "below"
 
 
 @router.get("", response_model=EtfHoldingsResponse, summary="Get ETF top holdings")
@@ -39,7 +16,7 @@ async def get_holdings(symbol: str, db: AsyncSession = Depends(get_db)):
 
     Only available for assets with `type=etf`. Data is fetched live from Yahoo Finance.
     """
-    asset = await _get_asset(symbol, db)
+    asset = await get_asset(symbol, db)
     if asset.type.value != "etf":
         raise HTTPException(400, f"{symbol} is not an ETF")
     data = fetch_etf_holdings(symbol)
@@ -51,7 +28,7 @@ async def get_holdings(symbol: str, db: AsyncSession = Depends(get_db)):
 @router.get("/indicators", response_model=list[HoldingIndicatorResponse], summary="Get technical indicators for each ETF holding")
 async def get_holdings_indicators(symbol: str, db: AsyncSession = Depends(get_db)):
     """Return latest indicator snapshot for each of the ETF's top holdings."""
-    asset = await _get_asset(symbol, db)
+    asset = await get_asset(symbol, db)
     if asset.type.value != "etf":
         raise HTTPException(400, f"{symbol} is not an ETF")
 
@@ -75,38 +52,7 @@ async def get_holdings_indicators(symbol: str, db: AsyncSession = Depends(get_db
             results.append(HoldingIndicatorResponse(symbol=sym, currency=currency))
             continue
 
-        indicators = compute_indicators(df)
-        latest = indicators.iloc[-1]
-        prev_close = indicators.iloc[-2]["close"] if len(indicators) >= 2 else None
-
-        change_pct = None
-        if prev_close and prev_close != 0:
-            change_pct = round((latest["close"] - prev_close) / prev_close * 100, 2)
-
-        macd_dir = None
-        if pd.notna(latest["macd"]) and pd.notna(latest["macd_signal"]):
-            macd_dir = "bullish" if latest["macd"] > latest["macd_signal"] else "bearish"
-
-        bb_pos = None
-        if pd.notna(latest["bb_upper"]) and pd.notna(latest["bb_middle"]) and pd.notna(latest["bb_lower"]):
-            bb_pos = _bb_position(latest["close"], latest["bb_upper"], latest["bb_middle"], latest["bb_lower"])
-
-        results.append(HoldingIndicatorResponse(
-            symbol=sym,
-            currency=currency,
-            close=round(latest["close"], 2),
-            change_pct=change_pct,
-            rsi=round(latest["rsi"], 2) if pd.notna(latest["rsi"]) else None,
-            sma_20=round(latest["sma_20"], 2) if pd.notna(latest["sma_20"]) else None,
-            sma_50=round(latest["sma_50"], 2) if pd.notna(latest["sma_50"]) else None,
-            macd=round(latest["macd"], 4) if pd.notna(latest["macd"]) else None,
-            macd_signal=round(latest["macd_signal"], 4) if pd.notna(latest["macd_signal"]) else None,
-            macd_hist=round(latest["macd_hist"], 4) if pd.notna(latest["macd_hist"]) else None,
-            macd_signal_dir=macd_dir,
-            bb_upper=round(latest["bb_upper"], 2) if pd.notna(latest["bb_upper"]) else None,
-            bb_middle=round(latest["bb_middle"], 2) if pd.notna(latest["bb_middle"]) else None,
-            bb_lower=round(latest["bb_lower"], 2) if pd.notna(latest["bb_lower"]) else None,
-            bb_position=bb_pos,
-        ))
+        snapshot = build_indicator_snapshot(compute_indicators(df))
+        results.append(HoldingIndicatorResponse(symbol=sym, currency=currency, **snapshot))
 
     return results

--- a/backend/tests/test_holdings.py
+++ b/backend/tests/test_holdings.py
@@ -5,25 +5,25 @@ import pandas as pd
 import pytest
 from unittest.mock import patch
 
-from app.routers.holdings import _bb_position
+from app.services.indicators import bb_position
 
 
-# ── Pure unit tests for _bb_position ──────────────────────────────────
+# ── Pure unit tests for bb_position ───────────────────────────────────
 
 def test_bb_position_above():
-    assert _bb_position(close=110, upper=105, middle=100, lower=95) == "above"
+    assert bb_position(close=110, upper=105, middle=100, lower=95) == "above"
 
 
 def test_bb_position_upper():
-    assert _bb_position(close=103, upper=105, middle=100, lower=95) == "upper"
+    assert bb_position(close=103, upper=105, middle=100, lower=95) == "upper"
 
 
 def test_bb_position_lower():
-    assert _bb_position(close=97, upper=105, middle=100, lower=95) == "lower"
+    assert bb_position(close=97, upper=105, middle=100, lower=95) == "lower"
 
 
 def test_bb_position_below():
-    assert _bb_position(close=90, upper=105, middle=100, lower=95) == "below"
+    assert bb_position(close=90, upper=105, middle=100, lower=95) == "below"
 
 
 # ── Helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Moved `bb_position()` from `holdings.py` and `pseudo_etf_analysis.py` into `services/indicators.py`
- Added `build_indicator_snapshot()` to `services/indicators.py` to eliminate duplicated indicator response building
- Created `routers/deps.py` with shared `find_asset()`/`get_asset()` helpers (previously duplicated across `prices.py` and `holdings.py`)
- Net reduction: -50 lines across 5 files

Closes #96

## Test plan
- [x] All 107 backend tests pass
- [x] `bb_position` unit tests updated to import from new location

🤖 Generated with [Claude Code](https://claude.com/claude-code)