### PR TITLE
refactor: decompose PriceChart into standalone components with shared sync context

### DIFF
--- a/frontend/src/components/chart/candlestick-chart.tsx
+++ b/frontend/src/components/chart/candlestick-chart.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useCallback, useMemo, Fragment } from "react"
+import type { IChartApi } from "lightweight-charts"
+import type { Annotation } from "@/lib/api"
+import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
+import {
+  createMainChart,
+  createOverlays,
+  setMainSeriesData,
+  setAllOverlayData,
+  addAnnotationMarkers,
+  type OverlayState,
+  type MarkersHandle,
+} from "./chart-builders"
+import { Legend } from "./chart-legends"
+import { useRegisterChart, useChartHoverValues, useChartData } from "./chart-sync-provider"
+import { getOverlayDescriptors } from "@/lib/indicator-registry"
+
+interface CandlestickChartProps {
+  annotations: Annotation[]
+  /** Per-descriptor visibility (keys = descriptor IDs). Missing keys default to true. */
+  indicatorVisibility?: Record<string, boolean>
+  chartType?: "candle" | "line"
+  height?: number
+  /** Whether to hide the time axis (e.g. when sub-charts are stacked below). */
+  hideTimeAxis?: boolean
+  /** Whether to show the OHLC + overlay legend above the chart. */
+  showLegend?: boolean
+  /** Rounded corner class for the chart container. */
+  roundedClass?: string
+  /** Called with the chart API after creation (for external lifecycle management). */
+  onChartReady?: (chart: IChartApi) => void
+  /** Called when the chart is destroyed. */
+  onChartDestroy?: () => void
+}
+
+interface ChartState {
+  mainChart: IChartApi
+  mainSeries: ReturnType<IChartApi["addSeries"]>
+  overlays: OverlayState
+}
+
+export function CandlestickChart({
+  annotations,
+  indicatorVisibility,
+  chartType = "candle",
+  height = 400,
+  hideTimeAxis = false,
+  showLegend = true,
+  roundedClass = "rounded-md",
+  onChartReady,
+  onChartDestroy,
+}: CandlestickChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const chartStateRef = useRef<ChartState | null>(null)
+  const markersRef = useRef<MarkersHandle | null>(null)
+
+  const { startLifecycle } = useChartLifecycle(containerRef, [chartRef])
+  const register = useRegisterChart()
+  const { hoverValues, latestValues } = useChartHoverValues()
+  const { prices, indicators } = useChartData()
+
+  const isVisible = useCallback(
+    (id: string) => indicatorVisibility?.[id] !== false,
+    [indicatorVisibility],
+  )
+
+  const enabledOverlayIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const d of getOverlayDescriptors()) {
+      if (isVisible(d.id)) ids.add(d.id)
+    }
+    return ids
+  }, [isVisible])
+
+  // Effect 1: Create chart structure
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const { chart, series } = createMainChart(containerRef.current, chartType, height, hideTimeAxis)
+    const overlays = createOverlays(chart)
+
+    chartRef.current = chart
+    chartStateRef.current = { mainChart: chart, mainSeries: series, overlays }
+
+    onChartReady?.(chart)
+
+    const unregister = register({ chart, series, role: "main" })
+    const cleanupLifecycle = startLifecycle([chart])
+
+    return () => {
+      markersRef.current = null
+      chartStateRef.current = null
+      chartRef.current = null
+      onChartDestroy?.()
+      unregister()
+      cleanupLifecycle()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- structural dependencies only
+  }, [chartType, height, hideTimeAxis, register, startLifecycle])
+
+  // Effect 2: Update data in-place
+  useEffect(() => {
+    const state = chartStateRef.current
+    if (!state || !prices.length) return
+
+    setMainSeriesData(state.mainSeries, prices, chartType)
+    setAllOverlayData(state.overlays, indicators, enabledOverlayIds)
+
+    try {
+      markersRef.current?.detach()
+    } catch {
+      /* chart may have been recreated */
+    }
+    markersRef.current = addAnnotationMarkers(state.mainSeries, annotations)
+
+    state.mainChart.timeScale().fitContent()
+  }, [prices, indicators, annotations, enabledOverlayIds, chartType, height])
+
+  const resetView = useCallback(() => {
+    chartRef.current?.timeScale().fitContent()
+  }, [])
+
+  return (
+    <Fragment>
+      {showLegend && (
+        <div className="flex items-center justify-between px-1 py-1">
+          <Legend values={hoverValues} latest={latestValues} />
+          <button
+            onClick={resetView}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded hover:bg-muted"
+            title="Reset chart view"
+          >
+            Reset view
+          </button>
+        </div>
+      )}
+      <div ref={containerRef} className={`w-full ${roundedClass} overflow-hidden`} />
+    </Fragment>
+  )
+}

