### PR TITLE
ci: switch to uv and split test deps out of prod image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: backend/requirements.txt
 
-      - run: pip install -r requirements.txt
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
+
+      - run: uv pip install --system -r requirements-dev.txt
       - run: pytest
 
   test-frontend:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY . .
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest==8.3.5
+pytest-asyncio==0.25.3
+httpx==0.28.1
+aiosqlite==0.21.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,3 @@ yahooquery>=2.3.7
 pandas==2.2.3
 apscheduler==3.11.0
 pydantic-settings==2.9.1
-pytest==8.3.5
-pytest-asyncio==0.25.3
-httpx==0.28.1
-aiosqlite==0.21.0


### PR DESCRIPTION
## Summary
- **Switch CI from pip to uv** (`astral-sh/setup-uv@v5`) for ~5-10x faster dependency installs in the `test-backend` job (#233)
- **Split test deps out of production image** by creating `backend/requirements-dev.txt` with pytest/httpx/aiosqlite, keeping `backend/requirements.txt` prod-only (#234)
- Update `backend/Dockerfile` (dev) to install `requirements-dev.txt`; root `Dockerfile` (prod) unchanged — automatically ships without test packages

## Test plan
- [ ] CI `test-backend` job passes with uv + requirements-dev.txt
- [ ] CI `test-frontend` job unaffected
- [ ] Verify uv cache works on subsequent runs (faster install on cache hit)
- [ ] Rebuild dev containers with `docker compose build backend` — tests still runnable inside container
- [ ] Production `docker build .` excludes pytest/httpx/aiosqlite from final image

Closes #233, Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)