### PR TITLE
feat: RSI & MACD as indicator cards in group table

### DIFF
--- a/frontend/src/components/chart/indicator-cards.tsx
+++ b/frontend/src/components/chart/indicator-cards.tsx
@@ -23,6 +23,8 @@ import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
 // ---------------------------------------------------------------------------
 
 const CARD_HELP: Record<string, string> = {
+  rsi: "Momentum oscillator — below 30 is oversold, above 70 is overbought",
+  macd: "Momentum crossover — positive histogram is bullish, negative is bearish",
   atr: "Average daily high-to-low range — higher means more volatile",
   adx: "Trend strength & direction — green is bullish, red is bearish",
 }
@@ -85,6 +87,17 @@ function CardValue({
           </span>
           <span className="text-red-500">
             -DI {getNumericValue(values as Record<string, number | null>, "minus_di")?.toFixed(1) ?? "--"}
+          </span>
+        </div>
+      )}
+      {/* MACD: show line + signal below histogram */}
+      {descriptor.id === "macd" && (
+        <div className={`flex gap-3 tabular-nums mt-0.5 ${compact ? "text-[10px]" : "text-xs"}`}>
+          <span className="text-sky-400">
+            M {getNumericValue(values as Record<string, number | null>, "macd")?.toFixed(2) ?? "--"}
+          </span>
+          <span className="text-orange-400">
+            S {getNumericValue(values as Record<string, number | null>, "macd_signal")?.toFixed(2) ?? "--"}
           </span>
         </div>
       )}
@@ -205,7 +218,7 @@ export function IndicatorCards({ descriptors, currency, compact }: IndicatorCard
   if (descriptors.length === 0) return null
 
   const gridClass = compact
-    ? "grid grid-cols-1 gap-1.5 mt-1.5"
+    ? "grid grid-cols-1 gap-2"
     : "grid grid-cols-2 gap-2 mt-2"
 
   const cardClass = compact

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -66,6 +66,8 @@ export interface IndicatorDescriptor {
     format: "numeric" | "compare_close" | "string_map"
     colorMap?: Record<string, string>
   }
+  /** When true, this indicator also renders as a card (in addition to its primary placement). */
+  cardEligible?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +103,7 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
       range: { min: 0, max: 100 },
     },
     holdingSummary: { label: "RSI", field: "rsi", format: "numeric" },
+    cardEligible: true,
   },
   {
     id: "sma_20",
@@ -179,6 +182,7 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
       format: "string_map",
       colorMap: { bullish: "text-emerald-500", bearish: "text-red-500" },
     },
+    cardEligible: true,
   },
   {
     id: "atr",
@@ -281,7 +285,7 @@ export function getSubChartDescriptors(): IndicatorDescriptor[] {
 }
 
 export function getCardDescriptors(): IndicatorDescriptor[] {
-  return INDICATOR_REGISTRY.filter((d) => d.placement === "card")
+  return INDICATOR_REGISTRY.filter((d) => d.placement === "card" || d.cardEligible)
 }
 
 export function getAllIndicatorFields(): string[] {


### PR DESCRIPTION
## Summary
- RSI and MACD now render as indicator cards (big clickable numbers) in the group table expanded row sidebar, replacing the old gauge/indicator components
- Added `cardEligible` flag to the indicator registry so subchart indicators can also appear as cards
- MACD card shows histogram value with line/signal secondary values; RSI uses threshold coloring (oversold/overbought)
- All 4 cards (RSI, MACD, ATR, ADX) are vertically spaced in the sidebar, aligned below the chart legend row

Closes #281, closes #283

## Test plan
- [ ] Group table: expand a row → 4 indicator cards visible in sidebar (RSI, MACD, ATR, ADX)
- [ ] Cards react to chart crosshair hover
- [ ] Click a card → modal with full chart opens
- [ ] Detail page: RSI/MACD cards appear below sub-charts (additive)
- [ ] Holdings grid: RSI/MACD cards appear below strip charts
- [ ] Settings: RSI/MACD toggles still control card visibility
- [ ] `pnpm build` and `pnpm lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)