### PR TITLE
feat: replace stacked area chart with multi-line overlay

### DIFF
--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -8,7 +8,7 @@ import { AnnotationsList } from "@/components/annotations-list"
 import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
 import { AddConstituentPicker } from "@/components/add-constituent-picker"
 import {
-  StackedAreaChart,
+  PerformanceOverlayChart,
   DailyContributionChart,
 } from "@/components/chart/pseudo-etf-charts"
 import { STACK_COLORS } from "@/lib/chart-utils"
@@ -81,7 +81,7 @@ export function PseudoEtfDetailPage() {
 
       {performance && performance.length > 0 && (
         <>
-          <StackedAreaChart data={performance} baseValue={etf.base_value} sortedSymbols={sortedSymbols} symbolColorMap={symbolColorMap} />
+          <PerformanceOverlayChart data={performance} baseValue={etf.base_value} sortedSymbols={sortedSymbols} symbolColorMap={symbolColorMap} />
           <PerformanceStats data={performance} baseValue={etf.base_value} />
           {performance.length > 1 && (
             <DailyContributionChart data={performance} sortedSymbols={sortedSymbols} symbolColorMap={symbolColorMap} />


### PR DESCRIPTION
## Summary
- Replaced `StackedAreaChart` with `PerformanceOverlayChart` in pseudo-ETF detail page
- Each constituent is now rendered as an individual `LineSeries`, rebased to base_value (`contribution[sym][date] / contribution[sym][first_date] * baseValue`)
- Added a prominent total index line (thicker, foreground-colored) with crosshair snapping
- Kept the dashed base value reference line at base_value
- SymbolLegend shows per-symbol rebased values and total index value on hover
- Removed unused `AreaSeries` import — no dead code left

## Test plan
- [x] `npx eslint . --max-warnings 0` passes
- [x] `npx tsc -b` passes
- [ ] Visual verification: navigate to a pseudo-ETF detail page and confirm multi-line overlay renders correctly with 10+ symbols
- [ ] Verify crosshair hover shows per-symbol rebased values and index total in legend
- [ ] Verify dark/light theme transitions apply correct colors

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)