### PR TITLE
feat: opt-in crosshair sync across pseudo-ETF charts (#262)

### DIFF
--- a/frontend/src/components/chart/crosshair-time-sync.tsx
+++ b/frontend/src/components/chart/crosshair-time-sync.tsx
@@ -1,0 +1,86 @@
+import { createContext, useContext, useRef, useCallback, type ReactNode } from "react"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type TimeListener = (time: string | null) => void
+
+interface CrosshairTimeSyncContextValue {
+  /**
+   * Subscribe to shared crosshair time changes. The `identity` object is used
+   * to skip the subscriber when it is also the broadcast source, preventing
+   * feedback loops. Returns an unsubscribe function.
+   */
+  subscribe: (listener: TimeListener, identity: object) => () => void
+  /**
+   * Broadcast a crosshair time to all subscribers except those registered
+   * with the same `sourceIdentity`.
+   */
+  broadcast: (time: string | null, sourceIdentity: object) => void
+}
+
+const CrosshairTimeSyncContext = createContext<CrosshairTimeSyncContextValue | null>(null)
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface CrosshairTimeSyncProviderProps {
+  enabled: boolean
+  children: ReactNode
+}
+
+interface ListenerEntry {
+  listener: TimeListener
+  identity: object
+}
+
+/**
+ * Shares crosshair time position across multiple independent ChartSyncProvider
+ * instances. When disabled, renders children without the context so each
+ * ChartSyncProvider operates independently.
+ *
+ * Uses a pub/sub pattern (not React state) to avoid re-renders on every
+ * crosshair move -- subscribers are called imperatively.
+ */
+export function CrosshairTimeSyncProvider({ enabled, children }: CrosshairTimeSyncProviderProps) {
+  const entriesRef = useRef<ListenerEntry[]>([])
+
+  const subscribe = useCallback((listener: TimeListener, identity: object): (() => void) => {
+    const entry: ListenerEntry = { listener, identity }
+    entriesRef.current = [...entriesRef.current, entry]
+    return () => {
+      entriesRef.current = entriesRef.current.filter((e) => e !== entry)
+    }
+  }, [])
+
+  const broadcast = useCallback((time: string | null, sourceIdentity: object) => {
+    for (const entry of entriesRef.current) {
+      if (entry.identity !== sourceIdentity) {
+        entry.listener(time)
+      }
+    }
+  }, [])
+
+  if (!enabled) return <>{children}</>
+
+  return (
+    <CrosshairTimeSyncContext.Provider value={{ subscribe, broadcast }}>
+      {children}
+    </CrosshairTimeSyncContext.Provider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Consumer hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the crosshair time sync context, or null if not within a
+ * CrosshairTimeSyncProvider (or if sync is disabled).
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useCrosshairTimeSync(): CrosshairTimeSyncContextValue | null {
+  return useContext(CrosshairTimeSyncContext)
+}

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -22,6 +22,7 @@ export interface AppSettings {
   theme: "dark" | "light" | "system"
   compact_mode: boolean
   decimal_places: number
+  sync_pseudo_etf_crosshairs: boolean
 }
 
 function defaultVisibility(): Record<string, boolean> {
@@ -44,6 +45,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   theme: "system",
   compact_mode: false,
   decimal_places: 2,
+  sync_pseudo_etf_crosshairs: false,
 }
 
 const STORAGE_KEY = "fibenchi-settings"

--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -3,15 +3,19 @@ import { useParams, Link } from "react-router-dom"
 import { ArrowLeft, UserPlus, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
 import { ThesisEditor } from "@/components/thesis-editor"
 import { AnnotationsList } from "@/components/annotations-list"
 import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
 import { AddConstituentPicker } from "@/components/add-constituent-picker"
+import { CrosshairTimeSyncProvider } from "@/components/chart/crosshair-time-sync"
 import {
   PerformanceOverlayChart,
   DailyContributionChart,
 } from "@/components/chart/pseudo-etf-charts"
 import { STACK_COLORS } from "@/lib/chart-utils"
+import { useSettings } from "@/lib/settings"
 import type { PerformanceBreakdownPoint } from "@/lib/api"
 import {
   usePseudoEtf,
@@ -164,6 +168,8 @@ function HoldingsTable({ etfId }: { etfId: number }) {
   )
   const removeConstituent = useRemovePseudoEtfConstituent()
   const [addingAsset, setAddingAsset] = useState(false)
+  const { settings, updateSettings } = useSettings()
+  const syncEnabled = settings.sync_pseudo_etf_crosshairs
 
   if (!etf) return null
 
@@ -182,7 +188,27 @@ function HoldingsTable({ etfId }: { etfId: number }) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-base">Holdings ({etf.constituents.length})</CardTitle>
+        <div className="flex items-center gap-4">
+          <CardTitle className="text-base">Holdings ({etf.constituents.length})</CardTitle>
+          {etf.constituents.length > 1 && (
+            <div className="flex items-center gap-1.5">
+              <Switch
+                id="sync-crosshairs"
+                size="sm"
+                checked={syncEnabled}
+                onCheckedChange={(checked: boolean) =>
+                  updateSettings({ sync_pseudo_etf_crosshairs: checked })
+                }
+              />
+              <Label
+                htmlFor="sync-crosshairs"
+                className="text-xs text-muted-foreground font-normal cursor-pointer"
+              >
+                Sync crosshairs
+              </Label>
+            </div>
+          )}
+        </div>
         <Button size="sm" variant="ghost" onClick={() => setAddingAsset(!addingAsset)}>
           <UserPlus className="h-3.5 w-3.5 mr-1" />
           Add
@@ -202,12 +228,14 @@ function HoldingsTable({ etfId }: { etfId: number }) {
         )}
 
         {etf.constituents.length > 0 && (
-          <HoldingsGrid
-            rows={rows}
-            indicatorMap={indicatorMap}
-            indicatorsLoading={indicatorsLoading}
-            onRemove={(key) => removeConstituent.mutate({ etfId, assetId: key as number })}
-          />
+          <CrosshairTimeSyncProvider enabled={syncEnabled}>
+            <HoldingsGrid
+              rows={rows}
+              indicatorMap={indicatorMap}
+              indicatorsLoading={indicatorsLoading}
+              onRemove={(key) => removeConstituent.mutate({ etfId, assetId: key as number })}
+            />
+          </CrosshairTimeSyncProvider>
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- Add `CrosshairTimeSyncProvider` context for cross-section crosshair time sync
- Integrate into `ChartSyncProvider` to broadcast/receive shared crosshair time
- Add `sync_pseudo_etf_crosshairs` setting (default: false)
- Add toggle on pseudo-ETF detail page
- When enabled, expanded holdings charts sync crosshair time across rows

Closes #262

## Test plan
- [ ] Default: crosshair sync OFF, expanded holdings rows independent
- [ ] Toggle ON: hovering one expanded row syncs time to other expanded rows
- [ ] Toggle persists in settings
- [ ] Performance overlay chart unaffected
- [ ] ESLint + TypeScript pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)