### PR TITLE
style: muted color palette for pseudo-ETF charts

### DIFF
--- a/frontend/src/lib/chart-utils.ts
+++ b/frontend/src/lib/chart-utils.ts
@@ -2,10 +2,16 @@ import { useState, useEffect, useMemo } from "react"
 import { ColorType } from "lightweight-charts"
 
 export const STACK_COLORS = [
-  "#2563eb", "#dc2626", "#16a34a", "#d97706", "#9333ea",
-  "#0891b2", "#e11d48", "#65a30d", "#c026d3", "#0d9488",
-  "#ea580c", "#4f46e5", "#059669", "#db2777", "#ca8a04",
-  "#7c3aed", "#0284c7", "#be123c", "#15803d", "#a21caf",
+  "#6366f1", // indigo-500
+  "#a78bfa", // violet-400
+  "#2dd4bf", // teal-400
+  "#fbbf24", // amber-400
+  "#f87171", // red-400
+  "#34d399", // emerald-400
+  "#fb923c", // orange-400
+  "#818cf8", // indigo-400
+  "#94a3b8", // slate-400
+  "#c084fc", // purple-400
 ]
 
 export function getChartTheme() {


### PR DESCRIPTION
## Summary
- Replace oversaturated primary `STACK_COLORS` palette in `chart-utils.ts` with muted/desaturated Tailwind tones (indigo, violet, teal, amber, red, emerald, orange, slate, purple)
- All consumers (`StackedAreaChart`, `DailyContributionChart`, `SymbolLegend`) automatically pick up the new colors via the shared constant
- 20 saturated colors reduced to 10 well-chosen muted tones for better visual coherence in both light and dark themes

## Test plan
- [x] `eslint . --max-warnings 0` passes
- [x] `tsc -b` passes
- [ ] Visual check: pseudo-ETF stacked area chart in light mode
- [ ] Visual check: pseudo-ETF daily contribution chart in dark mode

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)