### PR TITLE
feat: add card/table view toggle with settings persistence

### DIFF
--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -4,12 +4,14 @@ export type AssetTypeFilter = "all" | "stock" | "etf"
 export type WatchlistSortBy = "name" | "price" | "change_pct" | "rsi" | "macd_hist"
 export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"
+export type WatchlistViewMode = "card" | "table"
 
 export interface AppSettings {
   watchlist_show_rsi: boolean
   watchlist_show_macd: boolean
   watchlist_macd_style: MacdStyle
   watchlist_show_sparkline: boolean
+  watchlist_view_mode: WatchlistViewMode
   watchlist_type_filter: AssetTypeFilter
   watchlist_sort_by: WatchlistSortBy
   watchlist_sort_dir: SortDir
@@ -31,6 +33,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   watchlist_show_macd: true,
   watchlist_macd_style: "divergence",
   watchlist_show_sparkline: true,
+  watchlist_view_mode: "card",
   watchlist_type_filter: "all",
   watchlist_sort_by: "name",
   watchlist_sort_dir: "asc",

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { useSettings, type AppSettings, type MacdStyle } from "@/lib/settings"
+import { useSettings, type AppSettings, type MacdStyle, type WatchlistViewMode } from "@/lib/settings"
 
 function SettingSwitch({
   id,
@@ -61,9 +61,24 @@ export function SettingsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Watchlist Card Indicators</CardTitle>
+          <CardTitle>Watchlist</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <Label>Default View</Label>
+            <Select
+              value={draft.watchlist_view_mode}
+              onValueChange={(v) => change({ watchlist_view_mode: v as WatchlistViewMode })}
+            >
+              <SelectTrigger className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="card">Card</SelectItem>
+                <SelectItem value="table">Table</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
           <SettingSwitch id="wl-sparkline" label="Sparkline Chart" settingKey="watchlist_show_sparkline" draft={draft} onChange={change} />
           <SettingSwitch id="wl-rsi" label="RSI Gauge" settingKey="watchlist_show_rsi" draft={draft} onChange={change} />
           <SettingSwitch id="wl-macd" label="MACD Indicator" settingKey="watchlist_show_macd" draft={draft} onChange={change} />

--- a/frontend/src/pages/watchlist.tsx
+++ b/frontend/src/pages/watchlist.tsx
@@ -43,8 +43,9 @@ export function WatchlistPage() {
   const [symbol, setSymbol] = useState("")
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
-  const [viewMode, setViewMode] = useState<"card" | "table">("card")
   const { settings, updateSettings } = useSettings()
+  const viewMode = settings.watchlist_view_mode
+  const setViewMode = (v: "card" | "table") => updateSettings({ watchlist_view_mode: v })
   const { data: batchSparklines } = useWatchlistSparklines(sparklinePeriod)
   const { data: batchIndicators } = useWatchlistIndicators()
 


### PR DESCRIPTION
## Summary
- Add `watchlist_view_mode` setting (`"card"` | `"table"`, default `"card"`)
- Watchlist toolbar toggle now persists view preference across sessions via settings system
- Settings page: renamed "Watchlist Card Indicators" to "Watchlist", added "Default View" dropdown (Card/Table)

Closes #108
Part of #105

## Test plan
- [ ] Toggle view mode in watchlist toolbar — verify it persists on page refresh
- [ ] Change default view in Settings page — verify watchlist opens with that view
- [ ] Verify both views share same filter/sort/tag state
- [ ] `pnpm lint` and `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)