### PR TITLE
feat: add ATR(14) and ADX(14) to indicators endpoint

### DIFF
--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -24,11 +24,12 @@ async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depend
     return await price_service.get_prices(db, asset, symbol, period)
 
 
-@router.get("/indicators", response_model=list[IndicatorResponse], summary="Get technical indicators (RSI, SMA, MACD, Bollinger)")
+@router.get("/indicators", response_model=list[IndicatorResponse], summary="Get technical indicators (RSI, SMA, MACD, Bollinger, ATR, ADX)")
 async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
     """Return daily indicator time series for a symbol.
 
-    Includes RSI (14), SMA 20/50, Bollinger Bands (20, 2σ), and MACD (12/26/9).
+    Includes RSI (14), SMA 20/50, Bollinger Bands (20, 2σ), MACD (12/26/9),
+    ATR (14), and ADX (14) with +DI/-DI.
     An extra 80-day warmup window is fetched internally so that the first
     returned data point already has converged indicator values.
 

--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -106,7 +106,11 @@ async def compute_and_cache_indicators(
 
         df = pd.DataFrame([{
             "date": p.date,
+            "open": float(p.open),
+            "high": float(p.high),
+            "low": float(p.low),
             "close": float(p.close),
+            "volume": p.volume,
         } for p in prices]).set_index("date")
 
         snapshot = build_indicator_snapshot(compute_indicators(df))

--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -56,6 +56,66 @@ def macd(closes: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9) -> 
     return {"macd": macd_line, "signal": signal_line, "histogram": histogram}
 
 
+def _wilder_smooth(data: pd.Series, period: int) -> pd.Series:
+    """Wilder's smoothing method (equivalent to EWM with alpha=1/period).
+
+    First value is a simple sum over the initial `period` rows,
+    then subsequent values use: prev_smooth - (prev_smooth / period) + current.
+    """
+    return data.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+
+
+def _true_range(df: pd.DataFrame) -> pd.Series:
+    """True Range: max(High-Low, |High-PrevClose|, |Low-PrevClose|)."""
+    prev_close = df["close"].shift(1)
+    hl = df["high"] - df["low"]
+    hc = (df["high"] - prev_close).abs()
+    lc = (df["low"] - prev_close).abs()
+    return pd.concat([hl, hc, lc], axis=1).max(axis=1)
+
+
+def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Average True Range using Wilder's smoothing.
+
+    ATR measures volatility in price terms — useful for stop-loss
+    placement, position sizing, and breakout confirmation.
+    """
+    tr = _true_range(df)
+    return _wilder_smooth(tr, period)
+
+
+def adx(df: pd.DataFrame, period: int = 14) -> dict[str, pd.Series]:
+    """Average Directional Index with +DI and -DI using Wilder's smoothing.
+
+    ADX measures trend strength (0-100):
+      >25 = trending, 20-25 = weak/forming, <20 = range-bound.
+    +DI/-DI indicate trend direction.
+    """
+    high = df["high"]
+    low = df["low"]
+
+    # Directional movement
+    up_move = high.diff()
+    down_move = -low.diff()
+
+    plus_dm = pd.Series(0.0, index=df.index)
+    minus_dm = pd.Series(0.0, index=df.index)
+    plus_dm[(up_move > down_move) & (up_move > 0)] = up_move
+    minus_dm[(down_move > up_move) & (down_move > 0)] = down_move
+
+    atr_series = atr(df, period)
+
+    # Smoothed directional indicators
+    plus_di = 100 * _wilder_smooth(plus_dm, period) / atr_series
+    minus_di = 100 * _wilder_smooth(minus_dm, period) / atr_series
+
+    # Directional index and smoothed ADX
+    dx = 100 * (plus_di - minus_di).abs() / (plus_di + minus_di)
+    adx_series = _wilder_smooth(dx, period)
+
+    return {"adx": adx_series, "plus_di": plus_di, "minus_di": minus_di}
+
+
 def bb_position(close: float, upper: float, middle: float, lower: float) -> str:
     """Classify where price sits relative to Bollinger Bands."""
     if close > upper:
@@ -86,6 +146,19 @@ def _bb_snapshot_derived(row: pd.Series) -> dict:
     return {"bb_position": None}
 
 
+def _adx_snapshot_derived(row: pd.Series) -> dict:
+    """Derive ADX trend strength classification from latest row."""
+    if pd.notna(row["adx"]):
+        val = row["adx"]
+        if val > 25:
+            return {"adx_trend": "strong"}
+        elif val >= 20:
+            return {"adx_trend": "weak"}
+        else:
+            return {"adx_trend": "absent"}
+    return {"adx_trend": None}
+
+
 @dataclass(frozen=True)
 class IndicatorDef:
     """Declarative definition of a technical indicator."""
