### PR TITLE
perf: unblock event loop and cache indicators for faster detail page

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -44,7 +46,7 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     currency = "USD"
 
     if not name:
-        info = validate_symbol(symbol)
+        info = await asyncio.to_thread(validate_symbol, symbol)
         if not info:
             raise HTTPException(404, f"Symbol {symbol} not found on Yahoo Finance")
         name = info["name"]

--- a/backend/app/routers/pseudo_etf_analysis.py
+++ b/backend/app/routers/pseudo_etf_analysis.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,7 +49,7 @@ async def get_constituent_indicators(etf_id: int, db: AsyncSession = Depends(get
     symbols = [a.symbol for a in etf.constituents]
     symbol_to_name = {a.symbol: a.name for a in etf.constituents}
 
-    snapshots = compute_batch_indicator_snapshots(symbols)
+    snapshots = await asyncio.to_thread(compute_batch_indicator_snapshots, symbols)
     return [
         ConstituentIndicatorResponse(
             **s,

--- a/backend/app/routers/quotes.py
+++ b/backend/app/routers/quotes.py
@@ -26,7 +26,7 @@ async def get_quotes(symbols: str = Query(..., description="Comma-separated list
     symbol_list = [s.strip().upper() for s in symbols.split(",") if s.strip()]
     if not symbol_list:
         return []
-    return batch_fetch_quotes(symbol_list)
+    return await asyncio.to_thread(batch_fetch_quotes, symbol_list)
 
 
 async def _quote_event_generator():

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -1,5 +1,6 @@
 """Sync price data from Yahoo Finance to the database."""
 
+import asyncio
 from datetime import date
 
 import pandas as pd
@@ -13,7 +14,7 @@ from app.services.yahoo import fetch_history, batch_fetch_history
 
 async def sync_asset_prices(db: AsyncSession, asset: Asset, period: str = "3mo") -> int:
     """Fetch and upsert price data for a single asset. Returns number of rows upserted."""
-    df = fetch_history(asset.symbol, period=period)
+    df = await asyncio.to_thread(fetch_history, asset.symbol, period=period)
     return await _upsert_prices(db, asset.id, df)
 
 
@@ -21,7 +22,7 @@ async def sync_asset_prices_range(
     db: AsyncSession, asset: Asset, start: date, end: date
 ) -> int:
     """Fetch and upsert price data for a date range. Returns number of rows upserted."""
-    df = fetch_history(asset.symbol, start=start, end=end)
+    df = await asyncio.to_thread(fetch_history, asset.symbol, start=start, end=end)
     return await _upsert_prices(db, asset.id, df)
 
 
@@ -35,7 +36,7 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
 
     symbols = [a.symbol for a in assets]
     asset_map = {a.symbol: a.id for a in assets}
-    data = batch_fetch_history(symbols, period=period)
+    data = await asyncio.to_thread(batch_fetch_history, symbols, period=period)
 
     counts = {}
     for sym, df in data.items():


### PR DESCRIPTION
## Summary
- Wrapped all synchronous Yahoo Finance calls (`fetch_history`, `validate_symbol`, `fetch_etf_holdings`, `batch_fetch_quotes`, `compute_batch_indicator_snapshots`) in `asyncio.to_thread()` to prevent blocking the async event loop
- Added in-memory TTL cache (5 min) for computed indicator responses, keyed by `symbol:period:last_price_date` for automatic invalidation on new data
- Added per-symbol `asyncio.Lock` in `_ensure_prices()` to prevent duplicate Yahoo fetches when `/prices` and `/indicators` endpoints are called concurrently

Closes #109

## Test plan
- [x] All 115 backend tests pass
- [x] Frontend builds
- [ ] Verify asset detail page loads faster on repeat visits (indicator cache hit)
- [ ] Verify Yahoo calls don't block other concurrent API requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)