### PR TITLE
refactor: extract shared PeriodSelector component

### DIFF
--- a/frontend/src/components/period-selector.tsx
+++ b/frontend/src/components/period-selector.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/ui/button"
+
+const DEFAULT_PERIODS = ["1mo", "3mo", "6mo", "1y", "2y", "5y"] as const
+
+interface PeriodSelectorProps {
+  value: string
+  onChange: (period: string) => void
+  periods?: readonly string[]
+}
+
+export function PeriodSelector({
+  value,
+  onChange,
+  periods = DEFAULT_PERIODS,
+}: PeriodSelectorProps) {
+  return (
+    <div className="flex gap-1">
+      {periods.map((p) => (
+        <Button
+          key={p}
+          variant={value === p ? "default" : "ghost"}
+          size="sm"
+          onClick={() => onChange(p)}
+          className="text-xs"
+        >
+          {p}
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -8,6 +8,7 @@ import { ChartSkeleton } from "@/components/chart-skeleton"
 import { ThesisEditor } from "@/components/thesis-editor"
 import { AnnotationsList } from "@/components/annotations-list"
 import { TagInput } from "@/components/tag-input"
+import { PeriodSelector } from "@/components/period-selector"
 import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
 import { buildYahooFinanceUrl, formatPrice } from "@/lib/format"
 import { useQuotes } from "@/lib/quote-stream"
@@ -29,7 +30,6 @@ import {
 } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
 
-const PERIODS = ["1mo", "3mo", "6mo", "1y", "2y", "5y"] as const
 
 export function AssetDetailPage() {
   const { symbol } = useParams<{ symbol: string }>()
@@ -141,19 +141,7 @@ function Header({
         )}
       </div>
       <div className="flex items-center gap-2">
-        <div className="flex gap-1">
-          {PERIODS.map((p) => (
-            <Button
-              key={p}
-              variant={period === p ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setPeriod(p)}
-              className="text-xs"
-            >
-              {p}
-            </Button>
-          ))}
-        </div>
+        <PeriodSelector value={period} onChange={setPeriod} />
         {isWatchlisted && (
           <Button
             variant="outline"

--- a/frontend/src/pages/portfolio.tsx
+++ b/frontend/src/pages/portfolio.tsx
@@ -2,15 +2,13 @@ import { useEffect, useRef, useState } from "react"
 import { createChart, type IChartApi, ColorType, AreaSeries } from "lightweight-charts"
 import { Link } from "react-router-dom"
 import { Loader2, TrendingUp, TrendingDown } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ChartSkeleton } from "@/components/chart-skeleton"
+import { PeriodSelector } from "@/components/period-selector"
 import { usePortfolioIndex, usePortfolioPerformers, usePrefetchAssetDetail } from "@/lib/queries"
 import { getChartTheme, useChartTheme, chartThemeOptions } from "@/lib/chart-utils"
 import type { AssetPerformance } from "@/lib/api"
-
-const PERIODS = ["1mo", "3mo", "6mo", "1y", "2y", "5y"] as const
 
 export function PortfolioPage() {
   const [period, setPeriod] = useState<string>("1y")
@@ -19,18 +17,8 @@ export function PortfolioPage() {
 
   return (
     <div className="p-6 space-y-8">
-      <div className="flex justify-center gap-1">
-        {PERIODS.map((p) => (
-          <Button
-            key={p}
-            variant={period === p ? "default" : "ghost"}
-            size="sm"
-            onClick={() => setPeriod(p)}
-            className="text-xs"
-          >
-            {p}
-          </Button>
-        ))}
+      <div className="flex justify-center">
+        <PeriodSelector value={period} onChange={setPeriod} />
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
## Summary
- Creates `PeriodSelector` component with default periods array and optional custom list
- Replaces duplicated PERIODS + button groups in `asset-detail.tsx` and `portfolio.tsx`
- Removes unused `Button` import from `portfolio.tsx`

Closes #151

## Test plan
- [x] `pnpm build` passes
- [x] Period selection renders identically in both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)