### PR TITLE
cleanup: remove dead symbol prop from RsiGauge and MacdIndicator

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -98,8 +98,8 @@ export function AssetCard({
           {showSparkline && <SparklineChart symbol={symbol} period={sparklinePeriod} batchData={sparklineData} />}
           {(showRsi || showMacd) && (
             <div className="flex gap-1.5 mt-1">
-              {showRsi && <RsiGauge symbol={symbol} batchRsi={getNumericValue(indicatorData?.values, "rsi")} />}
-              {showMacd && <MacdIndicator symbol={symbol} batchMacd={indicatorData?.values ? { macd: getNumericValue(indicatorData.values, "macd"), macd_signal: getNumericValue(indicatorData.values, "macd_signal"), macd_hist: getNumericValue(indicatorData.values, "macd_hist") } : undefined} />}
+              {showRsi && <RsiGauge batchRsi={getNumericValue(indicatorData?.values, "rsi")} />}
+              {showMacd && <MacdIndicator batchMacd={indicatorData?.values ? { macd: getNumericValue(indicatorData.values, "macd"), macd_signal: getNumericValue(indicatorData.values, "macd_signal"), macd_hist: getNumericValue(indicatorData.values, "macd_hist") } : undefined} />}
             </div>
           )}
         </CardContent>

--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -173,12 +173,11 @@ function ExpandedContent({ symbol, indicator }: { symbol: string; indicator?: In
       <div className="flex-1 flex flex-col gap-3 justify-center min-w-[140px] max-w-[200px]">
         <div>
           <span className="text-xs text-muted-foreground mb-1 block">RSI</span>
-          <RsiGauge symbol={symbol} batchRsi={rsiVal} size="lg" />
+          <RsiGauge batchRsi={rsiVal} size="lg" />
         </div>
         <div>
           <span className="text-xs text-muted-foreground mb-1 block">MACD</span>
           <MacdIndicator
-            symbol={symbol}
             batchMacd={macdVals}
             size="lg"
           />

--- a/frontend/src/components/macd-indicator.tsx
+++ b/frontend/src/components/macd-indicator.tsx
@@ -83,7 +83,6 @@ export function MacdIndicator({
   batchMacd,
   size = "sm",
 }: {
-  symbol: string
   batchMacd?: { macd: number | null; macd_signal: number | null; macd_hist: number | null } | null
   size?: "sm" | "lg"
 }) {

--- a/frontend/src/components/rsi-gauge.tsx
+++ b/frontend/src/components/rsi-gauge.tsx
@@ -24,7 +24,7 @@ function getZoneLabel(rsi: number): string {
   return ""
 }
 
-export function RsiGauge({ batchRsi, size = "sm" }: { symbol: string; batchRsi?: number | null; size?: "sm" | "lg" }) {
+export function RsiGauge({ batchRsi, size = "sm" }: { batchRsi?: number | null; size?: "sm" | "lg" }) {
   const lg = size === "lg"
 
   if (batchRsi === undefined) {


### PR DESCRIPTION
Removes unused `symbol` prop from `RsiGauge` and `MacdIndicator` components and all call sites.

Fixes #237