### PR TITLE
refactor: consolidate period/warmup constants (#154)

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1,0 +1,14 @@
+"""Shared constants for period and indicator warmup calculations."""
+
+# Calendar days for each period string used across price, watchlist, and portfolio endpoints.
+PERIOD_DAYS: dict[str, int] = {
+    "1mo": 30,
+    "3mo": 90,
+    "6mo": 180,
+    "1y": 365,
+    "2y": 730,
+    "5y": 1825,
+}
+
+# Extra calendar days to fetch for indicator warmup (~50 trading days for SMA50).
+WARMUP_DAYS: int = 80


### PR DESCRIPTION
## Summary
- Creates `backend/app/constants.py` with `PERIOD_DAYS` and `WARMUP_DAYS`
- Removes duplicate definitions from `prices.py`, `watchlist.py`, and `portfolio.py`

## Test plan
- [x] All 115 backend tests pass

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)