### PR TITLE
Fix British stocks displaying pence as pounds

### DIFF
--- a/backend/alembic/versions/0002_normalize_subunit_currencies.py
+++ b/backend/alembic/versions/0002_normalize_subunit_currencies.py
@@ -1,0 +1,60 @@
+"""Normalize subunit currencies (GBp/GBX → GBP)
+
+Convert British pence (and other subunit currencies) stored by Yahoo Finance
+to their main currency. Divides historical prices by 100 and updates the
+currency code on affected assets.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-02-18
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Subunit currency codes → (main currency, divisor)
+SUBUNIT_CURRENCIES = {
+    "GBp": ("GBP", 100),
+    "GBX": ("GBP", 100),
+    "ILA": ("ILS", 100),
+    "ZAc": ("ZAR", 100),
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for subunit, (main_currency, divisor) in SUBUNIT_CURRENCIES.items():
+        # Divide OHLCV prices by the divisor for affected assets
+        conn.execute(sa.text("""
+            UPDATE price_history
+            SET open  = open  / :divisor,
+                high  = high  / :divisor,
+                low   = low   / :divisor,
+                close = close / :divisor
+            WHERE asset_id IN (
+                SELECT id FROM assets WHERE currency = :subunit
+            )
+        """), {"divisor": divisor, "subunit": subunit})
+
+        # Update the asset currency code
+        conn.execute(sa.text("""
+            UPDATE assets SET currency = :main WHERE currency = :subunit
+        """), {"main": main_currency, "subunit": subunit})
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    for subunit, (main_currency, divisor) in SUBUNIT_CURRENCIES.items():
+        # Note: downgrade cannot perfectly distinguish which assets were originally
+        # in subunit currencies vs already in main currency. This is best-effort.
+        pass

--- a/backend/tests/services/test_yahoo_currency.py
+++ b/backend/tests/services/test_yahoo_currency.py
@@ -1,0 +1,93 @@
+"""Tests for Yahoo Finance currency normalization (subunit → main currency)."""
+
+import pandas as pd
+import pytest
+
+from app.services.yahoo import normalize_currency, _normalize_ohlcv_df
+
+
+class TestNormalizeCurrency:
+    def test_gbp_pence_lowercase_p(self):
+        code, divisor = normalize_currency("GBp")
+        assert code == "GBP"
+        assert divisor == 100
+
+    def test_gbx(self):
+        code, divisor = normalize_currency("GBX")
+        assert code == "GBP"
+        assert divisor == 100
+
+    def test_israeli_agorot(self):
+        code, divisor = normalize_currency("ILA")
+        assert code == "ILS"
+        assert divisor == 100
+
+    def test_south_african_cents(self):
+        code, divisor = normalize_currency("ZAc")
+        assert code == "ZAR"
+        assert divisor == 100
+
+    def test_usd_unchanged(self):
+        code, divisor = normalize_currency("USD")
+        assert code == "USD"
+        assert divisor == 1
+
+    def test_eur_unchanged(self):
+        code, divisor = normalize_currency("EUR")
+        assert code == "EUR"
+        assert divisor == 1
+
+    def test_gbp_already_normalized(self):
+        code, divisor = normalize_currency("GBP")
+        assert code == "GBP"
+        assert divisor == 1
+
+    def test_unknown_currency_passthrough(self):
+        code, divisor = normalize_currency("XYZ")
+        assert code == "XYZ"
+        assert divisor == 1
+
+
+class TestNormalizeOhlcvDf:
+    @pytest.fixture
+    def sample_df(self):
+        return pd.DataFrame({
+            "open": [3200.0, 3250.0],
+            "high": [3300.0, 3350.0],
+            "low": [3100.0, 3150.0],
+            "close": [3250.0, 3300.0],
+            "volume": [1_000_000, 1_200_000],
+        })
+
+    def test_divisor_1_returns_same(self, sample_df):
+        result = _normalize_ohlcv_df(sample_df, 1)
+        assert result is sample_df  # no copy needed
+
+    def test_pence_to_pounds(self, sample_df):
+        result = _normalize_ohlcv_df(sample_df, 100)
+        assert result["open"].tolist() == [32.0, 32.5]
+        assert result["high"].tolist() == [33.0, 33.5]
+        assert result["low"].tolist() == [31.0, 31.5]
+        assert result["close"].tolist() == [32.5, 33.0]
+
+    def test_volume_unchanged(self, sample_df):
+        result = _normalize_ohlcv_df(sample_df, 100)
+        assert result["volume"].tolist() == [1_000_000, 1_200_000]
+
+    def test_does_not_mutate_original(self, sample_df):
+        original_open = sample_df["open"].tolist()
+        _normalize_ohlcv_df(sample_df, 100)
+        assert sample_df["open"].tolist() == original_open
+
+    def test_handles_adjclose(self):
+        df = pd.DataFrame({
+            "open": [3200.0],
+            "high": [3300.0],
+            "low": [3100.0],
+            "close": [3250.0],
+            "adjclose": [3250.0],
+            "volume": [1_000_000],
+        })
+        result = _normalize_ohlcv_df(df, 100)
+        assert result["adjclose"].tolist() == [32.5]
+        assert result["volume"].tolist() == [1_000_000]

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -2,6 +2,12 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   USD: "$",
   EUR: "\u20ac",
   GBP: "\u00a3",
+  GBp: "\u00a3",
+  GBX: "\u00a3",
+  ILS: "\u20aa",
+  ILA: "\u20aa",
+  ZAR: "R",
+  ZAc: "R",
   JPY: "\u00a5",
   CHF: "CHF\u00a0",
 }


### PR DESCRIPTION
## Summary
- Normalize Yahoo Finance subunit currencies (GBp/GBX → GBP, ILA → ILS, ZAc → ZAR) at the backend data layer, dividing prices by 100
- Add Alembic data migration to fix existing assets and their price history
- Add frontend fallback currency symbols as defense-in-depth
- 13 new unit tests for normalization logic

Closes #202

## Test plan
- [x] All 250 backend tests pass (including 13 new currency normalization tests)
- [x] ESLint clean
- [x] TypeScript + Vite build passes
- [ ] Manual verification: add BATS.L and verify price shows correct £ value
- [ ] Verify existing non-British stocks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)