### PR TITLE
feat: persist symbol directory in database for faster autocomplete (#193)

### DIFF
--- a/backend/alembic/versions/0002_add_symbol_directory.py
+++ b/backend/alembic/versions/0002_add_symbol_directory.py
@@ -1,0 +1,35 @@
+"""Add symbol_directory table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-02-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "symbol_directory",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("symbol", sa.String(20), nullable=False),
+        sa.Column("name", sa.String(300), nullable=False),
+        sa.Column("exchange", sa.String(100), nullable=False, server_default=""),
+        sa.Column("type", sa.String(10), nullable=False, server_default="stock"),
+        sa.Column("last_seen", sa.DateTime(), server_default=sa.func.now()),
+    )
+    op.create_index("ix_symbol_directory_symbol", "symbol_directory", ["symbol"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_symbol_directory_symbol", table_name="symbol_directory")
+    op.drop_table("symbol_directory")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,3 +6,4 @@ from app.models.thesis import Thesis  # noqa: F401
 from app.models.tag import Tag, tag_assets  # noqa: F401
 from app.models.pseudo_etf import PseudoETF, PseudoEtfAnnotation, PseudoEtfThesis, pseudo_etf_constituents  # noqa: F401
 from app.models.user_settings import UserSettings  # noqa: F401
+from app.models.symbol_directory import SymbolDirectory  # noqa: F401

--- a/backend/app/models/symbol_directory.py
+++ b/backend/app/models/symbol_directory.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class SymbolDirectory(Base):
+    __tablename__ = "symbol_directory"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    symbol: Mapped[str] = mapped_column(String(20), unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(300))
+    exchange: Mapped[str] = mapped_column(String(100), default="")
+    type: Mapped[str] = mapped_column(String(10), default="stock")
+    last_seen: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,11 +1,16 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db
 from app.services import search_service
 
 router = APIRouter(prefix="/api/search", tags=["search"])
 
 
 @router.get("")
-async def search_symbols(q: str = Query(..., min_length=1, max_length=50)):
+async def search_symbols(
+    q: str = Query(..., min_length=1, max_length=50),
+    db: AsyncSession = Depends(get_db),
+):
     """Search for ticker symbols by name or symbol prefix."""
-    return await search_service.search_symbols(q)
+    return await search_service.search_symbols(q, db)

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -1,39 +1,81 @@
-"""Search business logic — symbol search with TTL cache."""
+"""Search business logic — DB-backed symbol directory with Yahoo fallback."""
 
-import time
+from datetime import datetime, timezone
 
+from sqlalchemy import or_, select, func as sa_func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.symbol_directory import SymbolDirectory
 from app.services.yahoo import search as yahoo_search
 
-# Simple TTL cache: query -> (results, timestamp)
-_cache: dict[str, tuple[list, float]] = {}
-_CACHE_TTL = 300  # 5 minutes
-_CACHE_MAX = 200  # evict oldest when exceeded
+_MIN_LOCAL_RESULTS = 8
 
 
-def _get_cached(q: str) -> list | None:
-    entry = _cache.get(q)
-    if entry and time.monotonic() - entry[1] < _CACHE_TTL:
-        return entry[0]
-    return None
+async def _query_local(db: AsyncSession, query: str, limit: int = 8) -> list[dict]:
+    """Search the local symbol_directory table by prefix/substring."""
+    pattern = f"%{query}%"
+    stmt = (
+        select(SymbolDirectory)
+        .where(
+            or_(
+                sa_func.lower(SymbolDirectory.symbol).like(pattern),
+                sa_func.lower(SymbolDirectory.name).like(pattern),
+            )
+        )
+        .order_by(
+            # Exact symbol match first, then prefix, then substring
+            sa_func.lower(SymbolDirectory.symbol) != query,
+            ~sa_func.lower(SymbolDirectory.symbol).startswith(query),
+            SymbolDirectory.last_seen.desc(),
+        )
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return [
+        {
+            "symbol": row.symbol,
+            "name": row.name,
+            "exchange": row.exchange,
+            "type": row.type,
+        }
+        for row in result.scalars().all()
+    ]
 
 
-def _put_cache(q: str, results: list) -> None:
-    if len(_cache) >= _CACHE_MAX:
-        oldest = min(_cache, key=lambda k: _cache[k][1])
-        del _cache[oldest]
-    _cache[q] = (results, time.monotonic())
+async def _upsert_symbols(db: AsyncSession, results: list[dict]) -> None:
+    """Upsert Yahoo search results into the symbol_directory table."""
+    if not results:
+        return
+
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    rows = [
+        {
+            "symbol": r["symbol"],
+            "name": r["name"],
+            "exchange": r["exchange"],
+            "type": r["type"],
+            "last_seen": datetime.now(timezone.utc),
+        }
+        for r in results
+    ]
+
+    stmt = pg_insert(SymbolDirectory).values(rows)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["symbol"],
+        set_={
+            "name": stmt.excluded.name,
+            "exchange": stmt.excluded.exchange,
+            "type": stmt.excluded.type,
+            "last_seen": stmt.excluded.last_seen,
+        },
+    )
+    await db.execute(stmt)
+    await db.commit()
 
 
-async def search_symbols(query: str) -> list[dict]:
-    """Search for ticker symbols, returning up to 8 equity/ETF matches."""
-    q_lower = query.strip().lower()
-    cached = _get_cached(q_lower)
-    if cached is not None:
-        return cached
-
-    raw = await yahoo_search(q_lower, first_quote=False)
-    quotes = raw.get("quotes", [])
-
+def _parse_yahoo_results(quotes: list[dict]) -> list[dict]:
+    """Parse raw Yahoo search quotes into normalized dicts."""
     results = []
     for item in quotes:
         qt = item.get("quoteType", "")
@@ -47,6 +89,28 @@ async def search_symbols(query: str) -> list[dict]:
         })
         if len(results) >= 8:
             break
-
-    _put_cache(q_lower, results)
     return results
+
+
+async def search_symbols(query: str, db: AsyncSession) -> list[dict]:
+    """Search for ticker symbols, querying local DB first with Yahoo fallback."""
+    q_lower = query.strip().lower()
+
+    # Try local DB first
+    local_results = await _query_local(db, q_lower)
+    if len(local_results) >= _MIN_LOCAL_RESULTS:
+        return local_results
+
+    # Fall back to Yahoo Finance
+    raw = await yahoo_search(q_lower, first_quote=False)
+    yahoo_results = _parse_yahoo_results(raw.get("quotes", []))
+
+    # Persist Yahoo results to the directory (fire-and-forget on error)
+    if yahoo_results:
+        try:
+            await _upsert_symbols(db, yahoo_results)
+        except Exception:
+            await db.rollback()
+
+    # If we got Yahoo results, return those (fresher); otherwise return whatever local had
+    return yahoo_results if yahoo_results else local_results

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -1,10 +1,10 @@
-"""Unit tests for search_service — symbol search with TTL cache."""
+"""Unit tests for search_service — DB-backed symbol directory with Yahoo fallback."""
 
 import pytest
 from unittest.mock import AsyncMock, patch
 
-import app.services.search_service as search_mod
-from app.services.search_service import search_symbols
+from app.models.symbol_directory import SymbolDirectory
+from app.services.search_service import search_symbols, _parse_yahoo_results
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
@@ -26,24 +26,13 @@ def _mutual_fund(symbol: str, name: str = ""):
     return {"symbol": symbol, "shortname": name, "quoteType": "MUTUALFUND", "exchDisp": "NAS"}
 
 
-@pytest.fixture(autouse=True)
-def _clear_cache():
-    """Clear the module-level search cache before each test."""
-    search_mod._cache.clear()
-    yield
-    search_mod._cache.clear()
-
-
-@patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
-async def test_search_returns_filtered_results(mock_yahoo):
-    mock_yahoo.return_value = _yahoo_response(
+def test_parse_yahoo_results_filters_non_equity_etf():
+    quotes = [
         _equity("AAPL", "Apple Inc."),
         _mutual_fund("VFINX", "Vanguard 500"),
         _etf("SPY", "SPDR S&P 500"),
-    )
-
-    result = await search_symbols("apple")
-
+    ]
+    result = _parse_yahoo_results(quotes)
     assert len(result) == 2
     symbols = [r["symbol"] for r in result]
     assert "AAPL" in symbols
@@ -51,59 +40,82 @@ async def test_search_returns_filtered_results(mock_yahoo):
     assert "VFINX" not in symbols
 
 
+def test_parse_yahoo_results_caps_at_8():
+    quotes = [_equity(f"SYM{i}", f"Company {i}") for i in range(12)]
+    result = _parse_yahoo_results(quotes)
+    assert len(result) == 8
+
+
+def test_parse_yahoo_results_empty():
+    result = _parse_yahoo_results([])
+    assert result == []
+
+
+@patch("app.services.search_service._upsert_symbols", new_callable=AsyncMock)
 @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
-async def test_search_strips_and_lowercases_query(mock_yahoo):
+async def test_search_queries_yahoo_when_db_empty(mock_yahoo, mock_upsert, db):
+    mock_yahoo.return_value = _yahoo_response(
+        _equity("AAPL", "Apple Inc."),
+        _etf("SPY", "SPDR S&P 500"),
+    )
+
+    result = await search_symbols("apple", db)
+
+    assert len(result) == 2
+    mock_yahoo.assert_awaited_once_with("apple", first_quote=False)
+    mock_upsert.assert_awaited_once()
+
+
+@patch("app.services.search_service._upsert_symbols", new_callable=AsyncMock)
+@patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
+async def test_search_strips_and_lowercases_query(mock_yahoo, mock_upsert, db):
     mock_yahoo.return_value = _yahoo_response(_equity("AAPL", "Apple"))
 
-    await search_symbols("  AAPL  ")
+    await search_symbols("  AAPL  ", db)
 
     mock_yahoo.assert_awaited_once_with("aapl", first_quote=False)
 
 
+@patch("app.services.search_service._upsert_symbols", new_callable=AsyncMock)
 @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
-async def test_search_caps_results_at_8(mock_yahoo):
-    quotes = [_equity(f"SYM{i}", f"Company {i}") for i in range(12)]
-    mock_yahoo.return_value = _yahoo_response(*quotes)
+async def test_search_returns_local_when_enough_results(mock_yahoo, mock_upsert, db):
+    # Seed 8+ symbols into the DB
+    for i in range(10):
+        db.add(SymbolDirectory(symbol=f"AAPL{i}", name=f"Apple {i}", exchange="NYSE", type="stock"))
+    await db.commit()
 
-    result = await search_symbols("sym")
+    result = await search_symbols("aapl", db)
 
-    assert len(result) == 8
+    assert len(result) >= 8
+    mock_yahoo.assert_not_awaited()  # Should not call Yahoo when local has enough
 
 
+@patch("app.services.search_service._upsert_symbols", new_callable=AsyncMock)
 @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
-async def test_search_returns_cached_result_on_second_call(mock_yahoo):
-    mock_yahoo.return_value = _yahoo_response(_equity("AAPL", "Apple"))
+async def test_search_falls_back_to_yahoo_when_few_local(mock_yahoo, mock_upsert, db):
+    # Seed only 2 symbols
+    db.add(SymbolDirectory(symbol="AAPL", name="Apple Inc.", exchange="NYSE", type="stock"))
+    db.add(SymbolDirectory(symbol="AAPLX", name="Apple Extra", exchange="NYSE", type="stock"))
+    await db.commit()
 
-    first = await search_symbols("apple")
-    second = await search_symbols("apple")
+    mock_yahoo.return_value = _yahoo_response(
+        _equity("AAPL", "Apple Inc."),
+        _equity("AAPL2", "Apple 2"),
+    )
 
-    mock_yahoo.assert_awaited_once()  # Only one call — second hit cache
-    assert first == second
+    result = await search_symbols("aapl", db)
+
+    mock_yahoo.assert_awaited_once()
+    assert len(result) == 2  # Yahoo results take priority
 
 
+@patch("app.services.search_service._upsert_symbols", new_callable=AsyncMock)
 @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
-async def test_search_returns_empty_list_when_no_matches(mock_yahoo):
+async def test_search_returns_empty_when_no_matches(mock_yahoo, mock_upsert, db):
     mock_yahoo.return_value = _yahoo_response(
         _mutual_fund("VFINX", "Vanguard 500"),
     )
 
-    result = await search_symbols("vanguard")
+    result = await search_symbols("vanguard", db)
 
     assert result == []
-
-
-@patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
-async def test_cache_eviction_when_max_reached(mock_yahoo):
-    original_max = search_mod._CACHE_MAX
-    search_mod._CACHE_MAX = 3
-    try:
-        for i in range(4):
-            mock_yahoo.return_value = _yahoo_response(_equity(f"S{i}", f"Co {i}"))
-            await search_symbols(f"query{i}")
-
-        # Cache should have evicted the oldest entry
-        assert len(search_mod._cache) == 3
-        assert "query0" not in search_mod._cache
-        assert "query3" in search_mod._cache
-    finally:
-        search_mod._CACHE_MAX = original_max


### PR DESCRIPTION
## Summary
- New `symbol_directory` table to cache search results in PostgreSQL
- Search service queries local DB first; if >= 8 matches found, skips Yahoo entirely
- Yahoo Finance results are upserted into the directory for future searches
- Alembic migration `0002` creates the table with unique index on symbol
- Updated tests to cover DB-backed search with Yahoo fallback

## Changes
- `backend/app/models/symbol_directory.py`: New SQLAlchemy model
- `backend/app/models/__init__.py`: Register new model
- `backend/alembic/versions/0002_add_symbol_directory.py`: Migration
- `backend/app/services/search_service.py`: Rewritten to query DB first, fallback to Yahoo, upsert results
- `backend/app/routers/search.py`: Inject DB session dependency
- `backend/tests/services/test_search_service.py`: Updated tests for new behavior

## Test plan
- [x] All 246 backend tests pass
- [x] Frontend lint + build clean
- [x] Alembic migration runs successfully
- [ ] Manual: search populates symbol_directory, subsequent searches are faster

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)