### PR TITLE
feat: configurable column visibility in group table view

### DIFF
--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
-import { ChevronRight, ChevronDown } from "lucide-react"
+import { ChevronRight, ChevronDown, Settings2 } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { TagBadge } from "@/components/tag-badge"
 import { AssetActionMenu } from "@/components/asset-action-menu"
 import { MarketStatusDot } from "@/components/market-status-dot"
@@ -10,6 +11,14 @@ import { RsiGauge } from "@/components/rsi-gauge"
 import { MacdIndicator } from "@/components/macd-indicator"
 import { ChartSyncProvider, useChartHoverValues } from "@/components/chart/chart-sync-provider"
 import { CandlestickChart } from "@/components/chart/candlestick-chart"
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuCheckboxItem,
+} from "@/components/ui/dropdown-menu"
 import { ArrowUp, ArrowDown } from "lucide-react"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
 import type { GroupSortBy, SortDir } from "@/lib/settings"
@@ -27,6 +36,18 @@ import { useSettings } from "@/lib/settings"
 
 const SORTABLE_FIELDS = getAllSortableFields()
 
+/** Column identifiers for base (non-indicator) toggleable columns. */
+const BASE_COLUMN_DEFS: { key: string; label: string }[] = [
+  { key: "name", label: "Name" },
+  { key: "price", label: "Price" },
+  { key: "change_pct", label: "Change %" },
+]
+
+/** Check whether a column is visible. Missing key = visible (opt-out model). */
+function isColumnVisible(columnSettings: Record<string, boolean>, key: string): boolean {
+  return columnSettings[key] !== false
+}
+
 interface GroupTableProps {
   assets: Asset[]
   quotes: Record<string, Quote>
@@ -41,6 +62,8 @@ interface GroupTableProps {
 
 export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort }: GroupTableProps) {
   const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(new Set())
+  const { settings, updateSettings } = useSettings()
+  const columnSettings = settings.group_table_columns
 
   const toggleExpand = (symbol: string) => {
     setExpandedSymbols((prev) => {
@@ -51,6 +74,23 @@ export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, 
     })
   }
 
+  const toggleColumn = (key: string) => {
+    const current = isColumnVisible(columnSettings, key)
+    updateSettings({
+      group_table_columns: { ...columnSettings, [key]: !current },
+    })
+  }
+
+  const visibleIndicatorFields = useMemo(
+    () => SORTABLE_FIELDS.filter((f) => isColumnVisible(columnSettings, f)),
+    [columnSettings],
+  )
+
+  // Total visible columns: expand chevron (1) + symbol (1) + toggleable base + toggleable indicators + action menu (1)
+  const visibleBaseCount =
+    BASE_COLUMN_DEFS.filter((c) => isColumnVisible(columnSettings, c.key)).length
+  const totalColSpan = 1 + 1 + visibleBaseCount + visibleIndicatorFields.length + 1
+
   return (
     <div className="rounded-md border border-border overflow-hidden">
       <table className="w-full">
@@ -58,10 +98,16 @@ export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, 
           <tr className="border-b border-border bg-muted/50">
             <th className="w-8" />
             <SortableHeader label="Symbol" sortKey="name" align="left" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
-            <th className="text-left text-xs font-medium text-muted-foreground px-3 py-2">Name</th>
-            <SortableHeader label="Price" sortKey="price" align="right" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
-            <SortableHeader label="Change" sortKey="change_pct" align="right" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
-            {SORTABLE_FIELDS.map((field) => {
+            {isColumnVisible(columnSettings, "name") && (
+              <th className="text-left text-xs font-medium text-muted-foreground px-3 py-2">Name</th>
+            )}
+            {isColumnVisible(columnSettings, "price") && (
+              <SortableHeader label="Price" sortKey="price" align="right" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
+            )}
+            {isColumnVisible(columnSettings, "change_pct") && (
+              <SortableHeader label="Change" sortKey="change_pct" align="right" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
+            )}
+            {visibleIndicatorFields.map((field) => {
               const series = getSeriesByField(field)
               return (
                 <SortableHeader
@@ -75,7 +121,12 @@ export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, 
                 />
               )
             })}
-            <th className="w-8" />
+            <th className="w-8 text-right pr-1">
+              <ColumnVisibilityMenu
+                columnSettings={columnSettings}
+                onToggle={toggleColumn}
+              />
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -90,11 +141,77 @@ export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, 
               onDelete={() => onDelete(asset.symbol)}
               onHover={() => onHover?.(asset.symbol)}
               compactMode={compactMode}
+              columnSettings={columnSettings}
+              visibleIndicatorFields={visibleIndicatorFields}
+              totalColSpan={totalColSpan}
             />
           ))}
         </tbody>
       </table>
     </div>
+  )
+}
+
+function ColumnVisibilityMenu({
+  columnSettings,
+  onToggle,
+}: {
+  columnSettings: Record<string, boolean>
+  onToggle: (key: string) => void
+}) {
+  // Build indicator column defs from registry
+  const indicatorColumnDefs = useMemo(
+    () =>
+      SORTABLE_FIELDS.map((field) => {
+        const series = getSeriesByField(field)
+        return { key: field, label: series?.label ?? field }
+      }),
+    [],
+  )
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          aria-label="Toggle column visibility"
+        >
+          <Settings2 className="h-3.5 w-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuLabel>Columns</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {BASE_COLUMN_DEFS.map(({ key, label }) => (
+          <DropdownMenuCheckboxItem
+            key={key}
+            checked={isColumnVisible(columnSettings, key)}
+            onCheckedChange={() => onToggle(key)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            {label}
+          </DropdownMenuCheckboxItem>
+        ))}
+        {indicatorColumnDefs.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Indicators</DropdownMenuLabel>
+            {indicatorColumnDefs.map(({ key, label }) => (
+              <DropdownMenuCheckboxItem
+                key={key}
+                checked={isColumnVisible(columnSettings, key)}
+                onCheckedChange={() => onToggle(key)}
+                onSelect={(e) => e.preventDefault()}
+              >
+                {label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
@@ -232,6 +349,9 @@ function TableRow({
   onDelete,
   onHover,
   compactMode,
+  columnSettings,
+  visibleIndicatorFields,
+  totalColSpan,
 }: {
   asset: Asset
   quote?: Quote
@@ -241,6 +361,9 @@ function TableRow({
   onDelete: () => void
   onHover: () => void
   compactMode: boolean
+  columnSettings: Record<string, boolean>
+  visibleIndicatorFields: string[]
+  totalColSpan: number
 }) {
   const lastPrice = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
@@ -279,38 +402,44 @@ function TableRow({
             </Badge>
           </div>
         </td>
-        <td className={`${py} px-3 text-sm text-muted-foreground max-w-[250px]`}>
-          <div className="flex items-center gap-2 truncate">
-            <span className="truncate">{asset.name}</span>
-            {asset.tags.length > 0 && (
-              <span className="flex gap-1 shrink-0">
-                {asset.tags.map((tag) => (
-                  <TagBadge key={tag.id} name={tag.name} color={tag.color} />
-                ))}
+        {isColumnVisible(columnSettings, "name") && (
+          <td className={`${py} px-3 text-sm text-muted-foreground max-w-[250px]`}>
+            <div className="flex items-center gap-2 truncate">
+              <span className="truncate">{asset.name}</span>
+              {asset.tags.length > 0 && (
+                <span className="flex gap-1 shrink-0">
+                  {asset.tags.map((tag) => (
+                    <TagBadge key={tag.id} name={tag.name} color={tag.color} />
+                  ))}
+                </span>
+              )}
+            </div>
+          </td>
+        )}
+        {isColumnVisible(columnSettings, "price") && (
+          <td className={`${py} px-3 text-right tabular-nums`}>
+            {lastPrice != null ? (
+              <span ref={priceRef} className="font-medium rounded px-1 -mx-1">
+                {formatPrice(lastPrice, asset.currency)}
               </span>
+            ) : (
+              <Skeleton className="h-4 w-14 ml-auto rounded" />
             )}
-          </div>
-        </td>
-        <td className={`${py} px-3 text-right tabular-nums`}>
-          {lastPrice != null ? (
-            <span ref={priceRef} className="font-medium rounded px-1 -mx-1">
-              {formatPrice(lastPrice, asset.currency)}
-            </span>
-          ) : (
-            <Skeleton className="h-4 w-14 ml-auto rounded" />
-          )}
-        </td>
-        <td className={`${py} px-3 text-right tabular-nums`}>
-          {changePct != null ? (
-            <span ref={pctRef} className={`font-medium rounded px-1 -mx-1 ${changeColor}`}>
-              {changePct >= 0 ? "+" : ""}
-              {changePct.toFixed(2)}%
-            </span>
-          ) : (
-            <Skeleton className="h-4 w-12 ml-auto rounded" />
-          )}
-        </td>
-        {SORTABLE_FIELDS.map((field) => {
+          </td>
+        )}
+        {isColumnVisible(columnSettings, "change_pct") && (
+          <td className={`${py} px-3 text-right tabular-nums`}>
+            {changePct != null ? (
+              <span ref={pctRef} className={`font-medium rounded px-1 -mx-1 ${changeColor}`}>
+                {changePct >= 0 ? "+" : ""}
+                {changePct.toFixed(2)}%
+              </span>
+            ) : (
+              <Skeleton className="h-4 w-12 ml-auto rounded" />
+            )}
+          </td>
+        )}
+        {visibleIndicatorFields.map((field) => {
           if (field === "macd") {
             const macdVals = extractMacdValues(indicator?.values)
             const m = macdVals?.macd
@@ -360,7 +489,7 @@ function TableRow({
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={6 + SORTABLE_FIELDS.length} className="bg-muted/20 p-4 border-b border-border">
+          <td colSpan={totalColSpan} className="bg-muted/20 p-4 border-b border-border">
             <ExpandedContent symbol={asset.symbol} indicator={indicator} />
           </td>
         </tr>

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -15,6 +15,7 @@ export interface AppSettings {
   group_type_filter: AssetTypeFilter
   group_sort_by: GroupSortBy
   group_sort_dir: SortDir
+  group_table_columns: Record<string, boolean>
   detail_indicator_visibility: Record<string, boolean>
   chart_default_period: string
   chart_type: "candle" | "line"
@@ -36,6 +37,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   group_type_filter: "all",
   group_sort_by: "name",
   group_sort_dir: "asc",
+  group_table_columns: {},
   detail_indicator_visibility: defaultVisibility(),
   chart_default_period: "1y",
   chart_type: "candle",


### PR DESCRIPTION
## Summary
- Added `group_table_columns` setting (`Record<string, boolean>`) to `AppSettings` with opt-out model (missing key = visible, `false` = hidden)
- Added a column visibility dropdown menu (gear icon) in the table header's action column, using `DropdownMenuCheckboxItem` to toggle base columns (Name, Price, Change %) and indicator columns (RSI, MACD) independently
- Gated header, cell, and indicator column rendering in both `GroupTable` and `TableRow` based on visibility settings
- Updated expanded row `colSpan` to be dynamically computed from visible column count
- Symbol column and action menu column are always visible and not toggleable
- Setting persists across sessions via localStorage + backend sync through existing `useSettings()` hook

## Test plan
- [x] `npx eslint . --max-warnings 0` passes
- [x] `npx tsc -b` passes
- [ ] Manual: verify column visibility dropdown appears as gear icon in table header
- [ ] Manual: toggling columns hides/shows corresponding headers and cells
- [ ] Manual: expanded row spans correct number of columns
- [ ] Manual: settings persist after page reload

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)