@@ -97,6 +170,7 @@ class IndicatorDef:
     decimals: int = 2
     warmup_periods: int = 0
     snapshot_derived: Callable[[pd.Series], dict] | None = None
+    uses_ohlc: bool = False  # When True, func receives the full DataFrame instead of just closes
 
 
 INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
@@ -138,6 +212,24 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
         decimals=4,
         warmup_periods=35,
         snapshot_derived=_macd_snapshot_derived,
+    ),
+    "atr": IndicatorDef(
+        func=atr,
+        params={"period": 14},
+        output_fields=["atr"],
+        decimals=4,
+        warmup_periods=14,
+        uses_ohlc=True,
+    ),
+    "adx": IndicatorDef(
+        func=adx,
+        params={"period": 14},
+        output_fields=["adx", "plus_di", "minus_di"],
+        result_mapping={"adx": "adx", "plus_di": "plus_di", "minus_di": "minus_di"},
+        decimals=2,
+        warmup_periods=28,
+        snapshot_derived=_adx_snapshot_derived,
+        uses_ohlc=True,
     ),
 }
 
@@ -204,13 +296,16 @@ def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
     result["close"] = closes
 
     for defn in INDICATOR_REGISTRY.values():
-        output = defn.func(closes, **defn.params)
+        # OHLC indicators (ATR, ADX) receive the full DataFrame;
+        # close-only indicators receive just the close Series.
+        input_data = df if defn.uses_ohlc else closes
+        output = defn.func(input_data, **defn.params)
 
         if isinstance(output, pd.Series):
-            # Single-output indicator (e.g. rsi, sma)
+            # Single-output indicator (e.g. rsi, sma, atr)
             result[defn.output_fields[0]] = output
         elif isinstance(output, dict) and defn.result_mapping:
-            # Multi-output indicator (e.g. macd, bollinger_bands)
+            # Multi-output indicator (e.g. macd, bollinger_bands, adx)
             for func_key, col_name in defn.result_mapping.items():
                 result[col_name] = output[func_key]
 

--- a/backend/tests/services/test_indicators.py
+++ b/backend/tests/services/test_indicators.py
@@ -4,7 +4,17 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from app.services.compute.indicators import compute_indicators, get_all_output_fields, rsi, sma, macd
+from app.services.compute.indicators import (
+    _true_range,
+    adx,
+    atr,
+    build_indicator_snapshot,
+    compute_indicators,
+    get_all_output_fields,
+    macd,
+    rsi,
+    sma,
+)
 
 
 def _make_price_df(n: int = 100, start_price: float = 100.0) -> pd.DataFrame:
@@ -62,3 +72,152 @@ def test_compute_indicators_length():
     df = _make_price_df(100)
     result = compute_indicators(df)
     assert len(result) == 100