--- a/frontend/src/components/chart/chart-sync-provider.tsx
+++ b/frontend/src/components/chart/chart-sync-provider.tsx
@@ -1,0 +1,304 @@
+import {
+  createContext,
+  useContext,
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from "react"
+import type { IChartApi } from "lightweight-charts"
+import type { Price, Indicator } from "@/lib/api"
+import type { LegendValues } from "./chart-legends"
+import { getAllIndicatorFields } from "@/lib/indicator-registry"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChartRegistration {
+  chart: IChartApi
+  series: ReturnType<IChartApi["addSeries"]>
+  /** "main" for the candlestick/line chart, or an indicator field for sub-charts. */
+  role: "main" | string
+  /** Field name used to snap the crosshair y-position on this chart. */
+  snapField?: string
+}
+
+interface ChartSyncContextValue {
+  /** Register a chart into the sync group. Returns an unregister function. */
+  register: (entry: ChartRegistration) => () => void
+  /** Current crosshair hover values (null when not hovering). */
+  hoverValues: LegendValues | null
+  /** Latest data values (last price bar + last indicator values). */
+  latestValues: LegendValues
+  /** Prices array from the provider. */
+  prices: Price[]
+  /** Indicators array from the provider. */
+  indicators: Indicator[]
+}
+
+const ChartSyncContext = createContext<ChartSyncContextValue | null>(null)
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface ChartSyncProviderProps {
+  prices: Price[]
+  indicators: Indicator[]
+  children: ReactNode
+}
+
+export function ChartSyncProvider({ prices, indicators, children }: ChartSyncProviderProps) {
+  const [hoverValues, setHoverValues] = useState<LegendValues | null>(null)
+
+  // Lookup maps for fast crosshair snapping
+  const closeByTime = useRef(new Map<string, number>())
+  const ohlcByTime = useRef(new Map<string, { o: number; h: number; l: number; c: number }>())
+  const indicatorsByTime = useRef(new Map<string, Record<string, number>>())
+
+  // Registry of charts participating in sync
+  const registrations = useRef<ChartRegistration[]>([])
+  const syncingRef = useRef(false)
+  // Track subscription cleanup functions per chart
+  const cleanupFns = useRef(new Map<IChartApi, (() => void)[]>())
+
+  // Build lookup maps whenever data changes
+  useEffect(() => {
+    closeByTime.current.clear()
+    ohlcByTime.current.clear()
+    indicatorsByTime.current.clear()
+
+    for (const p of prices) {
+      closeByTime.current.set(p.date, p.close)
+      ohlcByTime.current.set(p.date, { o: p.open, h: p.high, l: p.low, c: p.close })
+    }
+    for (const i of indicators) {
+      const vals: Record<string, number> = {}
+      for (const [field, value] of Object.entries(i.values)) {
+        if (value != null && typeof value === "number") {
+          vals[field] = value
+        }
+      }
+      indicatorsByTime.current.set(i.date, vals)
+    }
+  }, [prices, indicators])
+
+  const getValuesForTime = useCallback((key: string): LegendValues => {
+    const ohlc = ohlcByTime.current.get(key)
+    const indVals = indicatorsByTime.current.get(key) ?? {}
+    return {
+      o: ohlc?.o,
+      h: ohlc?.h,
+      l: ohlc?.l,
+      c: ohlc?.c,
+      indicators: indVals,
+    }
+  }, [])
+
+  // Compute latest values for default legend display
+  const latestValues = useMemo<LegendValues>(() => {
+    if (!prices.length) return { indicators: {} }
+    const lastPrice = prices[prices.length - 1]
+    const reversed = [...indicators].reverse()
+    const findVal = (field: string): number | undefined =>
+      (reversed.find((i) => i.values[field] != null)?.values[field] ?? undefined) as
+        | number
+        | undefined
+
+    const indicatorValues: Record<string, number | undefined> = {}
+    for (const field of getAllIndicatorFields()) {
+      indicatorValues[field] = findVal(field)
+    }
+
+    return {
+      o: lastPrice.open,
+      h: lastPrice.high,
+      l: lastPrice.low,
+      c: lastPrice.close,
+      indicators: indicatorValues,
+    }
+  }, [prices, indicators])
+
+  // Wire up sync subscriptions between all registered charts
+  const wireSync = useCallback(() => {
+    const entries = registrations.current
+
+    // Clean up all existing subscriptions
+    for (const fns of cleanupFns.current.values()) {
+      for (const fn of fns) fn()
+    }
+    cleanupFns.current.clear()
+
+    if (entries.length === 0) return
+
+    const charts = entries.map((e) => e.chart)
+
+    // For each chart, subscribe to visible range changes and crosshair moves
+    for (const source of charts) {
+      const fns: (() => void)[] = []
+
+      // Sync visible time range
+      const rangeHandler = () => {
+        if (syncingRef.current) return
+        syncingRef.current = true
+        const timeRange = source.timeScale().getVisibleRange()
+        if (timeRange) {
+          for (const target of charts) {
+            if (target !== source) {
+              try {
+                target.timeScale().setVisibleRange(timeRange)
+              } catch {
+                // Target chart may not have data yet
+              }
+            }
+          }
+        }
+        syncingRef.current = false
+      }
+      source.timeScale().subscribeVisibleLogicalRangeChange(rangeHandler)
+      fns.push(() => source.timeScale().unsubscribeVisibleLogicalRangeChange(rangeHandler))
+
+      // Sync crosshair position
+      const crosshairHandler: Parameters<IChartApi["subscribeCrosshairMove"]>[0] = (param) => {
+        if (param.time) {
+          setHoverValues(getValuesForTime(String(param.time)))
+        } else {
+          setHoverValues(null)
+        }
+
+        if (syncingRef.current) return
+        syncingRef.current = true
+
+        if (param.time) {
+          const key = String(param.time)
+          for (const entry of entries) {
+            if (entry.role === "main") {
+              const closeVal = closeByTime.current.get(key)
+              if (closeVal !== undefined) {
+                entry.chart.setCrosshairPosition(closeVal, param.time, entry.series)
+              }
+            } else if (entry.snapField) {
+              const val = indicatorsByTime.current.get(key)?.[entry.snapField]
+              if (val !== undefined) {
+                entry.chart.setCrosshairPosition(val, param.time, entry.series)
+              }
+            }
+          }
+        } else {
+          for (const chart of charts) {
+            if (chart !== source) chart.clearCrosshairPosition()
+          }
+        }
+
+        syncingRef.current = false
+      }
+      source.subscribeCrosshairMove(crosshairHandler)
+      fns.push(() => source.unsubscribeCrosshairMove(crosshairHandler))
+
+      cleanupFns.current.set(source, fns)
+    }
+  }, [getValuesForTime])
+
+  // Single-chart crosshair setup (when only one chart is registered)
+  const wireSingleCrosshair = useCallback(
+    (entry: ChartRegistration) => {
+      const fns: (() => void)[] = []
+
+      const handler: Parameters<IChartApi["subscribeCrosshairMove"]>[0] = (param) => {
+        if (param.time) {
+          const key = String(param.time)
+          setHoverValues(getValuesForTime(key))
+          if (!syncingRef.current) {
+            syncingRef.current = true
+            const closeVal = closeByTime.current.get(key)
+            if (closeVal !== undefined) {
+              entry.chart.setCrosshairPosition(closeVal, param.time, entry.series)
+            }
+            syncingRef.current = false
+          }
+        } else {
+          setHoverValues(null)
+        }
+      }
+      entry.chart.subscribeCrosshairMove(handler)
+      fns.push(() => entry.chart.unsubscribeCrosshairMove(handler))
+
+      cleanupFns.current.set(entry.chart, fns)
+    },
+    [getValuesForTime],
+  )
+
+  const register = useCallback(
+    (entry: ChartRegistration): (() => void) => {
+      registrations.current = [...registrations.current, entry]
+
+      // Re-wire sync with the new participant
+      if (registrations.current.length === 1) {
+        wireSingleCrosshair(entry)
+      } else {
+        wireSync()
+      }
+
+      return () => {
+        // Clean up this chart's subscriptions
+        const fns = cleanupFns.current.get(entry.chart)
+        if (fns) {
+          for (const fn of fns) fn()
+          cleanupFns.current.delete(entry.chart)
+        }
+
+        registrations.current = registrations.current.filter((e) => e !== entry)
+
+        // Re-wire remaining charts
+        if (registrations.current.length === 1) {
+          wireSingleCrosshair(registrations.current[0])
+        } else if (registrations.current.length > 1) {
+          wireSync()
+        }
+      }
+    },
+    [wireSync, wireSingleCrosshair],
+  )
+
+  const value = useMemo<ChartSyncContextValue>(
+    () => ({ register, hoverValues, latestValues, prices, indicators }),
+    [register, hoverValues, latestValues, prices, indicators],
+  )
+
+  return <ChartSyncContext.Provider value={value}>{children}</ChartSyncContext.Provider>
+}
+
+// ---------------------------------------------------------------------------
+// Consumer hooks
+// ---------------------------------------------------------------------------
+
+/** Access the full chart sync context (must be used within ChartSyncProvider). */
+function useChartSyncContext(): ChartSyncContextValue {
+  const ctx = useContext(ChartSyncContext)
+  if (!ctx) throw new Error("useChartSyncContext must be used within a ChartSyncProvider")
+  return ctx
+}
+
+/** Register a chart into the sync group. Call inside a chart component's mount effect. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useRegisterChart() {
+  const { register } = useChartSyncContext()
+  return register
+}
+
+/** Read crosshair-position hover values. Works from any component inside ChartSyncProvider. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useChartHoverValues(): { hoverValues: LegendValues | null; latestValues: LegendValues } {
+  const { hoverValues, latestValues } = useChartSyncContext()
+  return { hoverValues, latestValues }
+}
+
+/** Access the prices and indicators data from the provider. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useChartData(): { prices: Price[]; indicators: Indicator[] } {
+  const { prices, indicators } = useChartSyncContext()
+  return { prices, indicators }
+}

--- a/frontend/src/components/chart/macd-chart.tsx
+++ b/frontend/src/components/chart/macd-chart.tsx
@@ -1,0 +1,13 @@
+import type { IChartApi } from "lightweight-charts"
+import { SubChart } from "./sub-chart"
+
+interface MacdChartProps {
+  showLegend?: boolean
+  roundedClass?: string
+  onChartReady?: (chart: IChartApi) => void
+  onChartDestroy?: () => void
+}
+
+export function MacdChart(props: MacdChartProps) {
+  return <SubChart descriptorId="macd" {...props} />
+}

--- a/frontend/src/components/chart/rsi-chart.tsx
+++ b/frontend/src/components/chart/rsi-chart.tsx
@@ -1,0 +1,13 @@
+import type { IChartApi } from "lightweight-charts"
+import { SubChart } from "./sub-chart"
+
+interface RsiChartProps {
+  showLegend?: boolean
+  roundedClass?: string
+  onChartReady?: (chart: IChartApi) => void
+  onChartDestroy?: () => void
+}
+
+export function RsiChart(props: RsiChartProps) {
+  return <SubChart descriptorId="rsi" {...props} />
+}

--- a/frontend/src/components/chart/sub-chart.tsx
+++ b/frontend/src/components/chart/sub-chart.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, Fragment } from "react"
+import type { IChartApi } from "lightweight-charts"
+import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
+import {
+  createSubChart,
+  setSubChartData,
+  type SubChartState,
+} from "./chart-builders"
+import { SubChartLegend } from "./chart-legends"
+import { useRegisterChart, useChartHoverValues, useChartData } from "./chart-sync-provider"
+import { getDescriptorById } from "@/lib/indicator-registry"
+
+interface SubChartProps {
+  /** Indicator descriptor ID (e.g. "rsi", "macd"). */
+  descriptorId: string
+  /** Whether to show the legend above the chart. */
+  showLegend?: boolean
+  /** Rounded corner class for the chart container. */
+  roundedClass?: string
+  /** Called with the chart API after creation. */
+  onChartReady?: (chart: IChartApi) => void
+  /** Called when the chart is destroyed. */
+  onChartDestroy?: () => void
+}
+
+export function SubChart({
+  descriptorId,
+  showLegend = true,
+  roundedClass = "",
+  onChartReady,
+  onChartDestroy,
+}: SubChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const stateRef = useRef<SubChartState | null>(null)
+
+  const { startLifecycle } = useChartLifecycle(containerRef, [chartRef])
+  const registerChart = useRegisterChart()
+  const { hoverValues, latestValues } = useChartHoverValues()
+  const { indicators } = useChartData()
+
+  const descriptor = getDescriptorById(descriptorId)
+
+  // Effect 1: Create chart structure
+  useEffect(() => {
+    if (!containerRef.current || !descriptor) return
+
+    const state = createSubChart(containerRef.current, descriptor)
+    chartRef.current = state.chart
+    stateRef.current = state
+
+    onChartReady?.(state.chart)
+
+    // Register with sync provider — use first series for crosshair snap
+    const firstSeries = state.seriesMap.values().next().value
+    let unregister: (() => void) | undefined
+    if (firstSeries) {
+      unregister = registerChart({
+        chart: state.chart,
+        series: firstSeries,
+        role: descriptorId,
+        snapField: state.snapField,
+      })
+    }
+
+    const cleanupLifecycle = startLifecycle([state.chart])
+
+    return () => {
+      stateRef.current = null
+      chartRef.current = null
+      onChartDestroy?.()
+      unregister?.()
+      cleanupLifecycle()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- structural dependencies only
+  }, [descriptorId, registerChart, startLifecycle])
+
+  // Effect 2: Update data in-place
+  useEffect(() => {
+    const state = stateRef.current
+    if (!state || !indicators.length) return
+
+    setSubChartData(state, indicators)
+    state.chart.timeScale().fitContent()
+  }, [indicators, descriptorId])
+
+  if (!descriptor) return null
+
+  return (
+    <Fragment>
+      {showLegend && (
+        <div className="px-1 py-1">
+          <SubChartLegend descriptorId={descriptorId} values={hoverValues} latest={latestValues} />
+        </div>
+      )}
+      <div ref={containerRef} className={`w-full ${roundedClass} overflow-hidden`} />
+    </Fragment>
+  )
+}

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -1,22 +1,9 @@
-import { useEffect, useRef, useCallback, useMemo, Fragment } from "react"
-import type { IChartApi } from "lightweight-charts"
+import { useMemo, useCallback } from "react"
 import type { Price, Indicator, Annotation } from "@/lib/api"
-import { useChartSync, type ChartEntry } from "@/lib/use-chart-sync"
-import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
-import {
-  createMainChart,
-  createOverlays,
-  createSubChart,
-  setMainSeriesData,
-  setAllOverlayData,
-  setSubChartData,
-  addAnnotationMarkers,
-  type OverlayState,
-  type SubChartState,
-  type MarkersHandle,
-} from "./chart/chart-builders"
-import { Legend, SubChartLegend, type LegendValues } from "./chart/chart-legends"
-import { getSubChartDescriptors, getOverlayDescriptors, getAllIndicatorFields, type IndicatorDescriptor } from "@/lib/indicator-registry"
+import { ChartSyncProvider } from "./chart/chart-sync-provider"
+import { CandlestickChart } from "./chart/candlestick-chart"
+import { SubChart } from "./chart/sub-chart"
+import { getSubChartDescriptors } from "@/lib/indicator-registry"
 
 const SUB_CHART_DESCRIPTORS = getSubChartDescriptors()
 
@@ -30,13 +17,6 @@ interface PriceChartProps {
   mainChartHeight?: number
 }
 
-interface ChartState {
-  mainChart: IChartApi
-  mainSeries: ReturnType<IChartApi["addSeries"]>
-  overlays: OverlayState
-  subCharts: SubChartState[]
-}
-
 export function PriceChart({
   prices,
   indicators,
@@ -45,193 +25,38 @@ export function PriceChart({
   chartType = "candle",
   mainChartHeight = 400,
 }: PriceChartProps) {
-  const mainRef = useRef<HTMLDivElement>(null)
-
-  // Pre-create refs for main + all possible sub-charts (hooks must be unconditional)
-  const mainChartRef = useRef<IChartApi | null>(null)
-  const subChartApiRefs = useRef(
-    Object.fromEntries(
-      SUB_CHART_DESCRIPTORS.map((d) => [d.id, { current: null as IChartApi | null }]),
-    ) as Record<string, { current: IChartApi | null }>,
-  )
-  const allChartRefs = useMemo(
-    () => [mainChartRef, ...SUB_CHART_DESCRIPTORS.map((d) => subChartApiRefs.current[d.id])],
-    [],
-  )
-  const subContainersRef = useRef(new Map<string, HTMLDivElement>())
-  const { startLifecycle } = useChartLifecycle(mainRef, allChartRefs)
-
-  const { hoverValues, buildLookupMaps, syncCharts, setupSingleChartCrosshair } = useChartSync()
-
-  const chartStateRef = useRef<ChartState | null>(null)
-  const markersRef = useRef<MarkersHandle | null>(null)
-
   const isVisible = useCallback(
     (id: string) => indicatorVisibility?.[id] !== false,
     [indicatorVisibility],
   )
 
-  const enabledOverlayIds = useMemo(() => {
-    const ids = new Set<string>()
-    for (const d of getOverlayDescriptors()) {
-      if (isVisible(d.id)) ids.add(d.id)
-    }
-    return ids
-  }, [isVisible])
-
-  const enabledSubCharts = useMemo<IndicatorDescriptor[]>(
+  const enabledSubCharts = useMemo(
     () => SUB_CHART_DESCRIPTORS.filter((d) => isVisible(d.id)),
     [isVisible],
   )
 
   const hasSubCharts = enabledSubCharts.length > 0
-
-  // Compute latest values for default legend display
-  const latestValues = useMemo<LegendValues>(() => {
-    if (!prices.length) return { indicators: {} }
-    const lastPrice = prices[prices.length - 1]
-    const lastIndicators = [...indicators].reverse()
-    const findVal = (field: string): number | undefined =>
-      (lastIndicators.find((i) => i.values[field] != null)?.values[field] ?? undefined) as number | undefined
-
-    const indicatorValues: Record<string, number | undefined> = {}
-    for (const field of getAllIndicatorFields()) {
-      indicatorValues[field] = findVal(field)
-    }
-
-    return {
-      o: lastPrice.open,
-      h: lastPrice.high,
-      l: lastPrice.low,
-      c: lastPrice.close,
-      indicators: indicatorValues,
-    }
-  }, [prices, indicators])
-
-  // Effect 1: Create chart structure (runs only on structural changes)
-  useEffect(() => {
-    if (!mainRef.current) return
-    // Ensure all enabled sub-chart containers are mounted
-    for (const desc of enabledSubCharts) {
-      if (!subContainersRef.current.has(desc.id)) return
-    }
-
-    const hideTimeAxis = hasSubCharts
-    const { chart: mainChart, series: mainSeries } = createMainChart(
-      mainRef.current, chartType, mainChartHeight, hideTimeAxis,
-    )
-    const overlays = createOverlays(mainChart)
-
-    mainChartRef.current = mainChart
-
-    const chartEntries: ChartEntry[] = [{ chart: mainChart, series: mainSeries }]
-    const createdCharts: IChartApi[] = [mainChart]
-    const subCharts: SubChartState[] = []
-
-    for (const desc of enabledSubCharts) {
-      const container = subContainersRef.current.get(desc.id)
-      if (!container) continue
-
-      const state = createSubChart(container, desc)
-      subChartApiRefs.current[desc.id].current = state.chart
-
-      // First series handle for crosshair snap
-      const firstSeries = state.seriesMap.values().next().value
-      if (firstSeries) {
-        chartEntries.push({ chart: state.chart, series: firstSeries, snapField: state.snapField })
-      }
-      createdCharts.push(state.chart)
-      subCharts.push(state)
-    }
-
-    // Sync all created charts
-    if (chartEntries.length > 1) {
-      syncCharts(chartEntries)
-    } else {
-      setupSingleChartCrosshair(mainChart, mainSeries)
-    }
-
-    chartStateRef.current = { mainChart, mainSeries, overlays, subCharts }
-
-    const cleanupLifecycle = startLifecycle(createdCharts)
-    const apiRefs = subChartApiRefs.current
-    return () => {
-      markersRef.current = null
-      chartStateRef.current = null
-      // Clear sub-chart refs
-      for (const desc of SUB_CHART_DESCRIPTORS) {
-        apiRefs[desc.id].current = null
-      }
-      cleanupLifecycle()
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- enabledSubCharts identity changes trigger re-creation
-  }, [chartType, enabledSubCharts, mainChartHeight, syncCharts, setupSingleChartCrosshair, startLifecycle])
-
-  // Effect 2: Update data in-place (runs on data and overlay toggle changes)
-  useEffect(() => {
-    const state = chartStateRef.current
-    if (!state || !prices.length) return
-
-    buildLookupMaps(prices, indicators)
-
-    // Main series data
-    setMainSeriesData(state.mainSeries, prices, chartType)
-
-    // Overlay data (disabled overlays get empty data)
-    setAllOverlayData(state.overlays, indicators, enabledOverlayIds)
-
-    // Annotation markers — detach old, create new
-    try { markersRef.current?.detach() } catch { /* chart may have been recreated */ }
-    markersRef.current = addAnnotationMarkers(state.mainSeries, annotations)
-
-    // Sub-chart data
-    for (const sc of state.subCharts) {
-      setSubChartData(sc, indicators)
-    }
-
-    // Fit content on all charts
-    state.mainChart.timeScale().fitContent()
-    for (const sc of state.subCharts) {
-      sc.chart.timeScale().fitContent()
-    }
-  }, [prices, indicators, annotations, enabledOverlayIds, chartType, enabledSubCharts, mainChartHeight, buildLookupMaps])
-
-  const resetView = useCallback(() => {
-    mainChartRef.current?.timeScale().fitContent()
-    for (const desc of SUB_CHART_DESCRIPTORS) {
-      subChartApiRefs.current[desc.id].current?.timeScale().fitContent()
-    }
-  }, [])
-
-  const mainRoundClass = !hasSubCharts ? "rounded-md" : "rounded-t-md"
+  const mainRoundedClass = hasSubCharts ? "rounded-t-md" : "rounded-md"
 
   return (
-    <div className="mb-4">
-      <div className="flex items-center justify-between px-1 py-1">
-        <Legend values={hoverValues} latest={latestValues} />
-        <button
-          onClick={resetView}
-          className="text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded hover:bg-muted"
-          title="Reset chart view"
-        >
-          Reset view
-        </button>
-      </div>
-      <div ref={mainRef} className={`w-full ${mainRoundClass} overflow-hidden`} />
-      {enabledSubCharts.map((desc, idx) => (
-        <Fragment key={desc.id}>
-          <div className="px-1 py-1">
-            <SubChartLegend descriptorId={desc.id} values={hoverValues} latest={latestValues} />
-          </div>
-          <div
-            ref={(el) => {
-              if (el) subContainersRef.current.set(desc.id, el)
-              else subContainersRef.current.delete(desc.id)
-            }}
-            className={`w-full ${idx === enabledSubCharts.length - 1 ? "rounded-b-md" : ""} overflow-hidden`}
+    <ChartSyncProvider prices={prices} indicators={indicators}>
+      <div className="mb-4">
+        <CandlestickChart
+          annotations={annotations}
+          indicatorVisibility={indicatorVisibility}
+          chartType={chartType}
+          height={mainChartHeight}
+          hideTimeAxis={hasSubCharts}
+          roundedClass={mainRoundedClass}
+        />
+        {enabledSubCharts.map((desc, idx) => (
+          <SubChart
+            key={desc.id}
+            descriptorId={desc.id}
+            roundedClass={idx === enabledSubCharts.length - 1 ? "rounded-b-md" : ""}
           />
-        </Fragment>
-      ))}
-    </div>
+        ))}
+      </div>
+    </ChartSyncProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Extracted the monolithic `PriceChart` into composable standalone chart components (`CandlestickChart`, `RsiChart`, `MacdChart`) that synchronize crosshairs via a shared `ChartSyncProvider` context
- Created `useRegisterChart()` hook for charts to join the sync group on mount, and `useChartHoverValues()` hook for any consumer to read crosshair-position values
- Recomposed `PriceChart` as a thin wrapper using the new components (backwards-compatible, no changes to asset detail page behavior)
- Upgraded `ExpandedContent` in group-table to use hover-reactive gauges that update RSI/MACD values as the user moves the crosshair over the chart

## New files
- `frontend/src/components/chart/chart-sync-provider.tsx` -- `ChartSyncProvider` context + `useRegisterChart`, `useChartHoverValues`, `useChartData` hooks
- `frontend/src/components/chart/candlestick-chart.tsx` -- Standalone main chart with overlays
- `frontend/src/components/chart/sub-chart.tsx` -- Generic standalone sub-chart (used by RSI/MACD)
- `frontend/src/components/chart/rsi-chart.tsx` -- Named RSI chart wrapper
- `frontend/src/components/chart/macd-chart.tsx` -- Named MACD chart wrapper

## Modified files
- `frontend/src/components/price-chart.tsx` -- Rewritten as thin wrapper (~60 lines, was ~237)
- `frontend/src/components/group-table.tsx` -- `ExpandedContent` now uses `ChartSyncProvider` + `CandlestickChart` with `HoverReactiveGauges`

## Test plan
- [x] `npx tsc -b` passes (TypeScript type check)
- [x] `npx eslint . --max-warnings 0` passes (lint clean)
- [ ] Asset detail page renders identically to before (stacked candlestick + RSI + MACD charts with synced crosshairs)
- [ ] Group table expanded row: chart renders with hover-reactive RSI/MACD gauges that update on crosshair movement
- [ ] Multiple charts in the same `ChartSyncProvider` sync their time range and crosshair position

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)