### PR TITLE
cleanup: extract MACD values helper and document Yahoo URL zero-width chars

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -10,7 +10,7 @@ import { MacdIndicator } from "@/components/macd-indicator"
 import { TagBadge } from "@/components/tag-badge"
 import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary } from "@/lib/api"
 import { formatPrice } from "@/lib/format"
-import { getNumericValue } from "@/lib/indicator-registry"
+import { getNumericValue, extractMacdValues } from "@/lib/indicator-registry"
 import { usePriceFlash } from "@/lib/use-price-flash"
 
 export interface AssetCardProps {
@@ -99,7 +99,7 @@ export function AssetCard({
           {(showRsi || showMacd) && (
             <div className="flex gap-1.5 mt-1">
               {showRsi && <RsiGauge batchRsi={getNumericValue(indicatorData?.values, "rsi")} />}
-              {showMacd && <MacdIndicator batchMacd={indicatorData?.values ? { macd: getNumericValue(indicatorData.values, "macd"), macd_signal: getNumericValue(indicatorData.values, "macd_signal"), macd_hist: getNumericValue(indicatorData.values, "macd_hist") } : undefined} />}
+              {showMacd && <MacdIndicator batchMacd={extractMacdValues(indicatorData?.values)} />}
             </div>
           )}
         </CardContent>

--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -15,6 +15,7 @@ import type { GroupSortBy, SortDir } from "@/lib/settings"
 import { formatPrice } from "@/lib/format"
 import {
   getNumericValue,
+  extractMacdValues,
   getAllSortableFields,
   getSeriesByField,
   resolveThresholdColor,
@@ -140,13 +141,7 @@ function ExpandedContent({ symbol, indicator }: { symbol: string; indicator?: In
   const loading = detailLoading
 
   const rsiVal = getNumericValue(indicator?.values, "rsi")
-  const macdVals = indicator?.values
-    ? {
-        macd: getNumericValue(indicator.values, "macd"),
-        macd_signal: getNumericValue(indicator.values, "macd_signal"),
-        macd_hist: getNumericValue(indicator.values, "macd_hist"),
-      }
-    : undefined
+  const macdVals = extractMacdValues(indicator?.values)
 
   return (
     <div className="flex gap-4">

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -32,6 +32,11 @@ export function formatChangePct(v: number | null): { text: string | null; classN
 /**
  * Build a Yahoo Finance advanced chart URL with pre-configured indicators.
  * Config includes: candlestick + volume, Bollinger Bands (20,2), RSI (14), MACD (12,26,9), 1Y daily.
+ *
+ * NOTE: Study key names contain invisible zero-width non-joiner characters (\u200c).
+ * Yahoo Finance's chart config format requires these characters as delimiters in
+ * study identifiers (e.g. "\u200cvol undr\u200c"). Removing them will break the
+ * pre-configured chart layout when the URL is opened.
  */
 export function buildYahooFinanceUrl(symbol: string): string {
   const config = {

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -263,6 +263,15 @@ export function buildSortOptions(): [string, string][] {
   return base
 }
 
+/** Extract the three MACD values from an indicator values dict. */
+export function extractMacdValues(values?: Record<string, number | string | null>) {
+  return values ? {
+    macd: getNumericValue(values, "macd"),
+    macd_signal: getNumericValue(values, "macd_signal"),
+    macd_hist: getNumericValue(values, "macd_hist"),
+  } : undefined
+}
+
 export function getSeriesByField(field: string): SeriesDescriptor | undefined {
   for (const desc of INDICATOR_REGISTRY) {
     const s = desc.series.find((ser) => ser.field === field)


### PR DESCRIPTION
- Extracts extractMacdValues() helper to DRY up MACD object construction
- Documents zero-width characters in Yahoo Finance URL builder

Fixes #240