### PR TITLE
feat: frontend UX batch — sortable headers, prefetch, staleTime & more

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,3 +140,8 @@
 }
 .flash-green { animation: flash-green 1.8s ease-out; }
 .flash-red   { animation: flash-red 1.8s ease-out; }
+
+@keyframes slide {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, useRef, type ReactNode } from "react"
 
 export type AssetTypeFilter = "all" | "stock" | "etf"
-export type WatchlistSortBy = "name" | "price" | "change_pct" | "rsi" | "macd_hist"
+export type WatchlistSortBy = "name" | "price" | "change_pct" | "rsi" | "macd" | "macd_signal" | "macd_hist"
 export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"
 export type WatchlistViewMode = "card" | "table"

--- a/frontend/src/lib/use-watchlist-filter.ts
+++ b/frontend/src/lib/use-watchlist-filter.ts
@@ -59,6 +59,18 @@ export function useFilteredSortedAssets(
             indicators?.[b.symbol]?.rsi ?? null,
           )
           break
+        case "macd":
+          cmp = compareNullable(
+            indicators?.[a.symbol]?.macd ?? null,
+            indicators?.[b.symbol]?.macd ?? null,
+          )
+          break
+        case "macd_signal":
+          cmp = compareNullable(
+            indicators?.[a.symbol]?.macd_signal ?? null,
+            indicators?.[b.symbol]?.macd_signal ?? null,
+          )
+          break
         case "macd_hist":
           cmp = compareNullable(
             indicators?.[a.symbol]?.macd_hist ?? null,

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -43,7 +43,7 @@ export function AssetDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <Header symbol={symbol} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isWatchlisted={isWatchlisted} />
+      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isWatchlisted={isWatchlisted} />
       <ChartSection
         symbol={symbol}
         period={period}
@@ -68,12 +68,14 @@ export function AssetDetailPage() {
 
 function Header({
   symbol,
+  name,
   currency,
   period,
   setPeriod,
   isWatchlisted,
 }: {
   symbol: string
+  name?: string
   currency: string
   period: string
   setPeriod: (p: string) => void
@@ -95,7 +97,10 @@ function Header({
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>
-        <h1 className="text-2xl font-bold">{symbol}</h1>
+        <div>
+          <h1 className="text-2xl font-bold">{symbol}</h1>
+          {name && <p className="text-sm text-muted-foreground">{name}</p>}
+        </div>
         {price != null && (
           <span ref={priceRef} className="text-xl font-semibold tabular-nums rounded px-1">
             {formatPrice(price, currency)}
@@ -183,8 +188,8 @@ function ChartSection({
   showMacdChart: boolean
   chartType: "candle" | "line"
 }) {
-  const { data: prices, isLoading: pricesLoading } = usePrices(symbol, period)
-  const { data: indicators, isLoading: indicatorsLoading } = useIndicators(symbol, period)
+  const { data: prices, isLoading: pricesLoading, isFetching: pricesFetching } = usePrices(symbol, period)
+  const { data: indicators, isLoading: indicatorsLoading, isFetching: indicatorsFetching } = useIndicators(symbol, period)
   const { data: annotations } = useAnnotations(symbol)
 
   if (pricesLoading || indicatorsLoading) {
@@ -205,17 +210,24 @@ function ChartSection({
   }
 
   return (
-    <PriceChart
-      prices={prices}
-      indicators={indicators ?? []}
-      annotations={annotations ?? []}
-      showSma20={showSma20}
-      showSma50={showSma50}
-      showBollinger={showBollinger}
-      showRsiChart={showRsiChart}
-      showMacdChart={showMacdChart}
-      chartType={chartType}
-    />
+    <div className="relative">
+      {(pricesFetching || indicatorsFetching) && (
+        <div className="absolute top-0 left-0 right-0 h-0.5 bg-primary/20 overflow-hidden z-10 rounded-t-md">
+          <div className="h-full w-1/3 bg-primary animate-[slide_1s_ease-in-out_infinite]" />
+        </div>
+      )}
+      <PriceChart
+        prices={prices}
+        indicators={indicators ?? []}
+        annotations={annotations ?? []}
+        showSma20={showSma20}
+        showSma50={showSma50}
+        showBollinger={showBollinger}
+        showRsiChart={showRsiChart}
+        showMacdChart={showMacdChart}
+        chartType={chartType}
+      />
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Batch of frontend UX and performance improvements:

- **Show asset name on detail page header** — displays company/fund name as subtitle below the symbol
- **Keep previous chart data during period switch** — uses `keepPreviousData` with a subtle animated loading bar so charts don't flash empty
- **Increase staleTime for stable data** — 5min staleTime on assets, tags, groups, pseudo-ETFs, thesis, annotations, portfolio queries to reduce redundant refetches
- **Prefetch asset detail on hover** — warms price + indicator cache on watchlist card/row and portfolio performer hover for instant navigation
- **Sortable column headers in table view** — clickable headers with sort arrows for Symbol, Price, Change, RSI, MACD, Signal, Hist
- **Three-dot menu for delete action** — replaces bare trash icon with a dropdown menu (extensible for future actions)

Closes #111, closes #117, closes #118, closes #119, closes #127, closes #130

## Test plan

- [ ] Verify asset name shows below symbol on detail page
- [ ] Switch chart period — old data stays visible with loading bar, then updates
- [ ] Navigate between pages — verify no unnecessary refetches (check network tab)
- [ ] Hover over watchlist item, then click — detail page should load near-instantly
- [ ] Click column headers in table view — verify sorting works for all columns
- [ ] Hover over table row — verify three-dot menu appears, click it, confirm delete option works

🤖 Generated with [Claude Code](https://claude.com/claude-code)