### PR TITLE
refactor: fix boolean comparisons and remove redundant pytest markers

### DIFF
--- a/backend/app/repositories/asset_repo.py
+++ b/backend/app/repositories/asset_repo.py
@@ -16,19 +16,19 @@ class AssetRepository:
 
     async def list_watchlisted(self) -> list[Asset]:
         result = await self.db.execute(
-            select(Asset).where(Asset.watchlisted == True).order_by(Asset.symbol)  # noqa: E712
+            select(Asset).where(Asset.watchlisted.is_(True)).order_by(Asset.symbol)
         )
         return list(result.scalars().all())
 
     async def list_watchlisted_ids(self) -> list[int]:
         result = await self.db.execute(
-            select(Asset.id).where(Asset.watchlisted == True)  # noqa: E712
+            select(Asset.id).where(Asset.watchlisted.is_(True))
         )
         return list(result.scalars().all())
 
     async def list_watchlisted_id_symbol_pairs(self) -> list[tuple[int, str]]:
         result = await self.db.execute(
-            select(Asset.id, Asset.symbol).where(Asset.watchlisted == True)  # noqa: E712
+            select(Asset.id, Asset.symbol).where(Asset.watchlisted.is_(True))
         )
         return list(result.all())
 

--- a/backend/tests/services/test_price_service.py
+++ b/backend/tests/services/test_price_service.py
@@ -16,7 +16,7 @@ from app.services.price_service import (
     refresh_prices,
 )
 
-pytestmark = pytest.mark.asyncio(loop_scope="function")
+
 
 
 def _make_asset(**overrides) -> Asset:

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -1,12 +1,10 @@
 """Unit tests for search_service — DB-backed symbol directory with Yahoo fallback."""
 
-import pytest
 from unittest.mock import AsyncMock, patch
 
 from app.models.symbol_directory import SymbolDirectory
 from app.services.search_service import search_symbols, _parse_yahoo_results
 
-pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 def _yahoo_response(*items):


### PR DESCRIPTION
## Summary
- Standardized `Asset.watchlisted == True` to `.is_(True)` in `asset_repo.py` (3 occurrences)
- Removed redundant `pytestmark = pytest.mark.asyncio` from test files that contain sync tests (eliminates 5 pytest warnings since `asyncio_mode=auto` in pytest.ini already handles async detection)

## Test plan
- [x] All 246 backend tests pass with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)