### PR TITLE
feat: skeleton loading when switching group view to cards

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AssetActionMenu } from "@/components/asset-action-menu"
 import { MarketStatusDot } from "@/components/market-status-dot"
-import { SparklineChart } from "@/components/sparkline"
+import { DeferredSparkline } from "@/components/sparkline"
 import { RsiGauge } from "@/components/rsi-gauge"
 import { MacdIndicator } from "@/components/macd-indicator"
 import { TagBadge } from "@/components/tag-badge"
@@ -95,7 +95,7 @@ export function AssetCard({
           )}
         </CardHeader>
         <CardContent className="pt-0 space-y-2">
-          {showSparkline && <SparklineChart symbol={symbol} period={sparklinePeriod} batchData={sparklineData} />}
+          {showSparkline && <DeferredSparkline symbol={symbol} period={sparklinePeriod} batchData={sparklineData} />}
           {(showRsi || showMacd) && (
             <div className="flex gap-1.5 mt-1">
               {showRsi && <RsiGauge batchRsi={getNumericValue(indicatorData?.values, "rsi")} />}

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useTransition } from "react"
 import { ArrowDownAZ, ArrowUpAZ, LayoutGrid, Pencil, Table, TrendingUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -31,8 +31,15 @@ export function GroupPage({ groupId }: { groupId: number }) {
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
   const { settings, updateSettings } = useSettings()
-  const viewMode = settings.group_view_mode
-  const setViewMode = (v: "card" | "table") => updateSettings({ group_view_mode: v })
+  const [isPending, startTransition] = useTransition()
+  const [deferredViewMode, setDeferredViewMode] = useState(settings.group_view_mode)
+  const viewMode = deferredViewMode
+  const setViewMode = (v: "card" | "table") => {
+    updateSettings({ group_view_mode: v })
+    startTransition(() => {
+      setDeferredViewMode(v)
+    })
+  }
   const { data: batchSparklines } = useGroupSparklines(groupId, sparklinePeriod)
   const { data: batchIndicators } = useGroupIndicators(groupId)
   const prefetch = usePrefetchAssetDetail(settings.chart_default_period)
@@ -131,7 +138,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
               { value: "card", label: <LayoutGrid className="h-3.5 w-3.5" /> },
               { value: "table", label: <Table className="h-3.5 w-3.5" /> },
             ]}
-            value={viewMode}
+            value={settings.group_view_mode}
             onChange={setViewMode}
           />
         </div>
@@ -173,6 +180,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
         </div>
       )}
 
+      <div className={isPending ? "opacity-70 transition-opacity" : "transition-opacity"}>
       {viewMode === "table" && assets && assets.length > 0 ? (
         <GroupTable
           assets={assets}
@@ -211,6 +219,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
           ))}
         </div>
       )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Wrap the view mode toggle in `useTransition` so React keeps the table visible while preparing the card grid (no freeze on switch)
- Add `DeferredSparkline` component that uses `IntersectionObserver` to defer chart creation until cards scroll into the viewport, preventing 20+ simultaneous `createChart()` calls from blocking the main thread
- Add subtle opacity fade on the current view during transition for visual feedback

## Test plan
- [x] `npx eslint . --max-warnings 0` passes
- [x] `npx tsc -b` passes
- [ ] Manual: switch from table to card view with 20+ assets -- table stays visible briefly, cards appear without freeze, sparklines render progressively
- [ ] Manual: sparklines still show skeleton when data is loading from API (no visual regression)
- [ ] Manual: cards below the fold defer sparkline creation until scrolled into view

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)