### PR TITLE
fix: detect KRW and other non-USD currencies for international exchanges

### DIFF
--- a/backend/tests/services/test_yahoo_currency.py
+++ b/backend/tests/services/test_yahoo_currency.py
@@ -1,9 +1,17 @@
-"""Tests for Yahoo Finance currency normalization (subunit → main currency)."""
+"""Tests for Yahoo Finance currency normalization and detection."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pandas as pd
 import pytest
 
-from app.services.yahoo import normalize_currency, _normalize_ohlcv_df
+from app.services.yahoo import (
+    EXCHANGE_CURRENCY_MAP,
+    _currency_from_suffix,
+    _extract_currency,
+    _normalize_ohlcv_df,
+    normalize_currency,
+)
 
 
 class TestNormalizeCurrency:
@@ -45,6 +53,170 @@ class TestNormalizeCurrency:
     def test_unknown_currency_passthrough(self):
         code, divisor = normalize_currency("XYZ")
         assert code == "XYZ"
+        assert divisor == 1
+
+
+class TestCurrencyFromSuffix:
+    """Tests for _currency_from_suffix exchange-suffix-to-currency mapping."""
+
+    def test_kospi_returns_krw(self):
+        assert _currency_from_suffix("006260.KS") == "KRW"
+
+    def test_kosdaq_returns_krw(self):
+        assert _currency_from_suffix("035420.KQ") == "KRW"
+
+    def test_tokyo_returns_jpy(self):
+        assert _currency_from_suffix("7203.T") == "JPY"
+
+    def test_hong_kong_returns_hkd(self):
+        assert _currency_from_suffix("0700.HK") == "HKD"
+
+    def test_xetra_returns_eur(self):
+        assert _currency_from_suffix("VWCE.DE") == "EUR"
+
+    def test_london_returns_gbp(self):
+        assert _currency_from_suffix("HSBA.L") == "GBP"
+
+    def test_toronto_returns_cad(self):
+        assert _currency_from_suffix("RY.TO") == "CAD"
+
+    def test_australia_returns_aud(self):
+        assert _currency_from_suffix("CBA.AX") == "AUD"
+
+    def test_india_nse_returns_inr(self):
+        assert _currency_from_suffix("RELIANCE.NS") == "INR"
+
+    def test_india_bse_returns_inr(self):
+        assert _currency_from_suffix("RELIANCE.BO") == "INR"
+
+    def test_shanghai_returns_cny(self):
+        assert _currency_from_suffix("600519.SS") == "CNY"
+
+    def test_swiss_returns_chf(self):
+        assert _currency_from_suffix("NESN.SW") == "CHF"
+
+    def test_copenhagen_returns_dkk(self):
+        assert _currency_from_suffix("NOVO-B.CO") == "DKK"
+
+    def test_oslo_returns_nok(self):
+        assert _currency_from_suffix("EQNR.OL") == "NOK"
+
+    def test_stockholm_returns_sek(self):
+        assert _currency_from_suffix("VOLV-B.ST") == "SEK"
+
+    def test_no_suffix_returns_none(self):
+        assert _currency_from_suffix("AAPL") is None
+
+    def test_unknown_suffix_returns_none(self):
+        assert _currency_from_suffix("FOO.ZZ") is None
+
+    def test_case_insensitive_suffix(self):
+        """Suffix lookup handles case variations (e.g. '.ks' vs '.KS')."""
+        assert _currency_from_suffix("006260.ks") == "KRW"
+
+    def test_all_map_entries_are_iso_4217_length(self):
+        """All currency codes in the exchange map are 3 characters (ISO 4217)."""
+        for suffix, currency in EXCHANGE_CURRENCY_MAP.items():
+            assert len(currency) == 3, f"{suffix} maps to non-ISO code: {currency}"
+            assert currency == currency.upper(), f"{suffix} maps to non-uppercase: {currency}"
+
+
+class TestExtractCurrency:
+    """Tests for _extract_currency which tries multiple Yahoo data sources."""
+
+    def _make_ticker(self, price_data=None, detail_data=None):
+        """Create a mock Ticker with configurable price and summary_detail."""
+        ticker = MagicMock()
+        type(ticker).price = PropertyMock(return_value=price_data or {})
+        type(ticker).summary_detail = PropertyMock(return_value=detail_data or {})
+        return ticker
+
+    def test_extracts_from_price_data(self):
+        """Primary path: currency from ticker.price."""
+        ticker = self._make_ticker(
+            price_data={"006260.KS": {"currency": "KRW", "regularMarketPrice": 50000}},
+        )
+        currency, divisor = _extract_currency(ticker, "006260.KS")
+        assert currency == "KRW"
+        assert divisor == 1
+
+    def test_normalizes_subunit_from_price_data(self):
+        """Subunit currency (GBp) from ticker.price is normalized to GBP."""
+        ticker = self._make_ticker(
+            price_data={"HSBA.L": {"currency": "GBp"}},
+        )
+        currency, divisor = _extract_currency(ticker, "HSBA.L")
+        assert currency == "GBP"
+        assert divisor == 100
+
+    def test_falls_back_to_summary_detail(self):
+        """When ticker.price has no currency, try ticker.summary_detail."""
+        ticker = self._make_ticker(
+            price_data={"006260.KS": "No data found"},  # error string, not dict
+            detail_data={"006260.KS": {"currency": "KRW"}},
+        )
+        currency, divisor = _extract_currency(ticker, "006260.KS")
+        assert currency == "KRW"
+        assert divisor == 1
+
+    def test_falls_back_to_suffix_when_both_fail(self):
+        """When both Yahoo data sources fail, use exchange suffix mapping."""
+        ticker = self._make_ticker(
+            price_data={"006260.KS": "No data found"},
+            detail_data={"006260.KS": "No data found"},
+        )
+        currency, divisor = _extract_currency(ticker, "006260.KS")
+        assert currency == "KRW"
+        assert divisor == 1
+
+    def test_defaults_to_usd_when_all_fail(self):
+        """When all sources fail and there's no recognized suffix, default to USD."""
+        ticker = self._make_ticker(
+            price_data={"UNKNOWN": "error"},
+            detail_data={"UNKNOWN": "error"},
+        )
+        currency, divisor = _extract_currency(ticker, "UNKNOWN")
+        assert currency == "USD"
+        assert divisor == 1
+
+    def test_price_data_missing_currency_key(self):
+        """When ticker.price returns a dict but without 'currency' key, try fallback."""
+        ticker = self._make_ticker(
+            price_data={"006260.KS": {"regularMarketPrice": 50000}},  # no currency key
+            detail_data={"006260.KS": {"currency": "KRW"}},
+        )
+        currency, divisor = _extract_currency(ticker, "006260.KS")
+        assert currency == "KRW"
+        assert divisor == 1
+
+    def test_price_data_none_currency(self):
+        """When ticker.price has currency=None, try fallback."""
+        ticker = self._make_ticker(
+            price_data={"006260.KS": {"currency": None}},
+            detail_data={"006260.KS": {"currency": "KRW"}},
+        )
+        currency, divisor = _extract_currency(ticker, "006260.KS")
+        assert currency == "KRW"
+        assert divisor == 1
+
+    def test_summary_detail_normalizes_subunit(self):
+        """Subunit from summary_detail is also normalized."""
+        ticker = self._make_ticker(
+            price_data={"HSBA.L": "error"},
+            detail_data={"HSBA.L": {"currency": "GBp"}},
+        )
+        currency, divisor = _extract_currency(ticker, "HSBA.L")
+        assert currency == "GBP"
+        assert divisor == 100
+
+    def test_empty_price_data_dict(self):
+        """Empty dict from ticker.price triggers fallback."""
+        ticker = self._make_ticker(
+            price_data={},
+            detail_data={"AAPL": {"currency": "USD"}},
+        )
+        currency, divisor = _extract_currency(ticker, "AAPL")
+        assert currency == "USD"
         assert divisor == 1
 
 