+
+
+# ---------------------------------------------------------------------------
+# ATR tests (#214)
+# ---------------------------------------------------------------------------
+
+
+def test_true_range_basic():
+    """True Range should equal High - Low when there's no gap."""
+    df = pd.DataFrame({
+        "high": [12.0, 12.0, 12.0],
+        "low": [10.0, 10.0, 10.0],
+        "close": [11.0, 11.0, 11.0],
+    })
+    tr = _true_range(df)
+    # First row: prev close is NaN, but hl = 2.0 is valid so max(skipna) = 2.0
+    assert tr.iloc[0] == pytest.approx(2.0)
+    # Subsequent rows: no gap, so TR = high - low = 2.0
+    assert tr.iloc[1] == pytest.approx(2.0)
+    assert tr.iloc[2] == pytest.approx(2.0)
+
+
+def test_true_range_with_gap():
+    """True Range should account for gaps (prev close outside today's range)."""
+    df = pd.DataFrame({
+        "high": [10.0, 15.0],
+        "low": [8.0, 13.0],
+        "close": [9.0, 14.0],
+    })
+    tr = _true_range(df)
+    # Row 1: hl = 2, |high - prev_close| = |15 - 9| = 6, |low - prev_close| = |13 - 9| = 4
+    # TR = max(2, 6, 4) = 6
+    assert tr.iloc[1] == pytest.approx(6.0)
+
+
+def test_atr_positive():
+    """ATR values should always be positive (volatility can't be negative)."""
+    df = _make_price_df(100)
+    result = atr(df)
+    valid = result.dropna()
+    assert len(valid) > 0
+    assert all(v > 0 for v in valid)
+
+
+def test_atr_length():
+    """ATR output should have same length as input."""
+    df = _make_price_df(100)
+    result = atr(df)
+    assert len(result) == 100
+
+
+def test_atr_warmup_nans():
+    """ATR should have NaN values during the warmup period."""
+    df = _make_price_df(30)
+    result = atr(df, period=14)
+    # First row is always NaN (no prev close for TR), plus warmup
+    assert pd.isna(result.iloc[0])
+
+
+def test_atr_in_compute_indicators():
+    """ATR should appear in compute_indicators output."""
+    df = _make_price_df(100)
+    result = compute_indicators(df)
+    assert "atr" in result.columns
+    valid = result["atr"].dropna()
+    assert len(valid) > 0
+    assert all(v > 0 for v in valid)
+
+
+# ---------------------------------------------------------------------------
+# ADX tests (#215)
+# ---------------------------------------------------------------------------
+
+
+def test_adx_keys():
+    """ADX function should return adx, plus_di, and minus_di."""
+    df = _make_price_df(100)
+    result = adx(df)
+    assert "adx" in result
+    assert "plus_di" in result
+    assert "minus_di" in result
+
+
+def test_adx_range():
+    """ADX and DI values should be between 0 and 100 (when valid)."""
+    df = _make_price_df(200)
+    result = adx(df)
+    for key in ["adx", "plus_di", "minus_di"]:
+        valid = result[key].dropna()
+        # Filter out inf values that can occur with division
+        valid = valid[np.isfinite(valid)]
+        assert len(valid) > 0
+        assert all(v >= 0 for v in valid), f"{key} has negative values"
+        assert all(v <= 100 for v in valid), f"{key} has values > 100"
+
+
+def test_adx_length():
+    """ADX output series should have same length as input."""
+    df = _make_price_df(100)
+    result = adx(df)
+    for key in ["adx", "plus_di", "minus_di"]:
+        assert len(result[key]) == 100
+
+
+def test_adx_in_compute_indicators():
+    """ADX, +DI, -DI should appear in compute_indicators output."""
+    df = _make_price_df(100)
+    result = compute_indicators(df)
+    assert "adx" in result.columns
+    assert "plus_di" in result.columns
+    assert "minus_di" in result.columns
+
+
+def test_adx_strong_trend():
+    """ADX should be high for a consistently trending series."""
+    n = 200
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    # Strong uptrend: price increases monotonically
+    prices = [100.0 + i * 1.0 for i in range(n)]
+    df = pd.DataFrame({
+        "open": [p - 0.2 for p in prices],
+        "high": [p + 0.5 for p in prices],
+        "low": [p - 0.5 for p in prices],
+        "close": prices,
+    }, index=dates)
+    result = adx(df)
+    # Last ADX value should indicate a strong trend (> 25)
+    last_valid = result["adx"].dropna().iloc[-1]
+    assert last_valid > 25, f"ADX should be > 25 for strong trend, got {last_valid}"
+
+
+def test_adx_snapshot_derived():
+    """ADX snapshot should classify trend strength."""
+    df = _make_price_df(200)
+    indicators = compute_indicators(df)
+    snapshot = build_indicator_snapshot(indicators)
+    assert "values" in snapshot
+    assert "adx_trend" in snapshot["values"]
+    # Should be one of the valid classifications or None
+    assert snapshot["values"]["adx_trend"] in ("strong", "weak", "absent", None)
+
+
+def test_atr_adx_in_all_output_fields():
+    """ATR and ADX fields should be listed in get_all_output_fields."""
+    fields = get_all_output_fields()
+    assert "atr" in fields
+    assert "adx" in fields
+    assert "plus_di" in fields
+    assert "minus_di" in fields


### PR DESCRIPTION
## Summary

- Add ATR (Average True Range, 14-period) as a volatility indicator for stop-loss placement and position sizing
- Add ADX (Average Directional Index, 14-period) with +DI/-DI to measure trend strength: strong (>25), weak (20-25), absent (<20)
- Extend the indicator registry with a `uses_ohlc` flag so OHLC-dependent indicators receive the full DataFrame
- Fix group batch indicators to include OHLC columns (was close-only, which broke when OHLC indicators were added)
- Both indicators use Wilder's smoothing and are returned in the existing `values` dict of the `/api/assets/{symbol}/indicators` response

New response fields: `atr`, `adx`, `plus_di`, `minus_di`, `adx_trend` (derived: strong/weak/absent)

Closes #214, Closes #215

## Test plan

- [x] 13 new unit tests covering True Range math, ATR positivity/warmup, ADX range/keys/trend detection/snapshot classification, registry integration
- [x] All 276 existing + new tests pass (including the previously-failing group indicator tests that now include OHLC data)
- [ ] Verify ATR/ADX values appear in `/api/assets/AAPL/indicators` response on dev environment
- [ ] Confirm group indicators endpoint still works with the OHLC DataFrame change

🤖 Generated with [Claude Code](https://claude.com/claude-code)