### PR TITLE
refactor: move crosshair sync toggle to settings page

### DIFF
--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -3,8 +3,6 @@ import { useParams, Link } from "react-router-dom"
 import { ArrowLeft, UserPlus, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Switch } from "@/components/ui/switch"
-import { Label } from "@/components/ui/label"
 import { ThesisEditor } from "@/components/thesis-editor"
 import { AnnotationsList } from "@/components/annotations-list"
 import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
@@ -168,7 +166,7 @@ function HoldingsTable({ etfId }: { etfId: number }) {
   )
   const removeConstituent = useRemovePseudoEtfConstituent()
   const [addingAsset, setAddingAsset] = useState(false)
-  const { settings, updateSettings } = useSettings()
+  const { settings } = useSettings()
   const syncEnabled = settings.sync_pseudo_etf_crosshairs
 
   if (!etf) return null
@@ -188,27 +186,7 @@ function HoldingsTable({ etfId }: { etfId: number }) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <div className="flex items-center gap-4">
-          <CardTitle className="text-base">Holdings ({etf.constituents.length})</CardTitle>
-          {etf.constituents.length > 1 && (
-            <div className="flex items-center gap-1.5">
-              <Switch
-                id="sync-crosshairs"
-                size="sm"
-                checked={syncEnabled}
-                onCheckedChange={(checked: boolean) =>
-                  updateSettings({ sync_pseudo_etf_crosshairs: checked })
-                }
-              />
-              <Label
-                htmlFor="sync-crosshairs"
-                className="text-xs text-muted-foreground font-normal cursor-pointer"
-              >
-                Sync crosshairs
-              </Label>
-            </div>
-          )}
-        </div>
+        <CardTitle className="text-base">Holdings ({etf.constituents.length})</CardTitle>
         <Button size="sm" variant="ghost" onClick={() => setAddingAsset(!addingAsset)}>
           <UserPlus className="h-3.5 w-3.5 mr-1" />
           Add

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -140,6 +140,12 @@ export function SettingsPage() {
           <CardTitle>Chart Preferences</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          <VisibilityToggle
+            id="sync-crosshairs"
+            label="Sync Pseudo-ETF Crosshairs"
+            checked={draft.sync_pseudo_etf_crosshairs}
+            onCheckedChange={(v) => change({ sync_pseudo_etf_crosshairs: v })}
+          />
           <div className="flex items-center justify-between">
             <Label>Default Period</Label>
             <Select


### PR DESCRIPTION
## Summary
- Remove inline "Sync crosshairs" Switch toggle from pseudo-ETF holdings card header
- Add the same toggle to the Settings page under Chart Preferences
- Centralizes all preference controls in one place

## Test plan
- [ ] Pseudo-ETF detail page: no more inline sync toggle in holdings header
- [ ] Settings page: "Sync Pseudo-ETF Crosshairs" toggle appears under Chart Preferences
- [ ] Toggle persists and controls crosshair sync behavior on pseudo-ETF expanded rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)