### PR TITLE
perf: pre-compute indicators after nightly price sync

### DIFF
--- a/backend/app/routers/watchlist.py
+++ b/backend/app/routers/watchlist.py
@@ -93,6 +93,14 @@ async def batch_indicators(
     and the latest price date. The cache auto-invalidates when new prices are
     synced (the latest date changes).
     """
+    return await compute_and_cache_indicators(db)
+
+
+async def compute_and_cache_indicators(db: AsyncSession) -> dict[str, dict]:
+    """Compute indicator snapshots for all watchlisted assets, with caching.
+
+    Called by the API endpoint and also by the nightly cron to warm the cache.
+    """
     assets_result = await db.execute(
         select(Asset.id, Asset.symbol).where(Asset.watchlisted == True)  # noqa: E712
     )


### PR DESCRIPTION
## Summary
- Extracts indicator computation into `compute_and_cache_indicators()` (reusable from both API and cron)
- After the nightly `sync_all_prices()`, calls `compute_and_cache_indicators()` to warm the in-memory cache from #121
- First watchlist page load after the cron is now instant — no on-demand computation needed
- No new DB tables or schema changes — leverages the existing 10-min TTL cache

Closes #124

## Test plan
- [ ] All 115 backend tests pass
- [ ] Watchlist indicators endpoint still works correctly
- [ ] Nightly cron logs "Pre-computed indicators for N assets" after price sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)