### PR TITLE
fix: standardize change% color to emerald across all components

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -49,7 +49,7 @@ export function AssetCard({
   const lastPrice = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
   const changeColor =
-    changePct != null ? (changePct >= 0 ? "text-green-500" : "text-red-500") : "text-muted-foreground"
+    changePct != null ? (changePct >= 0 ? "text-emerald-500" : "text-red-500") : "text-muted-foreground"
 
   const [priceRef, pctRef] = usePriceFlash(lastPrice)
 

--- a/frontend/src/components/chart/chart-legends.tsx
+++ b/frontend/src/components/chart/chart-legends.tsx
@@ -54,7 +54,7 @@ function OverlayEntry({ descriptor, v }: { descriptor: IndicatorDescriptor; v: L
 export function Legend({ values, latest }: { values: LegendValues | null; latest: LegendValues }) {
   const v = values ?? latest
   const changeColor = v.c !== undefined && v.o !== undefined
-    ? v.c >= v.o ? "text-green-500" : "text-red-500"
+    ? v.c >= v.o ? "text-emerald-500" : "text-red-500"
     : ""
 
   const overlays = getOverlayDescriptors()

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -111,7 +111,7 @@ function Header({
           <span
             ref={pctRef}
             className={`text-sm font-medium tabular-nums rounded px-1 ${
-              changePct >= 0 ? "text-green-500" : "text-red-500"
+              changePct >= 0 ? "text-emerald-500" : "text-red-500"
             }`}
           >
             {changePct >= 0 ? "+" : ""}

--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -144,7 +144,7 @@ function PerformanceStats({ data, baseValue }: { data: PerformanceBreakdownPoint
       </div>
       <div>
         <span className="text-muted-foreground">Total return: </span>
-        <span className={`font-medium ${totalReturn >= 0 ? "text-green-500" : "text-red-500"}`}>
+        <span className={`font-medium ${totalReturn >= 0 ? "text-emerald-500" : "text-red-500"}`}>
           {totalReturn >= 0 ? "+" : ""}{totalReturn.toFixed(1)}%
         </span>
       </div>


### PR DESCRIPTION
## Summary
- Replaced all `text-green-500` positive change% colors with `text-emerald-500` for visual consistency across the frontend
- Fixed in `asset-card.tsx`, `asset-detail.tsx`, `chart-legends.tsx`, and `pseudo-etf-detail.tsx`
- `group-table.tsx` and `format.ts` already used `text-emerald-500` (no changes needed)

Fixes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)