### PR TITLE
feat: crosshair sync across expanded group table rows (#264)

### DIFF
--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -19,6 +19,7 @@ import { buildSortOptions } from "@/lib/indicator-registry"
 import { useSettings, type AssetTypeFilter, type GroupSortBy, type SortDir } from "@/lib/settings"
 import { useFilteredSortedAssets } from "@/lib/use-group-filter"
 import { GroupTable } from "@/components/group-table"
+import { CrosshairTimeSyncProvider } from "@/components/chart/crosshair-time-sync"
 
 const SORT_OPTIONS = buildSortOptions()
 
@@ -182,17 +183,19 @@ export function GroupPage({ groupId }: { groupId: number }) {
 
       <div className={isPending ? "opacity-70 transition-opacity" : "transition-opacity"}>
       {viewMode === "table" && assets && assets.length > 0 ? (
-        <GroupTable
-          assets={assets}
-          quotes={quotes}
-          indicators={batchIndicators}
-          onDelete={handleRemove}
-          compactMode={settings.compact_mode}
-          onHover={prefetch}
-          sortBy={sortBy}
-          sortDir={sortDir}
-          onSort={handleSort}
-        />
+        <CrosshairTimeSyncProvider enabled={true}>
+          <GroupTable
+            assets={assets}
+            quotes={quotes}
+            indicators={batchIndicators}
+            onDelete={handleRemove}
+            compactMode={settings.compact_mode}
+            onHover={prefetch}
+            sortBy={sortBy}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+        </CrosshairTimeSyncProvider>
       ) : (
         <div className={`grid gap-4 ${
           settings.compact_mode


### PR DESCRIPTION
## Summary
- Create `CrosshairTimeSyncProvider` context for cross-section crosshair time sync
- Integrate into `ChartSyncProvider` to broadcast/receive shared crosshair time
- Wrap group page table view in `CrosshairTimeSyncProvider` (always-on)
- Expanded rows' charts now sync crosshair time across all open rows

Closes #264

## Test plan
- [ ] Expand 2+ rows in group table -> hover one chart, crosshair appears on other rows
- [ ] Collapse a row -> crosshair sync continues working with remaining rows
- [ ] Single expanded row -> crosshair works normally within the row
- [ ] Performance: no jank with 3-5 expanded rows
- [ ] ESLint + TypeScript pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)