### PR TITLE
feat: add market status indicator dot to watchlist and asset detail (#185)

### DIFF
--- a/frontend/src/components/market-status-dot.tsx
+++ b/frontend/src/components/market-status-dot.tsx
@@ -1,0 +1,43 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+const STATE_CONFIG: Record<string, { color: string; label: string }> = {
+  PRE: { color: "bg-blue-500", label: "Pre-market" },
+  PREPRE: { color: "bg-blue-500", label: "Pre-market" },
+  REGULAR: { color: "bg-emerald-500", label: "Market open" },
+  POST: { color: "bg-orange-500", label: "After-hours" },
+  POSTPOST: { color: "bg-orange-500", label: "After-hours" },
+  CLOSED: { color: "bg-red-500", label: "Closed" },
+}
+
+const DEFAULT_CONFIG = { color: "bg-red-500", label: "Closed" }
+
+export function MarketStatusDot({
+  marketState,
+  className,
+}: {
+  marketState: string | null | undefined
+  className?: string
+}) {
+  const config = (marketState && STATE_CONFIG[marketState]) || DEFAULT_CONFIG
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn("inline-block h-2 w-2 rounded-full shrink-0", config.color, className)}
+          />
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {config.label}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/frontend/src/components/watchlist-table.tsx
+++ b/frontend/src/components/watchlist-table.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import { TagBadge } from "@/components/tag-badge"
 import { AssetActionMenu } from "@/components/asset-action-menu"
+import { MarketStatusDot } from "@/components/market-status-dot"
 import { PriceChart } from "@/components/price-chart"
 import { RsiGauge } from "@/components/rsi-gauge"
 import { MacdIndicator } from "@/components/macd-indicator"
@@ -211,6 +212,7 @@ function TableRow({
         </td>
         <td className={`${py} px-3`}>
           <div className="flex items-center gap-2">
+            <MarketStatusDot marketState={quote?.market_state} />
             <Link
               to={`/asset/${asset.symbol}`}
               className="font-semibold hover:underline"

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -11,6 +11,7 @@ import { AnnotationsList } from "@/components/annotations-list"
 import { TagInput } from "@/components/tag-input"
 import { PeriodSelector } from "@/components/period-selector"
 import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
+import { MarketStatusDot } from "@/components/market-status-dot"
 import { buildYahooFinanceUrl, formatPrice } from "@/lib/format"
 import { useQuotes } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
@@ -99,7 +100,10 @@ function Header({
           </Button>
         </Link>
         <div>
-          <h1 className="text-2xl font-bold">{symbol}</h1>
+          <div className="flex items-center gap-2">
+            <MarketStatusDot marketState={quote?.market_state} className="h-2.5 w-2.5" />
+            <h1 className="text-2xl font-bold">{symbol}</h1>
+          </div>
           {name && <p className="text-sm text-muted-foreground">{name}</p>}
         </div>
         {price != null && (

--- a/frontend/src/pages/watchlist.tsx
+++ b/frontend/src/pages/watchlist.tsx
@@ -14,6 +14,7 @@ import { SegmentedControl } from "@/components/ui/segmented-control"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AddSymbolDialog } from "@/components/add-symbol-dialog"
 import { AssetActionMenu } from "@/components/asset-action-menu"
+import { MarketStatusDot } from "@/components/market-status-dot"
 import { useAssets, useDeleteAsset, useTags, useWatchlistSparklines, useWatchlistIndicators, usePrefetchAssetDetail } from "@/lib/queries"
 import { useQuotes } from "@/lib/quote-stream"
 import { SparklineChart } from "@/components/sparkline"
@@ -271,6 +272,7 @@ function AssetCard({
       <Link to={`/asset/${symbol}`}>
         <CardHeader className="pb-2">
           <div className="flex items-center gap-2">
+            <MarketStatusDot marketState={quote?.market_state} />
             <CardTitle className="text-base">{symbol}</CardTitle>
             <Badge variant="secondary" className="text-xs">
               {type}


### PR DESCRIPTION
## Summary
- New `MarketStatusDot` component with color-coded dot + tooltip for market state
- Color mapping: green (open), blue (pre-market), orange (after-hours), red (closed)
- Added to card view (next to symbol), table view (next to symbol), and asset detail header

## Test plan
- [ ] Lint clean (`pnpm lint`)
- [ ] Build passes (`pnpm build`)
- [ ] Visual check: dots appear in card view, table view, and asset detail page
- [ ] Tooltip shows correct label on hover

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)