### PR TITLE
fix: prefetch was caching under wrong keys, causing wasted requests

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11,11 +11,9 @@ import type {
   GroupCreate,
   GroupUpdate,
   HoldingIndicator,
-  Indicator,
   IndicatorSummary,
   PerformanceBreakdownPoint,
   PortfolioIndex,
-  Price,
   PseudoETF,
   PseudoETFCreate,
   PseudoETFUpdate,
@@ -72,10 +70,6 @@ export const api = {
       request<void>(`/assets/${symbol}`, { method: "DELETE" }),
   },
   prices: {
-    list: (symbol: string, period?: string) =>
-      request<Price[]>(`/assets/${symbol}/prices${qs({ period })}`),
-    indicators: (symbol: string, period?: string) =>
-      request<Indicator[]>(`/assets/${symbol}/indicators${qs({ period })}`),
     detail: (symbol: string, period?: string) =>
       request<AssetDetail>(`/assets/${symbol}/detail${qs({ period })}`),
     refresh: (symbol: string, period?: string) =>


### PR DESCRIPTION
## Summary
- `prefetchAssetDetail` fired 2 requests per asset (`/prices` + `/indicators`) cached under `keys.prices`/`keys.indicators`, but the detail page reads from `keys.assetDetail` (`/detail` endpoint) — prefetched data was never consumed
- Now prefetches the correct `/detail` endpoint (1 request instead of 2, and the cache actually gets used on click-through)
- Removed dead code: `usePrices`, `useIndicators`, `api.prices.list`, `api.prices.indicators`, and orphaned cache keys
- Fixed `useRefreshPrices` to invalidate `keys.assetDetail` so refresh actually works

## Test plan
- [x] `pnpm build` passes
- [ ] Hover over watchlist card → only 1 `/detail` request fires (not 2 `/prices` + `/indicators`)
- [ ] Click through to asset detail → page loads instantly from prefetched cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)