### PR TITLE
perf: cache watchlist indicator snapshots (10 min TTL)

### DIFF
--- a/backend/app/routers/watchlist.py
+++ b/backend/app/routers/watchlist.py
@@ -4,10 +4,11 @@ These return aggregated data for all watchlisted assets in a single request,
 eliminating the N+1 pattern of fetching prices/indicators per asset card.
 """
 
+import time
 from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import pandas as pd
@@ -17,6 +18,11 @@ from app.models import Asset, PriceHistory
 from app.services.indicators import compute_indicators
 
 router = APIRouter(prefix="/api/watchlist", tags=["watchlist"])
+
+# In-memory cache for batch indicator snapshots.
+# Key: (frozenset of symbols, latest_price_date) — auto-invalidates when prices change.
+_indicator_cache: dict[tuple, tuple[dict, float]] = {}
+_INDICATOR_CACHE_TTL = 600  # 10 minutes
 
 _PERIOD_DAYS = {
     "1mo": 30, "3mo": 90, "6mo": 180,
@@ -82,6 +88,10 @@ async def batch_indicators(
     window for SMA50/Bollinger Band convergence. Only the most recent non-null
     values are returned — this is optimised for the watchlist card badges, not
     for charting full indicator time series.
+
+    Results are cached for 10 minutes, keyed on the set of watchlisted symbols
+    and the latest price date. The cache auto-invalidates when new prices are
+    synced (the latest date changes).
     """
     assets_result = await db.execute(
         select(Asset.id, Asset.symbol).where(Asset.watchlisted == True)  # noqa: E712
@@ -92,6 +102,17 @@ async def batch_indicators(
 
     asset_ids = [r.id for r in asset_rows]
     id_to_symbol = {r.id: r.symbol for r in asset_rows}
+
+    # Build cache key: symbols + latest price date
+    latest_date_result = await db.execute(
+        select(func.max(PriceHistory.date)).where(PriceHistory.asset_id.in_(asset_ids))
+    )
+    latest_date = latest_date_result.scalar()
+    cache_key = (frozenset(id_to_symbol.values()), latest_date)
+
+    cached = _indicator_cache.get(cache_key)
+    if cached and time.monotonic() - cached[1] < _INDICATOR_CACHE_TTL:
+        return cached[0]
 
     # Fetch enough history for indicator warmup (SMA50 needs ~50 trading days)
     warmup_start = date.today() - timedelta(days=_PERIOD_DAYS["3mo"] + _WARMUP_DAYS)
@@ -147,5 +168,9 @@ async def batch_indicators(
             "macd_signal": macd_sig,
             "macd_hist": macd_hist,
         }
+
+    # Store in cache (single-entry — only latest key matters)
+    _indicator_cache.clear()
+    _indicator_cache[cache_key] = (out, time.monotonic())
 
     return out


### PR DESCRIPTION
## Summary
- Adds 10-minute in-memory TTL cache to the `/api/watchlist/indicators` endpoint
- Cache key is `(frozenset of symbols, latest_price_date)` — auto-invalidates when new prices are synced or watchlist changes
- Single-entry cache (cleared on recompute) since there's only one watchlist
- Eliminates expensive per-request pandas + indicator computation for all watchlisted assets

Closes #121

## Test plan
- [ ] All 115 backend tests pass
- [ ] Watchlist page loads indicators correctly
- [ ] Subsequent requests within 10 min return cached results
- [ ] Cache invalidates when prices are refreshed (latest date changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)