### PR TITLE
feat: add configurable MACD indicator style

### DIFF
--- a/frontend/src/components/macd-indicator.tsx
+++ b/frontend/src/components/macd-indicator.tsx
@@ -1,5 +1,81 @@
 import { Skeleton } from "@/components/ui/skeleton"
 import type { IndicatorSummary } from "@/lib/api"
+import { useSettings } from "@/lib/settings"
+
+type MacdProps = { macd: number; sig: number; hist: number }
+
+function ClassicMacd({ macd, sig, hist }: MacdProps) {
+  const histPositive = hist >= 0
+  const bullish = macd > sig
+  const barPct = 25
+
+  const histColor = histPositive ? "bg-emerald-500/30" : "bg-red-500/30"
+  const macdTextColor = bullish ? "text-emerald-400" : "text-red-400"
+  const histTextColor = histPositive ? "text-emerald-400" : "text-red-400"
+
+  return (
+    <div className="relative h-5 w-full rounded-full bg-muted overflow-hidden flex items-center px-2">
+      <div className="absolute left-1/2 top-0 h-full w-px bg-border" />
+      <div
+        className={`absolute top-0 h-full ${histColor}`}
+        style={{
+          left: histPositive ? "50%" : `${50 - barPct}%`,
+          width: `${barPct}%`,
+        }}
+      />
+      <span className={`relative z-10 text-[10px] font-medium tabular-nums ${macdTextColor}`}>
+        M {macd.toFixed(2)}
+      </span>
+      <span className="relative z-10 text-[10px] tabular-nums text-muted-foreground ml-1.5">
+        S {sig.toFixed(2)}
+      </span>
+      <span className={`relative z-10 text-[10px] font-medium tabular-nums ml-auto ${histTextColor}`}>
+        H {histPositive ? "+" : ""}{hist.toFixed(2)}
+      </span>
+    </div>
+  )
+}
+
+function DivergenceMacd({ macd, sig, hist }: MacdProps) {
+  const histPositive = hist >= 0
+  const bullish = macd > sig
+  const barPct = 25
+
+  const barColor = histPositive ? "bg-emerald-500/30" : "bg-red-500/30"
+  const trendColor = bullish ? "text-emerald-400" : "text-red-400"
+  const dotFill = bullish ? "bg-emerald-400" : "bg-red-400"
+  const histTextColor = histPositive ? "text-emerald-400" : "text-red-400"
+
+  const strength = Math.abs(hist)
+  const dots = strength > 0.5 ? 3 : strength > 0.15 ? 2 : 1
+
+  return (
+    <div className="relative h-5 w-full rounded-full bg-muted overflow-hidden flex items-center px-2">
+      <div className="absolute left-1/2 top-0 h-full w-px bg-border" />
+      <div
+        className={`absolute top-0 h-full ${barColor}`}
+        style={{
+          left: histPositive ? "50%" : `${50 - barPct}%`,
+          width: `${barPct}%`,
+        }}
+      />
+      <span className={`relative z-10 text-[10px] font-medium tabular-nums ${trendColor}`}>
+        {bullish ? "\u25B2" : "\u25BC"} {macd.toFixed(2)}
+      </span>
+      <span className="relative z-10 flex items-center gap-0.5 ml-1.5">
+        {Array.from({ length: dots }).map((_, i) => (
+          <span key={i} className={`inline-block h-1 w-1 rounded-full ${dotFill}`} />
+        ))}
+        {Array.from({ length: 3 - dots }).map((_, i) => (
+          <span key={i} className="inline-block h-1 w-1 rounded-full bg-muted-foreground/20" />
+        ))}
+      </span>
+      <span className={`relative z-10 text-[10px] font-medium tabular-nums ml-auto ${histTextColor}`}>
+        {histPositive ? "+" : ""}{hist.toFixed(2)}
+      </span>
+    </div>
+  )
+}
 
 export function MacdIndicator({
   batchMacd,
@@ -7,6 +83,8 @@ export function MacdIndicator({
   symbol: string
   batchMacd?: Pick<IndicatorSummary, "macd" | "macd_signal" | "macd_hist"> | null
 }) {
+  const { settings } = useSettings()
+
   if (batchMacd === undefined) {
     return <Skeleton className="h-5 w-full rounded-full" />
   }
@@ -19,39 +97,13 @@ export function MacdIndicator({
     )
   }
 
-  const { macd, macd_signal: sig, macd_hist: hist } = batchMacd
-  const histPositive = hist >= 0
-  const bullish = macd > sig
+  const props: MacdProps = {
+    macd: batchMacd.macd,
+    sig: batchMacd.macd_signal,
+    hist: batchMacd.macd_hist,
+  }
 
-  // Batch mode: no full series available, use a fixed proportion
-  const barPct = 25
-
-  const histColor = histPositive ? "bg-emerald-500/30" : "bg-red-500/30"
-  const macdTextColor = bullish ? "text-emerald-400" : "text-red-400"
-  const histTextColor = histPositive ? "text-emerald-400" : "text-red-400"
-
-  return (
-    <div className="relative h-5 w-full rounded-full bg-muted overflow-hidden flex items-center px-2">
-      {/* Center line */}
-      <div className="absolute left-1/2 top-0 h-full w-px bg-border" />
-      {/* Histogram fill */}
-      <div
-        className={`absolute top-0 h-full ${histColor}`}
-        style={{
-          left: histPositive ? "50%" : `${50 - barPct}%`,
-          width: `${barPct}%`,
-        }}
-      />
-      {/* Values inside bar */}
-      <span className={`relative z-10 text-[10px] font-medium tabular-nums ${macdTextColor}`}>
-        M {macd.toFixed(2)}
-      </span>
-      <span className="relative z-10 text-[10px] tabular-nums text-muted-foreground ml-1.5">
-        S {sig.toFixed(2)}
-      </span>
-      <span className={`relative z-10 text-[10px] font-medium tabular-nums ml-auto ${histTextColor}`}>
-        H {histPositive ? "+" : ""}{hist.toFixed(2)}
-      </span>
-    </div>
-  )
+  return settings.watchlist_macd_style === "classic"
+    ? <ClassicMacd {...props} />
+    : <DivergenceMacd {...props} />
 }

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -3,10 +3,12 @@ import { createContext, useContext, useEffect, useState, useCallback, useRef, ty
 export type AssetTypeFilter = "all" | "stock" | "etf"
 export type WatchlistSortBy = "name" | "price" | "change_pct" | "rsi" | "macd_hist"
 export type SortDir = "asc" | "desc"
+export type MacdStyle = "classic" | "divergence"
 
 export interface AppSettings {
   watchlist_show_rsi: boolean
   watchlist_show_macd: boolean
+  watchlist_macd_style: MacdStyle
   watchlist_show_sparkline: boolean
   watchlist_type_filter: AssetTypeFilter
   watchlist_sort_by: WatchlistSortBy
@@ -27,6 +29,7 @@ export interface AppSettings {
 export const DEFAULT_SETTINGS: AppSettings = {
   watchlist_show_rsi: true,
   watchlist_show_macd: true,
+  watchlist_macd_style: "divergence",
   watchlist_show_sparkline: true,
   watchlist_type_filter: "all",
   watchlist_sort_by: "name",

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { useSettings, type AppSettings } from "@/lib/settings"
+import { useSettings, type AppSettings, type MacdStyle } from "@/lib/settings"
 
 function SettingSwitch({
   id,
@@ -67,6 +67,23 @@ export function SettingsPage() {
           <SettingSwitch id="wl-sparkline" label="Sparkline Chart" settingKey="watchlist_show_sparkline" draft={draft} onChange={change} />
           <SettingSwitch id="wl-rsi" label="RSI Gauge" settingKey="watchlist_show_rsi" draft={draft} onChange={change} />
           <SettingSwitch id="wl-macd" label="MACD Indicator" settingKey="watchlist_show_macd" draft={draft} onChange={change} />
+          {draft.watchlist_show_macd && (
+            <div className="flex items-center justify-between pl-4">
+              <Label className="text-muted-foreground">MACD Style</Label>
+              <Select
+                value={draft.watchlist_macd_style}
+                onValueChange={(v) => change({ watchlist_macd_style: v as MacdStyle })}
+              >
+                <SelectTrigger className="w-32">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="classic">Classic</SelectItem>
+                  <SelectItem value="divergence">Divergence</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- Add divergence-style MACD indicator (trend arrow + strength dots + histogram) as alternative to classic M/S/H layout
- New `watchlist_macd_style` setting (Classic / Divergence) in Settings page, only visible when MACD is enabled
- Default: Divergence

Closes #103

## Test plan
- [x] `pnpm build` passes
- [ ] Toggle between Classic and Divergence in Settings — watchlist updates immediately
- [ ] Setting persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)