### PR TITLE
feat: snap crosshair to closing price on single-chart mode

### DIFF
--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -291,7 +291,7 @@ export function PriceChart({
     if (chartEntries.length > 1) {
       syncCharts(chartEntries)
     } else {
-      setupSingleChartCrosshair(mainChart)
+      setupSingleChartCrosshair(mainChart, mainSeries)
     }
 
     const resizeObserver = new ResizeObserver((entries) => {

--- a/frontend/src/lib/use-chart-sync.ts
+++ b/frontend/src/lib/use-chart-sync.ts
@@ -131,7 +131,7 @@ export function useChartSync() {
     }
   }, [getValuesForTime])
 
-  const setupSingleChartCrosshair = useCallback((chart: IChartApi) => {
+  const setupSingleChartCrosshair = useCallback((chart: IChartApi, series: ReturnType<IChartApi["addSeries"]>) => {
     chart.subscribeCrosshairMove((param) => {
       if (param.time) {
         const key = String(param.time)
@@ -146,6 +146,15 @@ export function useChartSync() {
           bbUpper: bbUpperByTime.current.get(key),
           bbLower: bbLowerByTime.current.get(key),
         })
+        // Snap crosshair to close price
+        if (!syncingRef.current) {
+          syncingRef.current = true
+          const closeVal = closeByTime.current.get(key)
+          if (closeVal !== undefined) {
+            chart.setCrosshairPosition(closeVal, param.time, series)
+          }
+          syncingRef.current = false
+        }
       } else {
         setHoverValues(null)
       }


### PR DESCRIPTION
## Summary
- Crosshair now snaps to the closing price when hovering over single-chart instances (table view expanded rows, detail page without RSI/MACD sub-charts)
- Uses manual `setCrosshairPosition` with re-entrancy guard, consistent with existing multi-chart sync approach

Closes #128

## Test plan
- [ ] Expand a row in the watchlist table view → hover over chart → crosshair snaps to close price, not to SMA/BB lines
- [ ] Detail page with RSI/MACD sub-charts → crosshair sync still works correctly
- [ ] Detail page without sub-charts → crosshair snaps to close price
- [ ] Legend values update correctly on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)