### PR TITLE
refactor: extract batch indicator snapshot computation into service

### DIFF
--- a/backend/tests/test_holdings.py
+++ b/backend/tests/test_holdings.py
@@ -68,7 +68,8 @@ async def test_holdings_indicators_success(client):
 
     with (
         patch("app.routers.holdings.fetch_etf_holdings", return_value=_MOCK_HOLDINGS),
-        patch("app.routers.holdings.batch_fetch_history", return_value=histories),
+        patch("app.services.indicators.batch_fetch_history", return_value=histories),
+        patch("app.services.indicators.batch_fetch_currencies", return_value={"AAPL": "USD", "MSFT": "USD"}),
     ):
         resp = await client.get("/api/assets/SPY/holdings/indicators")
 


### PR DESCRIPTION
## Summary
- Adds `compute_batch_indicator_snapshots(symbols)` to `services/indicators.py`
- Replaces duplicated fetch-history + compute-indicators loops in both `holdings.py` and `pseudo_etf_analysis.py`
- Updates test mocks to target the new function location

Closes #148

## Test plan
- [x] All 115 backend tests pass
- [x] Holdings indicator and pseudo-ETF constituent indicator endpoints use shared function

🤖 Generated with [Claude Code](https://claude.com/claude-code)