### PR TITLE
feat: add dev branch CI with fibenchi:dev Docker tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -52,7 +52,7 @@ jobs:
 
   build-image:
     needs: [test-backend, test-frontend]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=sha
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
- Extends CI workflow to support a `dev` branch alongside `main`
- Push to `dev` builds Docker image tagged `ghcr.io/jvanmelckebeke/fibenchi:dev` (+ sha)
- Push to `main` continues to build with `latest` tag (+ sha) — no behavior change
- PRs to either branch run tests (backend pytest + frontend lint/build)

Closes #211

## Test plan
- [ ] Verify CI triggers on PRs to `dev` branch
- [ ] Verify push to `dev` builds image with `dev` tag (not `latest`)
- [ ] Verify push to `main` still builds with `latest` tag (not `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)