### PR TITLE
fix: sparkline not rendering on initial card view load

### DIFF
--- a/frontend/src/components/sparkline.tsx
+++ b/frontend/src/components/sparkline.tsx
@@ -105,6 +105,8 @@ export function DeferredSparkline(props: {
     }
   }, [])
 
+  const hasData = !!props.batchData
+
   useEffect(() => {
     const el = sentinelRef.current
     if (!el || isVisible) return
@@ -114,7 +116,7 @@ export function DeferredSparkline(props: {
     })
     observer.observe(el)
     return () => observer.disconnect()
-  }, [isVisible, observerCallback])
+  }, [isVisible, observerCallback, hasData])
 
   if (isVisible) {
     return <SparklineChart {...props} />


### PR DESCRIPTION
## Summary
- The `DeferredSparkline` `IntersectionObserver` effect didn't re-run when `batchData` transitioned from `undefined` to data, so the observer was never set up for the sentinel div
- Adding `hasData` (`!!props.batchData`) to the effect dependency array fixes the timing issue
- Switching to table view and back worked because remounting with cached data meant `batchData` was already defined on first render

## Test plan
- [ ] Load a group in card view with sparklines enabled — sparklines should appear without needing to switch views

🤖 Generated with [Claude Code](https://claude.com/claude-code)