### PR TITLE
refactor: extract IndicatorSnapshotBase schema (#156)

### DIFF
--- a/backend/app/schemas/price.py
+++ b/backend/app/schemas/price.py
@@ -45,9 +45,8 @@ class EtfHoldingsResponse(BaseModel):
     total_percent: float = Field(description="Sum of top holding weights (may be < 100%)")
 
 
-class HoldingIndicatorResponse(BaseModel):
-    symbol: str = Field(description="Holding ticker symbol")
-    currency: str = Field(default="USD", description="ISO 4217 currency code")
+class IndicatorSnapshotBase(BaseModel):
+    """Shared indicator fields for holding and constituent snapshot responses."""
     close: float | None = Field(default=None, description="Latest closing price")
     change_pct: float | None = Field(default=None, description="1-day percentage change")
     rsi: float | None = Field(default=None, description="RSI (14-period)")
@@ -61,3 +60,8 @@ class HoldingIndicatorResponse(BaseModel):
     bb_middle: float | None = Field(default=None, description="Middle Bollinger Band")
     bb_lower: float | None = Field(default=None, description="Lower Bollinger Band")
     bb_position: str | None = Field(default=None, description="Price position vs Bollinger Bands: 'above', 'upper', 'lower', or 'below'")
+
+
+class HoldingIndicatorResponse(IndicatorSnapshotBase):
+    symbol: str = Field(description="Holding ticker symbol")
+    currency: str = Field(default="USD", description="ISO 4217 currency code")

--- a/backend/app/schemas/pseudo_etf.py
+++ b/backend/app/schemas/pseudo_etf.py
@@ -3,6 +3,7 @@ import datetime
 from pydantic import BaseModel, Field
 
 from app.schemas.asset import AssetResponse
+from app.schemas.price import IndicatorSnapshotBase
 
 
 class PseudoETFCreate(BaseModel):
@@ -45,21 +46,8 @@ class PerformanceBreakdownPoint(BaseModel):
     breakdown: dict[str, float] = Field(default={}, description="Per-symbol contribution to the index value")
 
 
-class ConstituentIndicatorResponse(BaseModel):
+class ConstituentIndicatorResponse(IndicatorSnapshotBase):
     symbol: str = Field(description="Constituent ticker symbol")
     name: str | None = Field(default=None, description="Company name")
     currency: str = Field(default="USD", description="ISO 4217 currency code")
     weight_pct: float | None = Field(default=None, description="Current portfolio weight percentage")
-    close: float | None = Field(default=None, description="Latest closing price")
-    change_pct: float | None = Field(default=None, description="1-day percentage change")
-    rsi: float | None = Field(default=None, description="RSI (14-period)")
-    sma_20: float | None = Field(default=None, description="20-day SMA")
-    sma_50: float | None = Field(default=None, description="50-day SMA")
-    macd: float | None = Field(default=None, description="MACD line")
-    macd_signal: float | None = Field(default=None, description="MACD signal line")
-    macd_hist: float | None = Field(default=None, description="MACD histogram")
-    macd_signal_dir: str | None = Field(default=None, description="MACD direction: 'bullish' or 'bearish'")
-    bb_upper: float | None = Field(default=None, description="Upper Bollinger Band")
-    bb_middle: float | None = Field(default=None, description="Middle Bollinger Band")
-    bb_lower: float | None = Field(default=None, description="Lower Bollinger Band")
-    bb_position: str | None = Field(default=None, description="Price vs Bollinger Bands: 'above', 'upper', 'lower', or 'below'")


### PR DESCRIPTION
## Summary
- Creates `IndicatorSnapshotBase` with 13 shared indicator fields in `schemas/price.py`
- `HoldingIndicatorResponse` and `ConstituentIndicatorResponse` now inherit from it

## Test plan
- [x] All 115 backend tests pass

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)