### PR TITLE
feat: combine MACD into single table column with inline M/S/H values

### DIFF
--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -311,6 +311,32 @@ function TableRow({
           )}
         </td>
         {SORTABLE_FIELDS.map((field) => {
+          if (field === "macd") {
+            const macdVals = extractMacdValues(indicator?.values)
+            const m = macdVals?.macd
+            const s = macdVals?.macd_signal
+            const h = macdVals?.macd_hist
+            const hasValues = m != null || s != null || h != null
+            const histColor = h != null ? (h >= 0 ? "text-emerald-400" : "text-red-400") : ""
+            const fmt = (v: number | null | undefined) =>
+              v != null ? v.toFixed(Math.abs(v) >= 100 ? 0 : 2) : "--"
+            return (
+              <td key={field} className={`${py} px-3 text-right text-sm tabular-nums`}>
+                {hasValues ? (
+                  <span className="inline-flex items-center gap-2">
+                    <span className="text-muted-foreground">M</span>
+                    <span>{fmt(m)}</span>
+                    <span className="text-muted-foreground">S</span>
+                    <span>{fmt(s)}</span>
+                    <span className="text-muted-foreground">H</span>
+                    <span className={histColor}>{fmt(h)}</span>
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">&mdash;</span>
+                )}
+              </td>
+            )
+          }
           const val = getNumericValue(indicator?.values, field)
           const series = getSeriesByField(field)
           const colorClass = resolveThresholdColor(series?.thresholdColors, val)

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -153,7 +153,7 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
     shortLabel: "MACD",
     placement: "subchart",
     fields: ["macd", "macd_signal", "macd_hist"],
-    sortableFields: ["macd", "macd_signal", "macd_hist"],
+    sortableFields: ["macd"],
     series: [
       {
         field: "macd_hist",


### PR DESCRIPTION
## Summary
- Merged 3 separate MACD columns (MACD, Signal, Histogram) into a single combined "MACD" column in the group table view
- Combined cell displays inline `M {val}  S {val}  H {val}` format with histogram value color-coded (emerald for positive, red for negative)
- Sorting on the MACD column sorts by the MACD line value
- RSI column remains unchanged

## Changes
- `frontend/src/lib/indicator-registry.ts`: Changed MACD `sortableFields` from `["macd", "macd_signal", "macd_hist"]` to `["macd"]`
- `frontend/src/components/group-table.tsx`: Added combined MACD cell rendering in `TableRow` that uses `extractMacdValues()` to display all three values inline with histogram coloring

## Test plan
- [x] `npx eslint . --max-warnings 0` passes
- [x] `npx tsc -b` passes
- [ ] Visual verification: group table shows single MACD column with M/S/H format
- [ ] Verify sorting by MACD column works correctly
- [ ] Verify histogram value shows emerald (positive) / red (negative) coloring

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)