### PR TITLE
ci: cancel in-progress runs on duplicate pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, dev]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
## Summary
- Adds `concurrency` group to CI workflow so that when multiple commits land on the same branch in quick succession, only the latest run completes
- Earlier in-progress runs are automatically cancelled, saving runner minutes and avoiding redundant Docker builds

Closes no issue — quality-of-life improvement.

## Test plan
- [ ] Merge two PRs into `dev` back-to-back, verify the first CI run gets cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)