### PR DESCRIPTION
## Summary
- Fixes currency detection for KOSPI-listed assets (e.g. `006260.KS`) and other international exchanges where `ticker.price` returns an error string instead of currency data
- Adds a three-tier fallback strategy for currency extraction: `ticker.price` -> `ticker.summary_detail` -> exchange suffix mapping (55+ exchanges covered)
- Fixes a secondary bug where providing a `name` when creating an asset skipped Yahoo Finance validation entirely, always defaulting to USD

## Changes
- **`backend/app/services/yahoo.py`**: Added `EXCHANGE_CURRENCY_MAP` (55+ exchange suffixes), `_currency_from_suffix()` helper, and `_extract_currency()` multi-source extraction function. Refactored all currency extraction points (`validate_symbol`, `fetch_history`, `batch_fetch_currencies`, `batch_fetch_quotes`, `batch_fetch_history`) to use the new helper.
- **`backend/app/services/asset_service.py`**: `create_asset()` now always calls `validate_symbol()` for new assets regardless of whether `name` is provided, ensuring currency is always detected. Falls back to exchange suffix when Yahoo fails and name was provided manually.
- **Tests**: Added `TestCurrencyFromSuffix` (18 tests), `TestExtractCurrency` (9 tests), and 3 new asset service tests covering KRW detection, currency detection with manual name, and suffix fallback.

## Test plan
- [x] All 295 existing tests pass
- [x] New tests cover: suffix mapping for KRW/JPY/HKD/EUR/GBP/CAD/AUD/INR/CNY/CHF/DKK/NOK/SEK and more
- [x] New tests cover: `_extract_currency` fallback chain (price -> summary_detail -> suffix -> USD)
- [x] New tests cover: asset creation with KRW currency, manual name + currency detection, suffix fallback when Yahoo fails
- [x] Integration test for `POST /api/assets` with `006260.KS` verifies KRW response

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)