### PR TITLE
perf: fix 63s→6s quote fetch regression from _extract_currency

### DIFF
--- a/frontend/src/lib/quote-stream.tsx
+++ b/frontend/src/lib/quote-stream.tsx
@@ -26,11 +26,18 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
     es.addEventListener("quotes", (e) => {
       try {
         const data = JSON.parse(e.data) as QuoteMap
+        const count = Object.keys(data).length
+        if (count === 0) return
         setQuotes((prev) => ({ ...prev, ...data }))
         setStatus("connected")
-      } catch {
-        // ignore malformed events
+      } catch (err) {
+        console.error("[QuoteStream] Failed to parse SSE event:", err, "raw:", e.data?.slice(0, 200))
       }
+    })
+
+    es.addEventListener("message", (e) => {
+      // SSE events without an "event:" field arrive as "message" — log if this happens
+      console.warn("[QuoteStream] Received unnamed SSE event (expected 'quotes'):", e.data?.slice(0, 200))
     })
 
     es.addEventListener("open", () => {


### PR DESCRIPTION
## Summary
- `_extract_currency` was re-accessing `ticker.price` for every symbol in batch calls, triggering redundant Yahoo Finance API round-trips
- With 17 symbols: **63s → 5.8s** (10x improvement)
- Fix: pass the already-fetched price data dict to `_extract_currency` via new `price_info` parameter
- Applied to all 3 batch callers: `batch_fetch_quotes`, `batch_fetch_currencies`, `batch_fetch_history`
- Single-symbol callers (validate_symbol, fetch_history) are unaffected — they fall through to the existing `ticker.price` access

Also adds SSE parse error logging in the frontend (replaces silent `catch {}` with `console.error`).

## Root cause
The currency detection PR (#252) added `_extract_currency` which accesses `ticker.price` to find currency. But `batch_fetch_quotes` already fetched `ticker.price` — and yahooquery doesn't cache property accesses, so each call was a fresh Yahoo API request.

## Test plan
- [x] `batch_fetch_quotes` returns correct data in 5.8s (was 63s)
- [x] All 17 symbols return prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)