### PR TITLE
feat: add expanded row content with price chart and indicators

### DIFF
--- a/frontend/src/components/macd-indicator.tsx
+++ b/frontend/src/components/macd-indicator.tsx
@@ -2,9 +2,9 @@ import { Skeleton } from "@/components/ui/skeleton"
 import type { IndicatorSummary } from "@/lib/api"
 import { useSettings } from "@/lib/settings"
 
-type MacdProps = { macd: number; sig: number; hist: number }
+type MacdProps = { macd: number; sig: number; hist: number; lg: boolean }
 
-function ClassicMacd({ macd, sig, hist }: MacdProps) {
+function ClassicMacd({ macd, sig, hist, lg }: MacdProps) {
   const histPositive = hist >= 0
   const bullish = macd > sig
   const barPct = 25
@@ -12,9 +12,10 @@ function ClassicMacd({ macd, sig, hist }: MacdProps) {
   const histColor = histPositive ? "bg-emerald-500/30" : "bg-red-500/30"
   const macdTextColor = bullish ? "text-emerald-400" : "text-red-400"
   const histTextColor = histPositive ? "text-emerald-400" : "text-red-400"
+  const textSize = lg ? "text-sm" : "text-[10px]"
 
   return (
-    <div className="relative h-5 w-full rounded-full bg-muted overflow-hidden flex items-center px-2">
+    <div className={`relative ${lg ? "h-10" : "h-5"} w-full rounded-full bg-muted overflow-hidden flex items-center ${lg ? "px-3" : "px-2"}`}>
       <div className="absolute left-1/2 top-0 h-full w-px bg-border" />
       <div
         className={`absolute top-0 h-full ${histColor}`}
@@ -23,20 +24,20 @@ function ClassicMacd({ macd, sig, hist }: MacdProps) {
           width: `${barPct}%`,
         }}
       />
-      <span className={`relative z-10 text-[10px] font-medium tabular-nums ${macdTextColor}`}>
+      <span className={`relative z-10 ${textSize} font-medium tabular-nums ${macdTextColor}`}>
         M {macd.toFixed(2)}
       </span>
-      <span className="relative z-10 text-[10px] tabular-nums text-muted-foreground ml-1.5">
+      <span className={`relative z-10 ${textSize} tabular-nums text-muted-foreground ml-1.5`}>
         S {sig.toFixed(2)}
       </span>
-      <span className={`relative z-10 text-[10px] font-medium tabular-nums ml-auto ${histTextColor}`}>
+      <span className={`relative z-10 ${textSize} font-medium tabular-nums ml-auto ${histTextColor}`}>
         H {histPositive ? "+" : ""}{hist.toFixed(2)}
       </span>
     </div>
   )
 }
 
-function DivergenceMacd({ macd, sig, hist }: MacdProps) {
+function DivergenceMacd({ macd, sig, hist, lg }: MacdProps) {
   const histPositive = hist >= 0
   const bullish = macd > sig
   const barPct = 25
@@ -45,12 +46,14 @@ function DivergenceMacd({ macd, sig, hist }: MacdProps) {
   const trendColor = bullish ? "text-emerald-400" : "text-red-400"
   const dotFill = bullish ? "bg-emerald-400" : "bg-red-400"
   const histTextColor = histPositive ? "text-emerald-400" : "text-red-400"
+  const textSize = lg ? "text-sm" : "text-[10px]"
 
   const strength = Math.abs(hist)
   const dots = strength > 0.5 ? 3 : strength > 0.15 ? 2 : 1
+  const dotSize = lg ? "h-1.5 w-1.5" : "h-1 w-1"
 
   return (
-    <div className="relative h-5 w-full rounded-full bg-muted overflow-hidden flex items-center px-2">
+    <div className={`relative ${lg ? "h-10" : "h-5"} w-full rounded-full bg-muted overflow-hidden flex items-center ${lg ? "px-3" : "px-2"}`}>
       <div className="absolute left-1/2 top-0 h-full w-px bg-border" />
       <div
         className={`absolute top-0 h-full ${barColor}`}
@@ -59,18 +62,18 @@ function DivergenceMacd({ macd, sig, hist }: MacdProps) {
           width: `${barPct}%`,
         }}
       />
-      <span className={`relative z-10 text-[10px] font-medium tabular-nums ${trendColor}`}>
+      <span className={`relative z-10 ${textSize} font-medium tabular-nums ${trendColor}`}>
         {bullish ? "\u25B2" : "\u25BC"} {macd.toFixed(2)}
       </span>
-      <span className="relative z-10 flex items-center gap-0.5 ml-1.5">
+      <span className={`relative z-10 flex items-center ${lg ? "gap-1" : "gap-0.5"} ml-1.5`}>
         {Array.from({ length: dots }).map((_, i) => (
-          <span key={i} className={`inline-block h-1 w-1 rounded-full ${dotFill}`} />
+          <span key={i} className={`inline-block ${dotSize} rounded-full ${dotFill}`} />
         ))}
         {Array.from({ length: 3 - dots }).map((_, i) => (
-          <span key={i} className="inline-block h-1 w-1 rounded-full bg-muted-foreground/20" />
+          <span key={i} className={`inline-block ${dotSize} rounded-full bg-muted-foreground/20`} />
         ))}
       </span>
-      <span className={`relative z-10 text-[10px] font-medium tabular-nums ml-auto ${histTextColor}`}>
+      <span className={`relative z-10 ${textSize} font-medium tabular-nums ml-auto ${histTextColor}`}>
         {histPositive ? "+" : ""}{hist.toFixed(2)}
       </span>
     </div>
@@ -79,19 +82,22 @@ function DivergenceMacd({ macd, sig, hist }: MacdProps) {
 
 export function MacdIndicator({
   batchMacd,
+  size = "sm",
 }: {
   symbol: string
   batchMacd?: Pick<IndicatorSummary, "macd" | "macd_signal" | "macd_hist"> | null
+  size?: "sm" | "lg"
 }) {
   const { settings } = useSettings()
+  const lg = size === "lg"
 
   if (batchMacd === undefined) {
-    return <Skeleton className="h-5 w-full rounded-full" />
+    return <Skeleton className={`${lg ? "h-10" : "h-5"} w-full rounded-full`} />
   }
 
   if (batchMacd?.macd == null || batchMacd?.macd_signal == null || batchMacd?.macd_hist == null) {
     return (
-      <div className="flex items-center justify-center h-5 rounded-full bg-muted text-[10px] text-muted-foreground">
+      <div className={`flex items-center justify-center ${lg ? "h-10 text-sm" : "h-5 text-[10px]"} rounded-full bg-muted text-muted-foreground`}>
         No MACD
       </div>
     )
@@ -101,6 +107,7 @@ export function MacdIndicator({
     macd: batchMacd.macd,
     sig: batchMacd.macd_signal,
     hist: batchMacd.macd_hist,
+    lg,
   }
 
   return settings.watchlist_macd_style === "classic"

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -23,6 +23,7 @@ interface PriceChartProps {
   showRsiChart?: boolean
   showMacdChart?: boolean
   chartType?: "candle" | "line"
+  mainChartHeight?: number
 }
 
 export function PriceChart({
@@ -35,6 +36,7 @@ export function PriceChart({
   showRsiChart = true,
   showMacdChart = true,
   chartType = "candle",
+  mainChartHeight = 400,
 }: PriceChartProps) {
   const mainRef = useRef<HTMLDivElement>(null)
   const rsiRef = useRef<HTMLDivElement>(null)
@@ -74,7 +76,7 @@ export function PriceChart({
 
     buildLookupMaps(prices, indicators)
 
-    const opts = baseChartOptions(mainRef.current, 400)
+    const opts = baseChartOptions(mainRef.current, mainChartHeight)
 
     // Main chart — hide time axis only when sub-charts exist below
     const hideMainTimeAxis = showRsiChart || showMacdChart
@@ -311,7 +313,7 @@ export function PriceChart({
       rsiChartRef.current = null
       macdChartRef.current = null
     }
-  }, [prices, indicators, annotations, buildLookupMaps, syncCharts, setupSingleChartCrosshair, showSma20, showSma50, showBollinger, showRsiChart, showMacdChart, chartType])
+  }, [prices, indicators, annotations, buildLookupMaps, syncCharts, setupSingleChartCrosshair, showSma20, showSma50, showBollinger, showRsiChart, showMacdChart, chartType, mainChartHeight])
 
   // Apply theme changes without recreating charts
   useEffect(() => {

--- a/frontend/src/components/rsi-gauge.tsx
+++ b/frontend/src/components/rsi-gauge.tsx
@@ -24,14 +24,16 @@ function getZoneLabel(rsi: number): string {
   return ""
 }
 
-export function RsiGauge({ batchRsi }: { symbol: string; batchRsi?: number | null }) {
+export function RsiGauge({ batchRsi, size = "sm" }: { symbol: string; batchRsi?: number | null; size?: "sm" | "lg" }) {
+  const lg = size === "lg"
+
   if (batchRsi === undefined) {
-    return <Skeleton className="h-5 w-full rounded-full" />
+    return <Skeleton className={`${lg ? "h-10" : "h-5"} w-full rounded-full`} />
   }
 
   if (batchRsi == null) {
     return (
-      <div className="flex items-center justify-center h-5 rounded-full bg-muted text-[10px] text-muted-foreground">
+      <div className={`flex items-center justify-center ${lg ? "h-10 text-sm" : "h-5 text-[10px]"} rounded-full bg-muted text-muted-foreground`}>
         No RSI
       </div>
     )
@@ -43,7 +45,7 @@ export function RsiGauge({ batchRsi }: { symbol: string; batchRsi?: number | nul
   const label = getZoneLabel(pct)
 
   return (
-    <div className="relative h-5 w-full rounded-full bg-muted overflow-hidden flex items-center px-2">
+    <div className={`relative ${lg ? "h-10" : "h-5"} w-full rounded-full bg-muted overflow-hidden flex items-center ${lg ? "px-3" : "px-2"}`}>
       {/* Zone backgrounds */}
       <div className="absolute inset-0 flex">
         <div className="w-[30%] bg-amber-500/10" />
@@ -52,15 +54,15 @@ export function RsiGauge({ batchRsi }: { symbol: string; batchRsi?: number | nul
       </div>
       {/* Marker */}
       <div
-        className="absolute top-0 h-full w-0.5 rounded-full"
+        className={`absolute top-0 h-full ${lg ? "w-1" : "w-0.5"} rounded-full`}
         style={{ left: `${pct}%`, backgroundColor: markerColor }}
       />
       {/* Text inside bar */}
-      <span className={`relative z-10 text-[10px] font-medium tabular-nums ${textClass}`}>
+      <span className={`relative z-10 ${lg ? "text-sm" : "text-[10px]"} font-medium tabular-nums ${textClass}`}>
         RSI {pct.toFixed(0)}
       </span>
       {label && (
-        <span className={`relative z-10 text-[10px] ml-auto ${textClass}`}>{label}</span>
+        <span className={`relative z-10 ${lg ? "text-sm" : "text-[10px]"} ml-auto ${textClass}`}>{label}</span>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Expanded table rows now show full price chart (80%) + scaled-up RSI/MACD gauges (20%)
- Price chart lazy-loads OHLCV data on expand (not pre-fetched), with SMA/Bollinger overlays per settings
- RSI chart and MACD chart sub-panels are hidden in expanded row (indicators shown as gauges instead)
- Added `mainChartHeight` prop to `PriceChart` for configurable height (300px in table, 400px default on detail page)
- Added `size` prop (`sm`/`lg`) to `RsiGauge` and `MacdIndicator` for scaled-up display

Closes #107
Part of #105

## Test plan
- [ ] Expand a table row — verify price chart loads with correct overlays
- [ ] Verify only price chart shows (no RSI/MACD sub-charts below it)
- [ ] Verify RSI and MACD gauges appear in the right column, larger than card versions
- [ ] Collapse and re-expand — verify cached data loads instantly
- [ ] Verify detail page PriceChart still works at default 400px height
- [ ] `pnpm lint` and `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)