### PR TITLE
chore: speed up Docker build with BuildKit layer caching (#191)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,9 +71,13 @@ jobs:
             type=sha
             type=raw,value=latest
 
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -r requirements.txt
 
 COPY backend/ .
 COPY --from=frontend-build /build/dist ./static


### PR DESCRIPTION
## Summary
- Added `docker/setup-buildx-action@v3` for BuildKit support
- Configured `cache-from: type=gha` and `cache-to: type=gha,mode=max` for GitHub Actions cache
- Removed `--no-cache-dir` from pip install in Dockerfile (layer caching makes it redundant)

## Test plan
- [ ] CI workflow passes on PR
- [ ] Docker image builds correctly on merge
- [ ] Subsequent builds with unchanged deps should be faster

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)