### PR TITLE
refactor: extract AssetActionMenu component

### DIFF
--- a/frontend/src/components/asset-action-menu.tsx
+++ b/frontend/src/components/asset-action-menu.tsx
@@ -1,0 +1,42 @@
+import { MoreVertical, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface AssetActionMenuProps {
+  onDelete: () => void
+  triggerClassName?: string
+}
+
+export function AssetActionMenu({ onDelete, triggerClassName = "" }: AssetActionMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={`transition-opacity ${triggerClassName}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+        >
+          <Trash2 className="h-3.5 w-3.5 mr-2" />
+          Remove
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/watchlist-table.tsx
+++ b/frontend/src/components/watchlist-table.tsx
@@ -1,16 +1,10 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
-import { ChevronRight, ChevronDown, MoreVertical, Trash2 } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { ChevronRight, ChevronDown } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import { TagBadge } from "@/components/tag-badge"
+import { AssetActionMenu } from "@/components/asset-action-menu"
 import { PriceChart } from "@/components/price-chart"
 import { RsiGauge } from "@/components/rsi-gauge"
 import { MacdIndicator } from "@/components/macd-indicator"
@@ -291,30 +285,10 @@ function TableRow({
           )}
         </td>
         <td className={`${py} pr-2`}>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                className="text-destructive focus:text-destructive"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onDelete()
-                }}
-              >
-                <Trash2 className="h-3.5 w-3.5 mr-2" />
-                Remove
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <AssetActionMenu
+            onDelete={onDelete}
+            triggerClassName="h-6 w-6 opacity-0 group-hover:opacity-100"
+          />
         </td>
       </tr>
       {expanded && (

--- a/frontend/src/pages/watchlist.tsx
+++ b/frontend/src/pages/watchlist.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
-import { ArrowDownAZ, ArrowUpAZ, LayoutGrid, MoreVertical, Table, Trash2, TrendingUp } from "lucide-react"
+import { ArrowDownAZ, ArrowUpAZ, LayoutGrid, Table, TrendingUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge"
 import { SegmentedControl } from "@/components/ui/segmented-control"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AddSymbolDialog } from "@/components/add-symbol-dialog"
+import { AssetActionMenu } from "@/components/asset-action-menu"
 import { useAssets, useDeleteAsset, useTags, useWatchlistSparklines, useWatchlistIndicators, usePrefetchAssetDetail } from "@/lib/queries"
 import { useQuotes } from "@/lib/quote-stream"
 import { SparklineChart } from "@/components/sparkline"
@@ -263,30 +264,10 @@ function AssetCard({
 
   return (
     <Card className="group relative hover:border-primary/50 transition-colors" onMouseEnter={onHover}>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="absolute right-2 top-2 h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity z-10"
-            onClick={(e) => e.preventDefault()}
-          >
-            <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="min-w-48">
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
-            onClick={(e) => {
-              e.preventDefault()
-              onDelete()
-            }}
-          >
-            <Trash2 className="h-3.5 w-3.5 mr-2" />
-            Remove
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <AssetActionMenu
+        onDelete={onDelete}
+        triggerClassName="absolute right-2 top-2 h-7 w-7 opacity-0 group-hover:opacity-100 z-10"
+      />
       <Link to={`/asset/${symbol}`}>
         <CardHeader className="pb-2">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Creates `AssetActionMenu` component with configurable trigger styling via `triggerClassName`
- Replaces inline dropdown menus in both watchlist card and table views
- Consistent event handling (stopPropagation) across both contexts

Closes #158

## Test plan
- [x] `pnpm build` passes
- [x] Action menu appears on hover in both card and table views

🤖 Generated with [Claude Code](https://claude.com/claude-code)