### PR TITLE
refactor: move compute_and_cache_indicators to service layer (#147)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,8 +14,8 @@ from sqlalchemy import select, text
 from app.database import async_session, engine, Base
 from app.models import Asset  # noqa: F401 - ensure models are imported for create_all
 from app.routers import annotations, assets, groups, holdings, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, tags, thesis, watchlist
-from app.routers.watchlist import compute_and_cache_indicators
 from app.services.price_sync import sync_all_prices
+from app.services.watchlist import compute_and_cache_indicators
 from app.services.yahoo import batch_fetch_currencies
 
 logger = logging.getLogger(__name__)

--- a/backend/app/routers/watchlist.py
+++ b/backend/app/routers/watchlist.py
@@ -4,26 +4,18 @@ These return aggregated data for all watchlisted assets in a single request,
 eliminating the N+1 pattern of fetching prices/indicators per asset card.
 """
 
-import time
 from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select, func
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import pandas as pd
-
-from app.constants import PERIOD_DAYS, WARMUP_DAYS
+from app.constants import PERIOD_DAYS
 from app.database import get_db
 from app.models import Asset, PriceHistory
-from app.services.indicators import compute_indicators
+from app.services.watchlist import compute_and_cache_indicators
 
 router = APIRouter(prefix="/api/watchlist", tags=["watchlist"])
-
-# In-memory cache for batch indicator snapshots.
-# Key: (frozenset of symbols, latest_price_date) — auto-invalidates when prices change.
-_indicator_cache: dict[tuple, tuple[dict, float]] = {}
-_INDICATOR_CACHE_TTL = 600  # 10 minutes
 
 
 @router.get("/sparklines", summary="Batch close prices for sparkline charts")
@@ -89,91 +81,3 @@ async def batch_indicators(
     synced (the latest date changes).
     """
     return await compute_and_cache_indicators(db)
-
-
-async def compute_and_cache_indicators(db: AsyncSession) -> dict[str, dict]:
-    """Compute indicator snapshots for all watchlisted assets, with caching.
-
-    Called by the API endpoint and also by the nightly cron to warm the cache.
-    """
-    assets_result = await db.execute(
-        select(Asset.id, Asset.symbol).where(Asset.watchlisted == True)  # noqa: E712
-    )
-    asset_rows = assets_result.all()
-    if not asset_rows:
-        return {}
-
-    asset_ids = [r.id for r in asset_rows]
-    id_to_symbol = {r.id: r.symbol for r in asset_rows}
-
-    # Build cache key: symbols + latest price date
-    latest_date_result = await db.execute(
-        select(func.max(PriceHistory.date)).where(PriceHistory.asset_id.in_(asset_ids))
-    )
-    latest_date = latest_date_result.scalar()
-    cache_key = (frozenset(id_to_symbol.values()), latest_date)
-
-    cached = _indicator_cache.get(cache_key)
-    if cached and time.monotonic() - cached[1] < _INDICATOR_CACHE_TTL:
-        return cached[0]
-
-    # Fetch enough history for indicator warmup (SMA50 needs ~50 trading days)
-    warmup_start = date.today() - timedelta(days=PERIOD_DAYS["3mo"] + WARMUP_DAYS)
-
-    prices_result = await db.execute(
-        select(PriceHistory)
-        .where(
-            PriceHistory.asset_id.in_(asset_ids),
-            PriceHistory.date >= warmup_start,
-        )
-        .order_by(PriceHistory.asset_id, PriceHistory.date)
-    )
-    all_prices = prices_result.scalars().all()
-
-    # Group prices by asset
-    grouped: dict[int, list[PriceHistory]] = {}
-    for p in all_prices:
-        grouped.setdefault(p.asset_id, []).append(p)
-
-    out: dict[str, dict] = {}
-    for asset_id, symbol in id_to_symbol.items():
-        prices = grouped.get(asset_id, [])
-        if len(prices) < 26:  # Need at least MACD slow period
-            out[symbol] = {"rsi": None, "macd": None, "macd_signal": None, "macd_hist": None}
-            continue
-
-        df = pd.DataFrame([{
-            "date": p.date,
-            "close": float(p.close),
-        } for p in prices]).set_index("date")
-
-        indicators = compute_indicators(df)
-
-        # Get last row with non-null RSI
-        rsi_val = None
-        for _, row in indicators.iloc[::-1].iterrows():
-            if pd.notna(row["rsi"]):
-                rsi_val = round(row["rsi"], 2)
-                break
-
-        # Get last row with non-null MACD triplet
-        macd_val = macd_sig = macd_hist = None
-        for _, row in indicators.iloc[::-1].iterrows():
-            if pd.notna(row["macd"]) and pd.notna(row["macd_signal"]) and pd.notna(row["macd_hist"]):
-                macd_val = round(row["macd"], 4)
-                macd_sig = round(row["macd_signal"], 4)
-                macd_hist = round(row["macd_hist"], 4)
-                break
-
-        out[symbol] = {
-            "rsi": rsi_val,
-            "macd": macd_val,
-            "macd_signal": macd_sig,
-            "macd_hist": macd_hist,
-        }
-
-    # Store in cache (single-entry — only latest key matters)
-    _indicator_cache.clear()
-    _indicator_cache[cache_key] = (out, time.monotonic())
-
-    return out

--- a/backend/app/services/watchlist.py
+++ b/backend/app/services/watchlist.py
@@ -1,0 +1,106 @@
+"""Batch indicator computation for the watchlist page."""
+
+import time
+from datetime import date, timedelta
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import pandas as pd
+
+from app.constants import PERIOD_DAYS, WARMUP_DAYS
+from app.models import Asset, PriceHistory
+from app.services.indicators import compute_indicators
+
+# In-memory cache for batch indicator snapshots.
+# Key: (frozenset of symbols, latest_price_date) — auto-invalidates when prices change.
+_indicator_cache: dict[tuple, tuple[dict, float]] = {}
+_INDICATOR_CACHE_TTL = 600  # 10 minutes
+
+
+async def compute_and_cache_indicators(db: AsyncSession) -> dict[str, dict]:
+    """Compute indicator snapshots for all watchlisted assets, with caching.
+
+    Called by the API endpoint and also by the nightly cron to warm the cache.
+    """
+    assets_result = await db.execute(
+        select(Asset.id, Asset.symbol).where(Asset.watchlisted == True)  # noqa: E712
+    )
+    asset_rows = assets_result.all()
+    if not asset_rows:
+        return {}
+
+    asset_ids = [r.id for r in asset_rows]
+    id_to_symbol = {r.id: r.symbol for r in asset_rows}
+
+    # Build cache key: symbols + latest price date
+    latest_date_result = await db.execute(
+        select(func.max(PriceHistory.date)).where(PriceHistory.asset_id.in_(asset_ids))
+    )
+    latest_date = latest_date_result.scalar()
+    cache_key = (frozenset(id_to_symbol.values()), latest_date)
+
+    cached = _indicator_cache.get(cache_key)
+    if cached and time.monotonic() - cached[1] < _INDICATOR_CACHE_TTL:
+        return cached[0]
+
+    # Fetch enough history for indicator warmup (SMA50 needs ~50 trading days)
+    warmup_start = date.today() - timedelta(days=PERIOD_DAYS["3mo"] + WARMUP_DAYS)
+
+    prices_result = await db.execute(
+        select(PriceHistory)
+        .where(
+            PriceHistory.asset_id.in_(asset_ids),
+            PriceHistory.date >= warmup_start,
+        )
+        .order_by(PriceHistory.asset_id, PriceHistory.date)
+    )
+    all_prices = prices_result.scalars().all()
+
+    # Group prices by asset
+    grouped: dict[int, list[PriceHistory]] = {}
+    for p in all_prices:
+        grouped.setdefault(p.asset_id, []).append(p)
+
+    out: dict[str, dict] = {}
+    for asset_id, symbol in id_to_symbol.items():
+        prices = grouped.get(asset_id, [])
+        if len(prices) < 26:  # Need at least MACD slow period
+            out[symbol] = {"rsi": None, "macd": None, "macd_signal": None, "macd_hist": None}
+            continue
+
+        df = pd.DataFrame([{
+            "date": p.date,
+            "close": float(p.close),
+        } for p in prices]).set_index("date")
+
+        indicators = compute_indicators(df)
+
+        # Get last row with non-null RSI
+        rsi_val = None
+        for _, row in indicators.iloc[::-1].iterrows():
+            if pd.notna(row["rsi"]):
+                rsi_val = round(row["rsi"], 2)
+                break
+
+        # Get last row with non-null MACD triplet
+        macd_val = macd_sig = macd_hist = None
+        for _, row in indicators.iloc[::-1].iterrows():
+            if pd.notna(row["macd"]) and pd.notna(row["macd_signal"]) and pd.notna(row["macd_hist"]):
+                macd_val = round(row["macd"], 4)
+                macd_sig = round(row["macd_signal"], 4)
+                macd_hist = round(row["macd_hist"], 4)
+                break
+
+        out[symbol] = {
+            "rsi": rsi_val,
+            "macd": macd_val,
+            "macd_signal": macd_sig,
+            "macd_hist": macd_hist,
+        }
+
+    # Store in cache (single-entry — only latest key matters)
+    _indicator_cache.clear()
+    _indicator_cache[cache_key] = (out, time.monotonic())
+
+    return out


### PR DESCRIPTION
## Summary
- Creates `services/watchlist.py` with the `compute_and_cache_indicators` function
- Thins `routers/watchlist.py` to just endpoint definitions
- Updates `main.py` to import from the service, eliminating the router→main backwards dependency

## Test plan
- [x] All 115 backend tests pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)