### PR TITLE
chore: migrate in-app DDL migrations to Alembic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,11 @@ Tests seed ~500 days of price data to avoid triggering Yahoo Finance sync (the b
 
 ## Database
 
-PostgreSQL with async SQLAlchemy. Schema is managed via `Base.metadata.create_all()` on startup plus `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` in the lifespan function for incremental migrations.
+PostgreSQL with async SQLAlchemy. Schema is managed via **Alembic** migrations (`backend/alembic/`). `alembic upgrade head` runs automatically on container startup (before uvicorn). The initial migration (`0001`) is idempotent — it detects existing tables and skips creation, so it works for both fresh and pre-existing databases.
+
+To create a new migration after model changes:
+```bash
+docker compose exec backend alembic revision --autogenerate -m "description"
+```
 
 DB credentials: `fibenchi/fibenchi@db:5432/fibenchi` (dev only).

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY backend/ .
 COPY --from=frontend-build /build/dist ./static
 
 EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,4 +9,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["sh", "-c", "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,12 +1,19 @@
 import asyncio
+import sys
 from logging.config import fileConfig
+from pathlib import Path
 
 from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-from app.database import Base
-from app.config import settings
+# Ensure the backend root (/app) is on sys.path so `app.*` imports resolve
+# when alembic is invoked as a CLI command.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.database import Base  # noqa: E402
+from app.config import settings  # noqa: E402
+import app.models  # noqa: E402,F401 — register all models with Base.metadata
 
 config = context.config
 config.set_main_option("sqlalchemy.url", settings.database_url)

--- a/backend/alembic/versions/0001_initial_schema.py
+++ b/backend/alembic/versions/0001_initial_schema.py
@@ -1,0 +1,236 @@
+"""Initial schema
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-02-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Idempotent: skip if tables already exist (existing database being migrated
+    # to Alembic). The alembic_version table is still stamped so future
+    # migrations apply normally.
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "assets" in inspector.get_table_names():
+        return
+
+    # -- Independent tables --
+
+    op.create_table(
+        "assets",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("symbol", sa.String(20), nullable=False),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("type", sa.Enum("stock", "etf", name="assettype"), nullable=False),
+        sa.Column("watchlisted", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("currency", sa.String(10), nullable=False, server_default="EUR"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("symbol"),
+    )
+    op.create_index("ix_assets_symbol", "assets", ["symbol"])
+
+    op.create_table(
+        "groups",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("description", sa.String(500), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "tags",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(50), nullable=False),
+        sa.Column("color", sa.String(7), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "pseudo_etfs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("base_date", sa.Date(), nullable=False),
+        sa.Column("base_value", sa.Numeric(12, 4), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_index("ix_pseudo_etfs_name", "pseudo_etfs", ["name"])
+
+    op.create_table(
+        "user_settings",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("data", sa.JSON(), nullable=False),
+    )
+
+    # -- Tables with foreign keys to assets --
+
+    op.create_table(
+        "price_history",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "asset_id",
+            sa.Integer(),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("open", sa.Numeric(12, 4), nullable=False),
+        sa.Column("high", sa.Numeric(12, 4), nullable=False),
+        sa.Column("low", sa.Numeric(12, 4), nullable=False),
+        sa.Column("close", sa.Numeric(12, 4), nullable=False),
+        sa.Column("volume", sa.Integer(), nullable=False),
+        sa.UniqueConstraint("asset_id", "date", name="uq_asset_date"),
+    )
+    op.create_index("ix_price_history_asset_id", "price_history", ["asset_id"])
+    op.create_index("ix_price_history_date", "price_history", ["date"])
+
+    op.create_table(
+        "theses",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "asset_id",
+            sa.Integer(),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("asset_id"),
+    )
+
+    op.create_table(
+        "annotations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "asset_id",
+            sa.Integer(),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("color", sa.String(7), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+    )
+    op.create_index("ix_annotations_asset_id", "annotations", ["asset_id"])
+
+    # -- Association tables --
+
+    op.create_table(
+        "group_assets",
+        sa.Column(
+            "group_id",
+            sa.Integer(),
+            sa.ForeignKey("groups.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "asset_id",
+            sa.Integer(),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+
+    op.create_table(
+        "tag_assets",
+        sa.Column(
+            "tag_id",
+            sa.Integer(),
+            sa.ForeignKey("tags.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "asset_id",
+            sa.Integer(),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+
+    op.create_table(
+        "pseudo_etf_constituents",
+        sa.Column(
+            "pseudo_etf_id",
+            sa.Integer(),
+            sa.ForeignKey("pseudo_etfs.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "asset_id",
+            sa.Integer(),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+
+    # -- Pseudo-ETF dependent tables --
+
+    op.create_table(
+        "pseudo_etf_theses",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "pseudo_etf_id",
+            sa.Integer(),
+            sa.ForeignKey("pseudo_etfs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("pseudo_etf_id"),
+    )
+
+    op.create_table(
+        "pseudo_etf_annotations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "pseudo_etf_id",
+            sa.Integer(),
+            sa.ForeignKey("pseudo_etfs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("color", sa.String(7), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_pseudo_etf_annotations_pseudo_etf_id",
+        "pseudo_etf_annotations",
+        ["pseudo_etf_id"],
+    )
+
+
+def downgrade() -> None:
+    # Drop in reverse dependency order
+    op.drop_table("pseudo_etf_annotations")
+    op.drop_table("pseudo_etf_theses")
+    op.drop_table("pseudo_etf_constituents")
+    op.drop_table("tag_assets")
+    op.drop_table("group_assets")
+    op.drop_table("annotations")
+    op.drop_table("theses")
+    op.drop_table("price_history")
+    op.drop_table("user_settings")
+    op.drop_table("pseudo_etfs")
+    op.drop_table("tags")
+    op.drop_table("groups")
+    op.drop_table("assets")
+    sa.Enum(name="assettype").drop(op.get_bind())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,14 +9,11 @@ from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
 from app.config import settings as app_settings
-from sqlalchemy import select, text
 
-from app.database import async_session, engine, Base
-from app.models import Asset  # noqa: F401 - ensure models are imported for create_all
+from app.database import async_session, engine
 from app.routers import annotations, assets, groups, holdings, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, tags, thesis, watchlist
 from app.services.price_sync import sync_all_prices
 from app.services.compute.watchlist import compute_and_cache_indicators
-from app.services.yahoo import batch_fetch_currencies
 
 logger = logging.getLogger(__name__)
 scheduler = AsyncIOScheduler()
@@ -45,37 +42,6 @@ async def scheduled_refresh():
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-        # Migration: add watchlisted column to existing assets table
-        await conn.execute(text(
-            "ALTER TABLE assets ADD COLUMN IF NOT EXISTS watchlisted BOOLEAN DEFAULT TRUE NOT NULL"
-        ))
-        # Migration: add currency column to existing assets table
-        await conn.execute(text(
-            "ALTER TABLE assets ADD COLUMN IF NOT EXISTS currency VARCHAR(10) DEFAULT 'USD' NOT NULL"
-        ))
-
-    # Backfill currencies for existing assets that still have the default "USD"
-    async with async_session() as db:
-        result = await db.execute(select(Asset).where(Asset.currency == "USD"))
-        usd_assets = result.scalars().all()
-        if usd_assets:
-            symbols = [a.symbol for a in usd_assets]
-            try:
-                currencies = batch_fetch_currencies(symbols)
-                updated = 0
-                for asset in usd_assets:
-                    fetched = currencies.get(asset.symbol)
-                    if fetched and fetched != "USD":
-                        asset.currency = fetched
-                        updated += 1
-                if updated:
-                    await db.commit()
-                    logger.info(f"Backfilled currency for {updated} assets")
-            except Exception:
-                logger.exception("Currency backfill failed (non-fatal)")
-
     # Parse cron expression (minute hour day month dow)
     parts = app_settings.refresh_cron.split()
     if len(parts) == 5:


### PR DESCRIPTION
## Summary
- Replace `Base.metadata.create_all()` and `ALTER TABLE IF NOT EXISTS` statements in the lifespan handler with proper Alembic migrations
- Initial migration (`0001`) is idempotent — detects existing tables and skips creation, handling both fresh and pre-existing databases
- `alembic upgrade head` runs automatically on container startup (before uvicorn) in both dev and production Dockerfiles

## Changes
- `backend/alembic/versions/0001_initial_schema.py` — baseline migration for all 13 tables
- `backend/alembic/env.py` — fix sys.path for CLI imports, register all models for `--autogenerate`
- `backend/app/main.py` — remove `create_all`, `ALTER TABLE` DDL, and currency backfill from lifespan
- `backend/Dockerfile` + root `Dockerfile` — run `alembic upgrade head` before uvicorn
- `CLAUDE.md` — update database section to reflect new migration workflow

Closes #140

## Test plan
- [x] All 242 backend tests pass
- [x] `alembic upgrade head` succeeds on existing database (idempotent check works)
- [x] Container startup shows alembic running before uvicorn
- [x] API health check returns OK after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)