### PR TITLE
refactor: add safe_round utility (#155)

### DIFF
--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -8,7 +8,7 @@ from app.database import get_db
 from app.models import Asset, PriceHistory
 from app.routers.deps import find_asset, get_asset
 from app.schemas.price import IndicatorResponse, PriceResponse
-from app.services.indicators import compute_indicators
+from app.services.indicators import compute_indicators, safe_round
 from app.services.price_sync import sync_asset_prices, sync_asset_prices_range
 from app.services.yahoo import fetch_history
 
@@ -171,15 +171,15 @@ async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = De
         rows.append(IndicatorResponse(
             date=dt,
             close=round(row["close"], 4),
-            rsi=round(row["rsi"], 2) if pd.notna(row["rsi"]) else None,
-            sma_20=round(row["sma_20"], 4) if pd.notna(row["sma_20"]) else None,
-            sma_50=round(row["sma_50"], 4) if pd.notna(row["sma_50"]) else None,
-            bb_upper=round(row["bb_upper"], 4) if pd.notna(row["bb_upper"]) else None,
-            bb_middle=round(row["bb_middle"], 4) if pd.notna(row["bb_middle"]) else None,
-            bb_lower=round(row["bb_lower"], 4) if pd.notna(row["bb_lower"]) else None,
-            macd=round(row["macd"], 4) if pd.notna(row["macd"]) else None,
-            macd_signal=round(row["macd_signal"], 4) if pd.notna(row["macd_signal"]) else None,
-            macd_hist=round(row["macd_hist"], 4) if pd.notna(row["macd_hist"]) else None,
+            rsi=safe_round(row["rsi"], 2),
+            sma_20=safe_round(row["sma_20"], 4),
+            sma_50=safe_round(row["sma_50"], 4),
+            bb_upper=safe_round(row["bb_upper"], 4),
+            bb_middle=safe_round(row["bb_middle"], 4),
+            bb_lower=safe_round(row["bb_lower"], 4),
+            macd=safe_round(row["macd"], 4),
+            macd_signal=safe_round(row["macd_signal"], 4),
+            macd_hist=safe_round(row["macd_hist"], 4),
         ))
 
     return rows

--- a/backend/app/services/indicators.py
+++ b/backend/app/services/indicators.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import pandas as pd
 
 
+def safe_round(value, decimals: int = 2) -> float | None:
+    """Round a value if it is not NaN/None, otherwise return None."""
+    if pd.notna(value):
+        return round(value, decimals)
+    return None
+
+
 def rsi(closes: pd.Series, period: int = 14) -> pd.Series:
     """RSI (Relative Strength Index). >70 overbought, <30 oversold."""
     delta = closes.diff()
@@ -83,16 +90,16 @@ def build_indicator_snapshot(indicators: pd.DataFrame) -> dict:
     return {
         "close": round(latest["close"], 2),
         "change_pct": change_pct,
-        "rsi": round(latest["rsi"], 2) if pd.notna(latest["rsi"]) else None,
-        "sma_20": round(latest["sma_20"], 2) if pd.notna(latest["sma_20"]) else None,
-        "sma_50": round(latest["sma_50"], 2) if pd.notna(latest["sma_50"]) else None,
-        "macd": round(latest["macd"], 4) if pd.notna(latest["macd"]) else None,
-        "macd_signal": round(latest["macd_signal"], 4) if pd.notna(latest["macd_signal"]) else None,
-        "macd_hist": round(latest["macd_hist"], 4) if pd.notna(latest["macd_hist"]) else None,
+        "rsi": safe_round(latest["rsi"], 2),
+        "sma_20": safe_round(latest["sma_20"], 2),
+        "sma_50": safe_round(latest["sma_50"], 2),
+        "macd": safe_round(latest["macd"], 4),
+        "macd_signal": safe_round(latest["macd_signal"], 4),
+        "macd_hist": safe_round(latest["macd_hist"], 4),
         "macd_signal_dir": macd_dir,
-        "bb_upper": round(latest["bb_upper"], 2) if pd.notna(latest["bb_upper"]) else None,
-        "bb_middle": round(latest["bb_middle"], 2) if pd.notna(latest["bb_middle"]) else None,
-        "bb_lower": round(latest["bb_lower"], 2) if pd.notna(latest["bb_lower"]) else None,
+        "bb_upper": safe_round(latest["bb_upper"], 2),
+        "bb_middle": safe_round(latest["bb_middle"], 2),
+        "bb_lower": safe_round(latest["bb_lower"], 2),
         "bb_position": bb_pos,
     }
 


### PR DESCRIPTION
## Summary
- Adds `safe_round(value, decimals)` to `services/indicators.py` that returns `round(value, decimals)` if non-NaN, else `None`
- Replaces 18 occurrences of `round(x, N) if pd.notna(x) else None` across `indicators.py` and `prices.py`

## Test plan
- [x] All 115 backend tests pass

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)