### PR TITLE
test: add quotes router test coverage

### DIFF
--- a/backend/tests/test_quotes.py
+++ b/backend/tests/test_quotes.py
@@ -1,0 +1,154 @@
+"""Tests for the quotes router (REST + SSE stream)."""
+
+import asyncio
+import json
+
+from unittest.mock import patch
+
+from tests.conftest import TestSession
+
+
+_MOCK_QUOTES = [
+    {
+        "symbol": "AAPL",
+        "price": 185.50,
+        "previous_close": 184.00,
+        "change": 1.50,
+        "change_percent": 0.82,
+        "currency": "USD",
+        "market_state": "REGULAR",
+    },
+    {
+        "symbol": "MSFT",
+        "price": 420.00,
+        "previous_close": 418.50,
+        "change": 1.50,
+        "change_percent": 0.36,
+        "currency": "USD",
+        "market_state": "REGULAR",
+    },
+]
+
+
+def _parse_sse_events(body: str) -> list[dict]:
+    """Parse SSE text into a list of data payloads."""
+    events = []
+    for line in body.split("\n"):
+        if line.startswith("data: "):
+            events.append(json.loads(line[6:]))
+    return events
+
+
+# ── REST endpoint tests ──────────────────────────────────────────────
+
+
+async def test_get_quotes_returns_data(client):
+    """GET /api/quotes returns quote data for requested symbols."""
+    with patch("app.routers.quotes.batch_fetch_quotes", return_value=_MOCK_QUOTES):
+        resp = await client.get("/api/quotes", params={"symbols": "AAPL,MSFT"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert data[0]["symbol"] == "AAPL"
+    assert data[0]["price"] == 185.50
+    assert data[1]["symbol"] == "MSFT"
+
+
+async def test_get_quotes_empty_symbols(client):
+    """GET /api/quotes with empty symbols returns empty list."""
+    with patch("app.routers.quotes.batch_fetch_quotes", return_value=[]):
+        resp = await client.get("/api/quotes", params={"symbols": ""})
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_get_quotes_single_symbol(client):
+    """GET /api/quotes works with a single symbol."""
+    with patch("app.routers.quotes.batch_fetch_quotes", return_value=[_MOCK_QUOTES[0]]):
+        resp = await client.get("/api/quotes", params={"symbols": "AAPL"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["symbol"] == "AAPL"
+    assert data[0]["market_state"] == "REGULAR"
+    assert data[0]["currency"] == "USD"
+
+
+async def test_get_quotes_uppercase_normalization(client):
+    """Symbols are normalized to uppercase before fetching."""
+    with patch("app.routers.quotes.batch_fetch_quotes", return_value=[_MOCK_QUOTES[0]]) as mock:
+        await client.get("/api/quotes", params={"symbols": "aapl"})
+
+    mock.assert_called_once_with(["AAPL"])
+
+
+# ── SSE stream tests ─────────────────────────────────────────────────
+# The SSE generator uses async_session directly (not get_db), so we must
+# patch it to use the test database session.
+
+
+async def test_stream_quotes_no_watchlisted(client):
+    """SSE stream emits empty payload when no assets are watchlisted."""
+    with (
+        patch("app.routers.quotes.async_session", TestSession),
+        patch("app.routers.quotes.asyncio.sleep", side_effect=asyncio.CancelledError()),
+    ):
+        resp = await client.get("/api/quotes/stream")
+
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+    body = resp.text
+    assert "event: quotes" in body
+    assert "data: {}" in body
+
+
+async def test_stream_quotes_emits_event(client):
+    """SSE stream emits quote data for watchlisted assets."""
+    await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
+
+    with (
+        patch("app.routers.quotes.async_session", TestSession),
+        patch("app.routers.quotes.batch_fetch_quotes", return_value=[_MOCK_QUOTES[0]]),
+        patch("app.routers.quotes.asyncio.sleep", side_effect=asyncio.CancelledError()),
+    ):
+        resp = await client.get("/api/quotes/stream")
+
+    assert resp.status_code == 200
+    events = _parse_sse_events(resp.text)
+    assert len(events) >= 1
+    assert "AAPL" in events[0]
+    assert events[0]["AAPL"]["price"] == 185.50
+    assert events[0]["AAPL"]["market_state"] == "REGULAR"
+
+
+async def test_stream_quotes_cache_headers(client):
+    """SSE stream sets correct cache-control and buffering headers."""
+    with (
+        patch("app.routers.quotes.async_session", TestSession),
+        patch("app.routers.quotes.asyncio.sleep", side_effect=asyncio.CancelledError()),
+    ):
+        resp = await client.get("/api/quotes/stream")
+
+    assert resp.headers.get("cache-control") == "no-cache"
+    assert resp.headers.get("x-accel-buffering") == "no"
+
+
+async def test_stream_quotes_multiple_symbols(client):
+    """SSE stream includes all watchlisted symbols in first event."""
+    await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
+    await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft", "type": "stock"})
+
+    with (
+        patch("app.routers.quotes.async_session", TestSession),
+        patch("app.routers.quotes.batch_fetch_quotes", return_value=_MOCK_QUOTES),
+        patch("app.routers.quotes.asyncio.sleep", side_effect=asyncio.CancelledError()),
+    ):
+        resp = await client.get("/api/quotes/stream")
+
+    events = _parse_sse_events(resp.text)
+    assert len(events) >= 1
+    assert "AAPL" in events[0]
+    assert "MSFT" in events[0]


### PR DESCRIPTION
## Summary
- Added 8 tests for the quotes router (the last untested backend router)
- 4 REST endpoint tests: multi-symbol, single symbol, empty input, uppercase normalization
- 4 SSE stream tests: empty watchlist, event format, cache headers, multi-symbol events
- Patches `async_session` for SSE tests since the generator bypasses `get_db`
- Test count: 107 → 115

Closes #97

## Test plan
- [x] All 115 backend tests pass
- [x] No network calls (Yahoo Finance mocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)