### PR TITLE
feat: add watchlist table component with collapsible rows

### DIFF
--- a/frontend/src/components/watchlist-table.tsx
+++ b/frontend/src/components/watchlist-table.tsx
@@ -1,0 +1,213 @@
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { ChevronRight, ChevronDown, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Badge } from "@/components/ui/badge"
+import { TagBadge } from "@/components/tag-badge"
+import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
+import { formatPrice } from "@/lib/format"
+import { usePriceFlash } from "@/lib/use-price-flash"
+
+interface WatchlistTableProps {
+  assets: Asset[]
+  quotes: Record<string, Quote>
+  indicators?: Record<string, IndicatorSummary>
+  onDelete: (symbol: string) => void
+  compactMode: boolean
+}
+
+export function WatchlistTable({ assets, quotes, indicators, onDelete, compactMode }: WatchlistTableProps) {
+  const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(new Set())
+
+  const toggleExpand = (symbol: string) => {
+    setExpandedSymbols((prev) => {
+      const next = new Set(prev)
+      if (next.has(symbol)) next.delete(symbol)
+      else next.add(symbol)
+      return next
+    })
+  }
+
+  return (
+    <div className="rounded-md border border-border overflow-hidden">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-border bg-muted/50">
+            <th className="w-8" />
+            <th className="text-left text-xs font-medium text-muted-foreground px-3 py-2">Symbol</th>
+            <th className="text-left text-xs font-medium text-muted-foreground px-3 py-2">Name</th>
+            <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">Price</th>
+            <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">Change</th>
+            <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">RSI</th>
+            <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">MACD</th>
+            <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">Signal</th>
+            <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">Hist</th>
+            <th className="w-8" />
+          </tr>
+        </thead>
+        <tbody>
+          {assets.map((asset) => (
+            <TableRow
+              key={asset.id}
+              asset={asset}
+              quote={quotes[asset.symbol]}
+              indicator={indicators?.[asset.symbol]}
+              expanded={expandedSymbols.has(asset.symbol)}
+              onToggle={() => toggleExpand(asset.symbol)}
+              onDelete={() => onDelete(asset.symbol)}
+              compactMode={compactMode}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function getRsiColor(rsi: number): string {
+  if (rsi <= 30) return "text-amber-400"
+  if (rsi >= 70) return "text-orange-400"
+  return ""
+}
+
+function TableRow({
+  asset,
+  quote,
+  indicator,
+  expanded,
+  onToggle,
+  onDelete,
+  compactMode,
+}: {
+  asset: Asset
+  quote?: Quote
+  indicator?: IndicatorSummary
+  expanded: boolean
+  onToggle: () => void
+  onDelete: () => void
+  compactMode: boolean
+}) {
+  const lastPrice = quote?.price ?? null
+  const changePct = quote?.change_percent ?? null
+  const changeColor =
+    changePct != null ? (changePct >= 0 ? "text-emerald-500" : "text-red-500") : "text-muted-foreground"
+
+  const [priceRef, pctRef] = usePriceFlash(lastPrice)
+  const py = compactMode ? "py-1.5" : "py-2.5"
+
+  return (
+    <>
+      <tr
+        className="border-b border-border hover:bg-muted/30 cursor-pointer group transition-colors"
+        onClick={onToggle}
+      >
+        <td className={`${py} pl-2`}>
+          {expanded ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </td>
+        <td className={`${py} px-3`}>
+          <div className="flex items-center gap-2">
+            <Link
+              to={`/asset/${asset.symbol}`}
+              className="font-semibold hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {asset.symbol}
+            </Link>
+            <Badge variant="secondary" className="text-[10px] px-1 py-0">
+              {asset.type}
+            </Badge>
+          </div>
+        </td>
+        <td className={`${py} px-3 text-sm text-muted-foreground max-w-[250px]`}>
+          <div className="flex items-center gap-2 truncate">
+            <span className="truncate">{asset.name}</span>
+            {asset.tags.length > 0 && (
+              <span className="flex gap-1 shrink-0">
+                {asset.tags.map((tag) => (
+                  <TagBadge key={tag.id} name={tag.name} color={tag.color} />
+                ))}
+              </span>
+            )}
+          </div>
+        </td>
+        <td className={`${py} px-3 text-right tabular-nums`}>
+          {lastPrice != null ? (
+            <span ref={priceRef} className="font-medium rounded px-1 -mx-1">
+              {formatPrice(lastPrice, asset.currency)}
+            </span>
+          ) : (
+            <Skeleton className="h-4 w-14 ml-auto rounded" />
+          )}
+        </td>
+        <td className={`${py} px-3 text-right tabular-nums`}>
+          {changePct != null ? (
+            <span ref={pctRef} className={`font-medium rounded px-1 -mx-1 ${changeColor}`}>
+              {changePct >= 0 ? "+" : ""}
+              {changePct.toFixed(2)}%
+            </span>
+          ) : (
+            <Skeleton className="h-4 w-12 ml-auto rounded" />
+          )}
+        </td>
+        <td className={`${py} px-3 text-right text-sm tabular-nums`}>
+          {indicator?.rsi != null ? (
+            <span className={getRsiColor(indicator.rsi)}>{indicator.rsi.toFixed(0)}</span>
+          ) : (
+            <span className="text-muted-foreground">&mdash;</span>
+          )}
+        </td>
+        <td className={`${py} px-3 text-right text-sm tabular-nums`}>
+          {indicator?.macd != null ? (
+            indicator.macd.toFixed(2)
+          ) : (
+            <span className="text-muted-foreground">&mdash;</span>
+          )}
+        </td>
+        <td className={`${py} px-3 text-right text-sm tabular-nums`}>
+          {indicator?.macd_signal != null ? (
+            indicator.macd_signal.toFixed(2)
+          ) : (
+            <span className="text-muted-foreground">&mdash;</span>
+          )}
+        </td>
+        <td className={`${py} px-3 text-right text-sm tabular-nums`}>
+          {indicator?.macd_hist != null ? (
+            <span className={indicator.macd_hist >= 0 ? "text-emerald-400" : "text-red-400"}>
+              {indicator.macd_hist >= 0 ? "+" : ""}
+              {indicator.macd_hist.toFixed(2)}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">&mdash;</span>
+          )}
+        </td>
+        <td className={`${py} pr-2`}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete()
+            }}
+          >
+            <Trash2 className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
+          </Button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={10} className="bg-muted/20 p-4 border-b border-border">
+            <div className="text-sm text-muted-foreground italic">
+              Chart and indicators will appear here when expanded.
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/watchlist.tsx
+++ b/frontend/src/pages/watchlist.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
-import { ArrowDownAZ, ArrowUpAZ, MoreVertical, Plus, Trash2, TrendingUp } from "lucide-react"
+import { ArrowDownAZ, ArrowUpAZ, LayoutGrid, MoreVertical, Plus, Table, Trash2, TrendingUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -23,6 +23,7 @@ import { formatPrice } from "@/lib/format"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useSettings, type AssetTypeFilter, type WatchlistSortBy, type SortDir } from "@/lib/settings"
 import { useFilteredSortedAssets } from "@/lib/use-watchlist-filter"
+import { WatchlistTable } from "@/components/watchlist-table"
 
 const SORT_OPTIONS: [WatchlistSortBy, string][] = [
   ["name", "Name"],
@@ -42,6 +43,7 @@ export function WatchlistPage() {
   const [symbol, setSymbol] = useState("")
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
+  const [viewMode, setViewMode] = useState<"card" | "table">("card")
   const { settings, updateSettings } = useSettings()
   const { data: batchSparklines } = useWatchlistSparklines(sparklinePeriod)
   const { data: batchIndicators } = useWatchlistIndicators()
@@ -145,6 +147,31 @@ export function WatchlistPage() {
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
+          {/* View mode toggle */}
+          <div className="flex rounded-md border border-border overflow-hidden">
+            <button
+              onClick={() => setViewMode("card")}
+              className={`px-2 py-1 transition-colors ${
+                viewMode === "card"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+              }`}
+              title="Card view"
+            >
+              <LayoutGrid className="h-3.5 w-3.5" />
+            </button>
+            <button
+              onClick={() => setViewMode("table")}
+              className={`px-2 py-1 transition-colors ${
+                viewMode === "table"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+              }`}
+              title="Table view"
+            >
+              <Table className="h-3.5 w-3.5" />
+            </button>
+          </div>
         </div>
         <div className="flex gap-2">
           <Input
@@ -199,30 +226,40 @@ export function WatchlistPage() {
         </div>
       )}
 
-      <div className={`grid gap-4 ${
-        settings.compact_mode
-          ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5"
-          : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-      }`}>
-        {assets?.map((asset) => (
-          <AssetCard
-            key={asset.id}
-            symbol={asset.symbol}
-            name={asset.name}
-            type={asset.type}
-            currency={asset.currency}
-            tags={asset.tags}
-            quote={quotes[asset.symbol]}
-            sparklinePeriod={sparklinePeriod}
-            sparklineData={batchSparklines?.[asset.symbol]}
-            indicatorData={batchIndicators?.[asset.symbol]}
-            onDelete={() => deleteAsset.mutate(asset.symbol)}
-            showSparkline={settings.watchlist_show_sparkline}
-            showRsi={settings.watchlist_show_rsi}
-            showMacd={settings.watchlist_show_macd}
-          />
-        ))}
-      </div>
+      {viewMode === "table" && assets && assets.length > 0 ? (
+        <WatchlistTable
+          assets={assets}
+          quotes={quotes}
+          indicators={batchIndicators}
+          onDelete={(s) => deleteAsset.mutate(s)}
+          compactMode={settings.compact_mode}
+        />
+      ) : (
+        <div className={`grid gap-4 ${
+          settings.compact_mode
+            ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5"
+            : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+        }`}>
+          {assets?.map((asset) => (
+            <AssetCard
+              key={asset.id}
+              symbol={asset.symbol}
+              name={asset.name}
+              type={asset.type}
+              currency={asset.currency}
+              tags={asset.tags}
+              quote={quotes[asset.symbol]}
+              sparklinePeriod={sparklinePeriod}
+              sparklineData={batchSparklines?.[asset.symbol]}
+              indicatorData={batchIndicators?.[asset.symbol]}
+              onDelete={() => deleteAsset.mutate(asset.symbol)}
+              showSparkline={settings.watchlist_show_sparkline}
+              showRsi={settings.watchlist_show_rsi}
+              showMacd={settings.watchlist_show_macd}
+            />
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add `WatchlistTable` component with columns: Symbol, Name, Price, Change%, RSI, MACD, Signal, Hist
- Click-to-expand rows with chevron indicator (expanded content placeholder for #107)
- View mode toggle (card/table icons) in watchlist toolbar
- Reuses existing data hooks, filter/sort, price flash animation, and skeleton states

Closes #106
Part of #105

## Test plan
- [ ] Verify table renders all watchlisted assets with correct columns
- [ ] Click rows to expand/collapse, verify chevron toggles
- [ ] Toggle between card and table view via toolbar icons
- [ ] Verify sort and filter controls work in table view
- [ ] Verify price flash animation on SSE updates in table view
- [ ] Verify compact mode reduces row padding
- [ ] `pnpm lint` and `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)