### PR TITLE
refactor: rename watchlist vestiges to group-based naming

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1,6 +1,6 @@
 """Shared constants for period and indicator warmup calculations."""
 
-# Calendar days for each period string used across price, watchlist, and portfolio endpoints.
+# Calendar days for each period string used across price, group, and portfolio endpoints.
 PERIOD_DAYS: dict[str, int] = {
     "1mo": 30,
     "3mo": 90,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from app.config import settings as app_settings
 from app.database import async_session, engine
 from app.routers import annotations, assets, groups, holdings, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, tags, thesis
 from app.services.price_sync import sync_all_prices
-from app.services.compute.watchlist import compute_and_cache_indicators
+from app.services.compute.group import compute_and_cache_indicators
 
 logger = logging.getLogger(__name__)
 scheduler = AsyncIOScheduler()

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -19,15 +19,15 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     """Add a new asset by ticker symbol. The symbol is validated against Yahoo Finance
     which also auto-detects the asset name, type (stock/etf), and currency.
 
-    By default the asset is added to the Watchlist group. Set `add_to_watchlist=false`
+    By default the asset is added to the default group. Set `add_to_default_group=false`
     to create the asset record without group membership (e.g. for pseudo-ETF constituents).
     """
-    return await asset_service.create_asset(db, data.symbol, data.name, data.type, data.add_to_watchlist)
+    return await asset_service.create_asset(db, data.symbol, data.name, data.type, data.add_to_default_group)
 
 
-@router.delete("/{symbol}", status_code=204, summary="Remove an asset from the watchlist")
+@router.delete("/{symbol}", status_code=204, summary="Remove an asset from the default group")
 async def delete_asset(symbol: str, db: AsyncSession = Depends(get_db)):
-    """Remove the asset from the default Watchlist group. The row is preserved so that
+    """Remove the asset from the default group. The row is preserved so that
     pseudo-ETF constituent relationships remain intact.
     """
     await asset_service.delete_asset(db, symbol)

--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.schemas.group import GroupAddAssets, GroupCreate, GroupResponse, GroupUpdate
 from app.services import group_service
-from app.services.compute.watchlist import compute_and_cache_indicators, get_batch_sparklines
+from app.services.compute.group import compute_and_cache_indicators, get_batch_sparklines
 
 router = APIRouter(prefix="/api/groups", tags=["groups"])
 

--- a/backend/app/routers/portfolio.py
+++ b/backend/app/routers/portfolio.py
@@ -27,11 +27,11 @@ class AssetPerformance(BaseModel):
 
 @router.get("/index", response_model=PortfolioIndexResponse, summary="Get composite portfolio index")
 async def get_portfolio_index(period: str = "1y", db: AsyncSession = Depends(get_db)):
-    """Compute equal-weight composite index of all watchlisted assets."""
+    """Compute equal-weight composite index of all grouped assets."""
     return await compute_portfolio_index(db, period)
 
 
 @router.get("/performers", response_model=list[AssetPerformance], summary="Get top and bottom performers by return")
 async def get_performers(period: str = "1y", db: AsyncSession = Depends(get_db)):
-    """Return watchlisted assets ranked by period return (best first)."""
+    """Return grouped assets ranked by period return (best first)."""
     return await compute_performers(db, period)

--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -13,9 +13,9 @@ router = APIRouter(prefix="/api/assets/{symbol}", tags=["prices"])
 async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
     """Return daily OHLCV price history for a symbol.
 
-    For watchlisted assets, prices are read from the database (and auto-synced
+    For tracked assets, prices are read from the database (and auto-synced
     from Yahoo Finance if the requested period isn't yet covered). For
-    non-watchlisted symbols, prices are fetched ephemerally from Yahoo without
+    untracked symbols, prices are fetched ephemerally from Yahoo without
     persisting.
 
     Supported periods: `1mo`, `3mo` (default), `6mo`, `1y`, `2y`, `5y`.
@@ -53,7 +53,7 @@ async def get_detail(symbol: str, period: str = "3mo", db: AsyncSession = Depend
 
 @router.post("/refresh", status_code=200, summary="Force-refresh prices from Yahoo Finance")
 async def refresh_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
-    """Force a re-sync of price data from Yahoo Finance for a watchlisted asset.
+    """Force a re-sync of price data from Yahoo Finance for a tracked asset.
 
     Returns the number of price points upserted.
     """

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -20,6 +20,6 @@ async def get_settings(db: AsyncSession = Depends(get_db)):
 @router.put("", response_model=SettingsResponse, summary="Update user settings")
 async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_db)):
     """Replace the user settings object. The `data` field is a free-form JSON
-    object storing preferences like `watchlist_show_rsi`, `compact_mode`, etc.
+    object storing preferences like `group_show_rsi`, `compact_mode`, etc.
     """
     return await settings_service.update_settings(db, body.data)

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -9,7 +9,7 @@ class AssetCreate(BaseModel):
     symbol: str = Field(description="Ticker symbol (e.g. AAPL, VOO). Validated against Yahoo Finance.")
     name: str | None = Field(default=None, description="Display name. Auto-detected from Yahoo Finance if omitted.")
     type: AssetType = Field(default=AssetType.STOCK, description="Asset type: stock or etf. Auto-detected if name is omitted.")
-    add_to_watchlist: bool = Field(default=True, description="If true, add to the default Watchlist group after creation. Set false for pseudo-ETF constituents.")
+    add_to_default_group: bool = Field(default=True, description="If true, add to the default group after creation. Set false for pseudo-ETF constituents.")
 
 
 class TagBrief(BaseModel):

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field
 
 
 class SettingsResponse(BaseModel):
-    data: dict = Field(description="Free-form settings object (e.g. watchlist_show_rsi, compact_mode)")
+    data: dict = Field(description="Free-form settings object (e.g. group_show_rsi, compact_mode)")
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -17,14 +17,14 @@ async def create_asset(
     symbol: str,
     name: str | None,
     asset_type: AssetType,
-    add_to_watchlist: bool = True,
+    add_to_default_group: bool = True,
 ):
     repo = AssetRepository(db)
     symbol = symbol.upper()
 
     existing = await repo.find_by_symbol(symbol)
     if existing:
-        if add_to_watchlist:
+        if add_to_default_group:
             # Add to default group if not already in it
             group_repo = GroupRepository(db)
             default_group = await group_repo.get_default()
@@ -49,7 +49,7 @@ async def create_asset(
         symbol=symbol, name=name, type=asset_type, currency=currency,
     )
 
-    if add_to_watchlist:
+    if add_to_default_group:
         group_repo = GroupRepository(db)
         default_group = await group_repo.get_default()
         if default_group:
@@ -60,7 +60,7 @@ async def create_asset(
 
 
 async def delete_asset(db: AsyncSession, symbol: str):
-    """Remove an asset from the default Watchlist group (soft-delete).
+    """Remove an asset from the default group (soft-delete).
 
     The asset row is preserved so that pseudo-ETF constituent relationships
     remain intact.

--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -20,7 +20,7 @@ _indicator_cache: TTLCache = TTLCache(default_ttl=600)
 
 
 async def _get_default_group_pairs(db: AsyncSession):
-    """Get (id, symbol) pairs for assets in the default Watchlist group."""
+    """Get (id, symbol) pairs for assets in the default group."""
     group = await GroupRepository(db).get_default()
     if not group:
         return []
@@ -32,7 +32,7 @@ async def get_batch_sparklines(
 ) -> dict[str, list[dict]]:
     """Return close-price sparkline data for assets in a group.
 
-    If group_id is None, uses the default Watchlist group.
+    If group_id is None, uses the default group.
     """
     days = PERIOD_DAYS.get(period, 90)
     start = date.today() - timedelta(days=days)
@@ -64,7 +64,7 @@ async def compute_and_cache_indicators(
 ) -> dict[str, dict]:
     """Compute indicator snapshots for assets in a group, with caching.
 
-    If group_id is None, uses the default Watchlist group.
+    If group_id is None, uses the default group.
     """
     if group_id is not None:
         asset_rows = await AssetRepository(db).list_in_group_id_symbol_pairs(group_id)

--- a/backend/app/services/compute/portfolio.py
+++ b/backend/app/services/compute/portfolio.py
@@ -17,7 +17,7 @@ _MIN_ENTRY_PRICE = 10.0
 async def compute_portfolio_index(
     db: AsyncSession, period: str = "1y",
 ) -> dict:
-    """Compute equal-weight composite index of all watchlisted assets.
+    """Compute equal-weight composite index of all grouped assets.
 
     Returns dict with keys: dates, values, current, change, change_pct.
     """
@@ -58,7 +58,7 @@ async def compute_portfolio_index(
 async def compute_performers(
     db: AsyncSession, period: str = "1y",
 ) -> list[dict]:
-    """Return watchlisted assets ranked by period return (best first).
+    """Return grouped assets ranked by period return (best first).
 
     Returns list of dicts with keys: symbol, name, type, change_pct.
     """

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -27,7 +27,7 @@ async def sync_asset_prices_range(
 
 
 async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int]:
-    """Fetch and upsert prices for all watchlist assets. Returns {symbol: count}."""
+    """Fetch and upsert prices for all tracked assets. Returns {symbol: count}."""
     assets = await AssetRepository(db).list_all()
 
     if not assets:

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -22,7 +22,7 @@ async def seed_asset_with_prices(
     """Create an asset with n_days of realistic price data.
 
     When add_to_group is True (default), the asset is added to the default
-    Watchlist group so it appears in watchlist/portfolio queries.
+    default group so it appears in group/portfolio queries.
     """
     asset = Asset(
         symbol=symbol, name=name or f"{symbol} Inc.",

--- a/backend/tests/integration/test_portfolio.py
+++ b/backend/tests/integration/test_portfolio.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="function")
 # --- GET /portfolio/index ---
 
 async def test_index_empty_portfolio(client):
-    """Empty watchlist returns zero values."""
+    """Empty portfolio returns zero values."""
     resp = await client.get("/api/portfolio/index?period=1y")
     assert resp.status_code == 200
     data = resp.json()

--- a/backend/tests/integration/test_prices.py
+++ b/backend/tests/integration/test_prices.py
@@ -38,7 +38,7 @@ async def test_get_prices_respects_period_boundary(client, db):
 
 
 async def test_get_prices_ephemeral_symbol(client):
-    """Non-watchlisted symbol fetches from Yahoo without persisting."""
+    """Untracked symbol fetches from Yahoo without persisting."""
     mock_df = make_yahoo_df()
     with patch("app.services.price_service.fetch_history", return_value=mock_df):
         resp = await client.get("/api/assets/UNKNOWN/prices?period=3mo")

--- a/backend/tests/integration/test_quotes.py
+++ b/backend/tests/integration/test_quotes.py
@@ -90,8 +90,8 @@ async def test_get_quotes_uppercase_normalization(client):
 # patch it to use the test database session.
 
 
-async def test_stream_quotes_no_watchlisted(client):
-    """SSE stream emits empty payload when no assets are watchlisted."""
+async def test_stream_quotes_no_tracked(client):
+    """SSE stream emits empty payload when no assets are tracked."""
     with (
         patch("app.services.quote_service.async_session", TestSession),
         patch("app.services.quote_service.asyncio.sleep", side_effect=asyncio.CancelledError()),
@@ -106,7 +106,7 @@ async def test_stream_quotes_no_watchlisted(client):
 
 
 async def test_stream_quotes_emits_event(client):
-    """SSE stream emits quote data for watchlisted assets."""
+    """SSE stream emits quote data for tracked assets."""
     await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
 
     with (
@@ -137,7 +137,7 @@ async def test_stream_quotes_cache_headers(client):
 
 
 async def test_stream_quotes_multiple_symbols(client):
-    """SSE stream includes all watchlisted symbols in first event."""
+    """SSE stream includes all tracked symbols in first event."""
     await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
     await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft", "type": "stock"})
 

--- a/backend/tests/integration/test_watchlist.py
+++ b/backend/tests/integration/test_watchlist.py
@@ -16,7 +16,7 @@ async def _get_default_group_id(db):
 
 
 async def _seed_assets(db, count=3, n_days=200):
-    """Create multiple assets in the default Watchlist group with price history."""
+    """Create multiple assets in the default group with price history."""
     symbols = ["AAPL", "GOOGL", "MSFT"][:count]
     assets = []
     for i, sym in enumerate(symbols):

--- a/backend/tests/repositories/test_asset_repo.py
+++ b/backend/tests/repositories/test_asset_repo.py
@@ -21,7 +21,7 @@ async def _create_asset(db, symbol: str, **kwargs) -> Asset:
 
 
 async def _add_to_default_group(db, asset: Asset) -> None:
-    """Add an asset to the default Watchlist group."""
+    """Add an asset to the default group."""
     default_group = await GroupRepository(db).get_default()
     default_group.assets.append(asset)
     await db.commit()

--- a/backend/tests/services/test_settings_service.py
+++ b/backend/tests/services/test_settings_service.py
@@ -28,7 +28,7 @@ async def test_get_settings_returns_row_when_found(MockRepo):
     db = AsyncMock()
     mock_repo = MockRepo.return_value
     row = MagicMock()
-    row.data = {"compact_mode": True, "watchlist_show_rsi": False}
+    row.data = {"compact_mode": True, "group_show_rsi": False}
     mock_repo.get = AsyncMock(return_value=row)
 
     result = await get_settings(db)

--- a/frontend/src/components/add-constituent-picker.tsx
+++ b/frontend/src/components/add-constituent-picker.tsx
@@ -40,7 +40,7 @@ export function AddConstituentPicker({
     if (!sym) return
     setTickerError("")
     createAsset.mutate(
-      { symbol: sym, add_to_watchlist: false },
+      { symbol: sym, add_to_default_group: false },
       {
         onSuccess: (asset) => {
           addConstituents.mutate(

--- a/frontend/src/components/add-symbol-dialog.tsx
+++ b/frontend/src/components/add-symbol-dialog.tsx
@@ -18,7 +18,7 @@ export function AddSymbolDialog({ groupId, isDefaultGroup }: { groupId?: number;
   const createAsset = useCreateAsset()
   const addAssetsToGroup = useAddAssetsToGroup()
   const { data: assets } = useAssets()
-  const watchlistedSymbols = useMemo(
+  const trackedSymbols = useMemo(
     () => new Set(assets?.map((a) => a.symbol)),
     [assets],
   )
@@ -89,7 +89,7 @@ export function AddSymbolDialog({ groupId, isDefaultGroup }: { groupId?: number;
                 className="absolute z-50 top-full left-0 right-0 mt-1 rounded-md border border-border bg-popover shadow-md max-h-60 overflow-auto"
               >
                 {searchResults.map((r) => {
-                  const isWatchlisted = watchlistedSymbols.has(r.symbol)
+                  const isTracked = trackedSymbols.has(r.symbol)
                   return (
                     <button
                       key={r.symbol}
@@ -97,7 +97,7 @@ export function AddSymbolDialog({ groupId, isDefaultGroup }: { groupId?: number;
                       className="flex w-full items-center gap-3 px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
                       onMouseDown={(e) => e.preventDefault()}
                       onClick={() => {
-                        if (isWatchlisted) {
+                        if (isTracked) {
                           setDialogOpen(false)
                           navigate(`/asset/${r.symbol}`)
                         } else {
@@ -108,10 +108,10 @@ export function AddSymbolDialog({ groupId, isDefaultGroup }: { groupId?: number;
                     >
                       <span className="font-mono font-medium text-primary shrink-0">{r.symbol}</span>
                       <span className="text-muted-foreground truncate">{r.name}</span>
-                      {isWatchlisted ? (
+                      {isTracked ? (
                         <Badge variant="outline" className="ml-auto text-xs shrink-0 gap-1 text-emerald-500 border-emerald-500/30">
                           <Check className="h-3 w-3" />
-                          Watchlisted
+                          Tracked
                         </Badge>
                       ) : (
                         <Badge variant="secondary" className="ml-auto text-xs shrink-0">{r.exchange}</Badge>

--- a/frontend/src/components/command-search.tsx
+++ b/frontend/src/components/command-search.tsx
@@ -15,7 +15,7 @@ export function CommandSearch() {
   const prevResultsRef = useRef<string>("")
   const { data: results } = useSymbolSearch(debouncedQuery)
   const { data: assets } = useAssets()
-  const watchlistedSymbols = useMemo(
+  const trackedSymbols = useMemo(
     () => new Set(assets?.map((a) => a.symbol)),
     [assets],
   )
@@ -118,7 +118,7 @@ export function CommandSearch() {
           {results && results.length > 0 && query.trim() && (
             <div className="max-h-72 overflow-auto py-1">
               {results.map((r, i) => {
-                const isWatchlisted = watchlistedSymbols.has(r.symbol)
+                const isTracked = trackedSymbols.has(r.symbol)
                 return (
                   <button
                     key={r.symbol}
@@ -135,10 +135,10 @@ export function CommandSearch() {
                       {r.symbol}
                     </span>
                     <span className="text-muted-foreground truncate">{r.name}</span>
-                    {isWatchlisted ? (
+                    {isTracked ? (
                       <Badge variant="outline" className="ml-auto text-xs shrink-0 gap-1 text-emerald-500 border-emerald-500/30">
                         <Check className="h-3 w-3" />
-                        Watchlisted
+                        Tracked
                       </Badge>
                     ) : (
                       <Badge variant="secondary" className="ml-auto text-xs shrink-0">

--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -11,25 +11,25 @@ import { RsiGauge } from "@/components/rsi-gauge"
 import { MacdIndicator } from "@/components/macd-indicator"
 import { ArrowUp, ArrowDown } from "lucide-react"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
-import type { WatchlistSortBy, SortDir } from "@/lib/settings"
+import type { GroupSortBy, SortDir } from "@/lib/settings"
 import { formatPrice } from "@/lib/format"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useAssetDetail, useAnnotations } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
 
-interface WatchlistTableProps {
+interface GroupTableProps {
   assets: Asset[]
   quotes: Record<string, Quote>
   indicators?: Record<string, IndicatorSummary>
   onDelete: (symbol: string) => void
   compactMode: boolean
   onHover?: (symbol: string) => void
-  sortBy?: WatchlistSortBy
+  sortBy?: GroupSortBy
   sortDir?: SortDir
-  onSort?: (key: WatchlistSortBy) => void
+  onSort?: (key: GroupSortBy) => void
 }
 
-export function WatchlistTable({ assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort }: WatchlistTableProps) {
+export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort }: GroupTableProps) {
   const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(new Set())
 
   const toggleExpand = (symbol: string) => {
@@ -87,11 +87,11 @@ function SortableHeader({
   onSort,
 }: {
   label: string
-  sortKey: WatchlistSortBy
+  sortKey: GroupSortBy
   align: "left" | "right"
-  sortBy?: WatchlistSortBy
+  sortBy?: GroupSortBy
   sortDir?: SortDir
-  onSort?: (key: WatchlistSortBy) => void
+  onSort?: (key: GroupSortBy) => void
 }) {
   const active = sortBy === sortKey
   const Icon = active && sortDir === "asc" ? ArrowUp : ArrowDown

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -101,7 +101,7 @@ function GroupsSection() {
         </div>
       )}
 
-      {/* Default Watchlist group — always first */}
+      {/* Default group — always first */}
       {defaultGroup && (
         <NavLink
           to={`/groups/${defaultGroup.id}`}

--- a/frontend/src/components/macd-indicator.tsx
+++ b/frontend/src/components/macd-indicator.tsx
@@ -110,7 +110,7 @@ export function MacdIndicator({
     lg,
   }
 
-  return settings.watchlist_macd_style === "classic"
+  return settings.group_macd_style === "classic"
     ? <ClassicMacd {...props} />
     : <DivergenceMacd {...props} />
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,7 +27,6 @@ import type {
   Thesis,
 } from "./types"
 
-// Re-export all types for backwards compatibility
 export type * from "./types"
 
 // API client

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -1,20 +1,20 @@
 import { createContext, useContext, useEffect, useState, useCallback, useRef, type ReactNode } from "react"
 
 export type AssetTypeFilter = "all" | "stock" | "etf"
-export type WatchlistSortBy = "name" | "price" | "change_pct" | "rsi" | "macd" | "macd_signal" | "macd_hist"
+export type GroupSortBy = "name" | "price" | "change_pct" | "rsi" | "macd" | "macd_signal" | "macd_hist"
 export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"
-export type WatchlistViewMode = "card" | "table"
+export type GroupViewMode = "card" | "table"
 
 export interface AppSettings {
-  watchlist_show_rsi: boolean
-  watchlist_show_macd: boolean
-  watchlist_macd_style: MacdStyle
-  watchlist_show_sparkline: boolean
-  watchlist_view_mode: WatchlistViewMode
-  watchlist_type_filter: AssetTypeFilter
-  watchlist_sort_by: WatchlistSortBy
-  watchlist_sort_dir: SortDir
+  group_show_rsi: boolean
+  group_show_macd: boolean
+  group_macd_style: MacdStyle
+  group_show_sparkline: boolean
+  group_view_mode: GroupViewMode
+  group_type_filter: AssetTypeFilter
+  group_sort_by: GroupSortBy
+  group_sort_dir: SortDir
   detail_show_sma20: boolean
   detail_show_sma50: boolean
   detail_show_bollinger: boolean
@@ -29,14 +29,14 @@ export interface AppSettings {
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const DEFAULT_SETTINGS: AppSettings = {
-  watchlist_show_rsi: true,
-  watchlist_show_macd: true,
-  watchlist_macd_style: "divergence",
-  watchlist_show_sparkline: true,
-  watchlist_view_mode: "card",
-  watchlist_type_filter: "all",
-  watchlist_sort_by: "name",
-  watchlist_sort_dir: "asc",
+  group_show_rsi: true,
+  group_show_macd: true,
+  group_macd_style: "divergence",
+  group_show_sparkline: true,
+  group_view_mode: "card",
+  group_type_filter: "all",
+  group_sort_by: "name",
+  group_sort_dir: "asc",
   detail_show_sma20: true,
   detail_show_sma50: true,
   detail_show_bollinger: true,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -40,7 +40,7 @@ export interface AssetCreate {
   symbol: string
   name?: string
   type?: AssetType
-  add_to_watchlist?: boolean
+  add_to_default_group?: boolean
 }
 
 export interface SymbolSearchResult {

--- a/frontend/src/lib/use-group-filter.ts
+++ b/frontend/src/lib/use-group-filter.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
-import type { AssetTypeFilter, WatchlistSortBy, SortDir } from "@/lib/settings"
+import type { AssetTypeFilter, GroupSortBy, SortDir } from "@/lib/settings"
 
 function compareNullable(a: number | null, b: number | null): number {
   if (a == null && b == null) return 0
@@ -14,7 +14,7 @@ export function useFilteredSortedAssets(
   opts: {
     typeFilter: AssetTypeFilter
     selectedTags: number[]
-    sortBy: WatchlistSortBy
+    sortBy: GroupSortBy
     sortDir: SortDir
     quotes: Record<string, Quote>
     indicators?: Record<string, IndicatorSummary>

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -38,14 +38,14 @@ export function AssetDetailPage() {
   const [period, setPeriod] = useState<string>(settings.chart_default_period)
   const { data: assets } = useAssets()
   const asset = assets?.find((a) => a.symbol === symbol?.toUpperCase())
-  const isWatchlisted = !!asset
+  const isTracked = !!asset
   const isEtf = asset?.type === "etf"
 
   if (!symbol) return null
 
   return (
     <div className="p-6 space-y-6">
-      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isWatchlisted={isWatchlisted} />
+      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isTracked={isTracked} />
       <ChartSection
         symbol={symbol}
         period={period}
@@ -57,7 +57,7 @@ export function AssetDetailPage() {
         chartType={settings.chart_type}
       />
       {isEtf && <HoldingsSection symbol={symbol} />}
-      {isWatchlisted && (
+      {isTracked && (
         <>
           <TagInput symbol={symbol} currentTags={asset?.tags ?? []} />
           <AssetAnnotations symbol={symbol} />
@@ -74,14 +74,14 @@ function Header({
   currency,
   period,
   setPeriod,
-  isWatchlisted,
+  isTracked,
 }: {
   symbol: string
   name?: string
   currency: string
   period: string
   setPeriod: (p: string) => void
-  isWatchlisted: boolean
+  isTracked: boolean
 }) {
   const refresh = useRefreshPrices(symbol)
   const createAsset = useCreateAsset()
@@ -132,7 +132,7 @@ function Header({
             <ExternalLink className="h-4 w-4 text-muted-foreground" />
           </Button>
         </a>
-        {!isWatchlisted && (
+        {!isTracked && (
           <Button
             variant="outline"
             size="sm"
@@ -140,13 +140,13 @@ function Header({
             disabled={createAsset.isPending}
           >
             <Plus className="h-3.5 w-3.5 mr-1.5" />
-            {createAsset.isPending ? "Adding..." : "Add to Watchlist"}
+            {createAsset.isPending ? "Adding..." : "Track"}
           </Button>
         )}
       </div>
       <div className="flex items-center gap-2">
         <PeriodSelector value={period} onChange={setPeriod} />
-        {isWatchlisted && (
+        {isTracked && (
           <Button
             variant="outline"
             size="sm"

--- a/frontend/src/pages/group-detail.tsx
+++ b/frontend/src/pages/group-detail.tsx
@@ -1,9 +1,9 @@
 import { useParams } from "react-router-dom"
-import { WatchlistPage } from "@/pages/watchlist"
+import { GroupPage } from "@/pages/group-page"
 
 export function GroupDetailPage() {
   const { id } = useParams<{ id: string }>()
   const groupId = Number(id)
 
-  return <WatchlistPage groupId={groupId} />
+  return <GroupPage groupId={groupId} />
 }

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -25,11 +25,11 @@ import { TagBadge } from "@/components/tag-badge"
 import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary } from "@/lib/api"
 import { formatPrice } from "@/lib/format"
 import { usePriceFlash } from "@/lib/use-price-flash"
-import { useSettings, type AssetTypeFilter, type WatchlistSortBy, type SortDir } from "@/lib/settings"
-import { useFilteredSortedAssets } from "@/lib/use-watchlist-filter"
-import { WatchlistTable } from "@/components/watchlist-table"
+import { useSettings, type AssetTypeFilter, type GroupSortBy, type SortDir } from "@/lib/settings"
+import { useFilteredSortedAssets } from "@/lib/use-group-filter"
+import { GroupTable } from "@/components/group-table"
 
-const SORT_OPTIONS: [WatchlistSortBy, string][] = [
+const SORT_OPTIONS: [GroupSortBy, string][] = [
   ["name", "Name"],
   ["price", "Price"],
   ["change_pct", "Change %"],
@@ -39,24 +39,24 @@ const SORT_OPTIONS: [WatchlistSortBy, string][] = [
   ["macd_hist", "MACD Hist"],
 ]
 
-const SORT_LABELS: Record<WatchlistSortBy, string> = Object.fromEntries(SORT_OPTIONS) as Record<WatchlistSortBy, string>
+const SORT_LABELS: Record<GroupSortBy, string> = Object.fromEntries(SORT_OPTIONS) as Record<GroupSortBy, string>
 
-export function WatchlistPage({ groupId }: { groupId: number }) {
+export function GroupPage({ groupId }: { groupId: number }) {
   const { data: group, isLoading: groupLoading } = useGroup(groupId)
   const { data: allTags } = useTags()
   const removeFromGroup = useRemoveAssetFromGroup()
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
   const { settings, updateSettings } = useSettings()
-  const viewMode = settings.watchlist_view_mode
-  const setViewMode = (v: "card" | "table") => updateSettings({ watchlist_view_mode: v })
+  const viewMode = settings.group_view_mode
+  const setViewMode = (v: "card" | "table") => updateSettings({ group_view_mode: v })
   const { data: batchSparklines } = useGroupSparklines(groupId, sparklinePeriod)
   const { data: batchIndicators } = useGroupIndicators(groupId)
   const prefetch = usePrefetchAssetDetail(settings.chart_default_period)
 
-  const typeFilter = settings.watchlist_type_filter
-  const sortBy = settings.watchlist_sort_by
-  const sortDir = settings.watchlist_sort_dir
+  const typeFilter = settings.group_type_filter
+  const sortBy = settings.group_sort_by
+  const sortDir = settings.group_sort_dir
 
   const quotes = useQuotes()
 
@@ -73,14 +73,14 @@ export function WatchlistPage({ groupId }: { groupId: number }) {
   })
 
   const setTypeFilter = (v: AssetTypeFilter) =>
-    updateSettings({ watchlist_type_filter: v })
+    updateSettings({ group_type_filter: v })
 
-  const handleSort = (key: WatchlistSortBy) => {
+  const handleSort = (key: GroupSortBy) => {
     if (sortBy === key) {
-      updateSettings({ watchlist_sort_dir: sortDir === "asc" ? "desc" : "asc" })
+      updateSettings({ group_sort_dir: sortDir === "asc" ? "desc" : "asc" })
     } else {
       const defaultDir: SortDir = key === "name" ? "asc" : "desc"
-      updateSettings({ watchlist_sort_by: key, watchlist_sort_dir: defaultDir })
+      updateSettings({ group_sort_by: key, group_sort_dir: defaultDir })
     }
   }
 
@@ -191,7 +191,7 @@ export function WatchlistPage({ groupId }: { groupId: number }) {
       )}
 
       {viewMode === "table" && assets && assets.length > 0 ? (
-        <WatchlistTable
+        <GroupTable
           assets={assets}
           quotes={quotes}
           indicators={batchIndicators}
@@ -222,9 +222,9 @@ export function WatchlistPage({ groupId }: { groupId: number }) {
               indicatorData={batchIndicators?.[asset.symbol]}
               onDelete={() => handleRemove(asset.symbol)}
               onHover={() => prefetch(asset.symbol)}
-              showSparkline={settings.watchlist_show_sparkline}
-              showRsi={settings.watchlist_show_rsi}
-              showMacd={settings.watchlist_show_macd}
+              showSparkline={settings.group_show_sparkline}
+              showRsi={settings.group_show_rsi}
+              showMacd={settings.group_show_macd}
             />
           ))}
         </div>

--- a/frontend/src/pages/groups.tsx
+++ b/frontend/src/pages/groups.tsx
@@ -213,7 +213,7 @@ function AddAssetToGroup({
   return (
     <div className="p-3 rounded-md border bg-muted/30 space-y-2">
       {available.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No more assets to add. Add assets from the watchlist first.</p>
+        <p className="text-sm text-muted-foreground">No more assets to add. Add assets from the default group first.</p>
       ) : (
         <div className="flex flex-wrap gap-1.5">
           {available.map((a) => (

--- a/frontend/src/pages/portfolio.tsx
+++ b/frontend/src/pages/portfolio.tsx
@@ -26,7 +26,7 @@ export function PortfolioPage() {
         <ChartSkeleton height={480} />
       ) : !data || !data.dates.length ? (
         <div className="h-[480px] flex items-center justify-center text-muted-foreground">
-          No data yet. Add assets to your watchlist and refresh prices.
+          No data yet. Add assets to a group and refresh prices.
         </div>
       ) : (
         <div className="relative">

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { useSettings, type AppSettings, type MacdStyle, type WatchlistViewMode } from "@/lib/settings"
+import { useSettings, type AppSettings, type MacdStyle, type GroupViewMode } from "@/lib/settings"
 
 function SettingSwitch({
   id,
@@ -62,14 +62,14 @@ export function SettingsPage() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       <Card>
         <CardHeader>
-          <CardTitle>Watchlist</CardTitle>
+          <CardTitle>Group View</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex items-center justify-between">
             <Label>Default View</Label>
             <Select
-              value={draft.watchlist_view_mode}
-              onValueChange={(v) => change({ watchlist_view_mode: v as WatchlistViewMode })}
+              value={draft.group_view_mode}
+              onValueChange={(v) => change({ group_view_mode: v as GroupViewMode })}
             >
               <SelectTrigger className="w-28">
                 <SelectValue />
@@ -80,15 +80,15 @@ export function SettingsPage() {
               </SelectContent>
             </Select>
           </div>
-          <SettingSwitch id="wl-sparkline" label="Sparkline Chart" settingKey="watchlist_show_sparkline" draft={draft} onChange={change} />
-          <SettingSwitch id="wl-rsi" label="RSI Gauge" settingKey="watchlist_show_rsi" draft={draft} onChange={change} />
-          <SettingSwitch id="wl-macd" label="MACD Indicator" settingKey="watchlist_show_macd" draft={draft} onChange={change} />
-          {draft.watchlist_show_macd && (
+          <SettingSwitch id="wl-sparkline" label="Sparkline Chart" settingKey="group_show_sparkline" draft={draft} onChange={change} />
+          <SettingSwitch id="wl-rsi" label="RSI Gauge" settingKey="group_show_rsi" draft={draft} onChange={change} />
+          <SettingSwitch id="wl-macd" label="MACD Indicator" settingKey="group_show_macd" draft={draft} onChange={change} />
+          {draft.group_show_macd && (
             <div className="flex items-center justify-between pl-4">
               <Label className="text-muted-foreground">MACD Style</Label>
               <Select
-                value={draft.watchlist_macd_style}
-                onValueChange={(v) => change({ watchlist_macd_style: v as MacdStyle })}
+                value={draft.group_macd_style}
+                onValueChange={(v) => change({ group_macd_style: v as MacdStyle })}
               >
                 <SelectTrigger className="w-32">
                   <SelectValue />


### PR DESCRIPTION
## Summary
- Rename files: `watchlist.tsx` → `group-page.tsx`, `watchlist-table.tsx` → `group-table.tsx`, `use-watchlist-filter.ts` → `use-group-filter.ts`, `compute/watchlist.py` → `compute/group.py`
- Rename types: `WatchlistSortBy` → `GroupSortBy`, `WatchlistViewMode` → `GroupViewMode`
- Rename settings keys: `watchlist_*` → `group_*`
- Rename param: `add_to_watchlist` → `add_to_default_group` (schema, service, frontend type)
- Rename variables: `isWatchlisted` → `isTracked`, `watchlistedSymbols` → `trackedSymbols`
- Update all docstrings from "watchlisted" to "grouped/tracked"
- Remove misleading "backwards compatibility" comment in `api.ts`
- Keep `/watchlist` redirect route (user-facing URL) and "Watchlist" as default group display name

Closes #221

## Test plan
- [x] ESLint clean
- [x] TypeScript build clean
- [x] 263 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)