### PR TITLE
refactor: extract PRICE_DENOMINATED to indicator-registry (#290)

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -18,9 +18,6 @@ import { usePriceFlash } from "@/lib/use-price-flash"
 
 const CARD_DESCRIPTORS = getCardDescriptors()
 
-/** IDs of indicators whose values are denominated in the asset's currency. */
-const PRICE_DENOMINATED = new Set(["atr"])
-
 export interface AssetCardProps {
   symbol: string
   name: string
@@ -81,7 +78,7 @@ function MiniIndicatorCard({
     <div className="rounded bg-muted/50 px-2 py-1">
       <span className="text-[10px] text-muted-foreground">{descriptor.shortLabel}</span>
       <span className={`block text-sm font-semibold tabular-nums ${colorClass || "text-foreground"}`}>
-        {currency && PRICE_DENOMINATED.has(descriptor.id) ? currencySymbol(currency) : ""}{mainVal.toFixed(descriptor.decimals)}
+        {currency && descriptor.priceDenominated ? currencySymbol(currency) : ""}{mainVal.toFixed(descriptor.decimals)}
       </span>
       {descriptor.id === "adx" && (
         <div className="flex gap-2 tabular-nums text-[10px] mt-0.5">

--- a/frontend/src/components/chart/indicator-cards.tsx
+++ b/frontend/src/components/chart/indicator-cards.tsx
@@ -33,9 +33,6 @@ const CARD_HELP: Record<string, string> = {
 // Card value display
 // ---------------------------------------------------------------------------
 
-/** IDs of indicators whose values are denominated in the asset's currency. */
-const PRICE_DENOMINATED = new Set(["atr"])
-
 /** Resolve the ADX color class based on strength + direction. */
 function resolveAdxColor(
   adx: number,
@@ -77,7 +74,7 @@ function CardValue({
   return (
     <div className="flex flex-col">
       <span className={`${sizeClass} font-semibold tabular-nums ${colorClass || "text-foreground"}`}>
-        {currency && PRICE_DENOMINATED.has(descriptor.id) ? currencySymbol(currency) : ""}{mainVal.toFixed(descriptor.decimals)}
+        {currency && descriptor.priceDenominated ? currencySymbol(currency) : ""}{mainVal.toFixed(descriptor.decimals)}
       </span>
       {/* ADX: show +DI / -DI below the main value */}
       {descriptor.id === "adx" && (

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -68,6 +68,8 @@ export interface IndicatorDescriptor {
   }
   /** When true, this indicator also renders as a card (in addition to its primary placement). */
   cardEligible?: boolean
+  /** When true, the indicator's values are denominated in the asset's currency (e.g. ATR). */
+  priceDenominated?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -196,6 +198,7 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
     ],
     decimals: 2,
     holdingSummary: { label: "ATR", field: "atr", format: "numeric" },
+    priceDenominated: true,
   },
   {
     id: "adx",
@@ -327,6 +330,11 @@ export function extractMacdValues(values?: Record<string, number | string | null
     macd_signal: getNumericValue(values, "macd_signal"),
     macd_hist: getNumericValue(values, "macd_hist"),
   } : undefined
+}
+
+/** Check whether an indicator's values are denominated in the asset's currency. */
+export function isPriceDenominated(id: string): boolean {
+  return INDICATOR_REGISTRY.find((d) => d.id === id)?.priceDenominated === true
 }
 
 export function getSeriesByField(field: string): SeriesDescriptor | undefined {


### PR DESCRIPTION
## Summary
- Added `priceDenominated?: boolean` field to the `IndicatorDescriptor` interface in `indicator-registry.ts` and set it to `true` on the ATR entry
- Exported a `isPriceDenominated(id)` helper for consumers that don't already have the descriptor object
- Removed the duplicated `PRICE_DENOMINATED = new Set(["atr"])` constant from both `indicator-cards.tsx` and `asset-card.tsx`, replacing the `Set.has()` calls with direct `descriptor.priceDenominated` checks

Closes #290

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [ ] Verify ATR values on the asset detail page still display the currency symbol prefix
- [ ] Verify ATR values on the dashboard asset cards still display the currency symbol prefix
- [ ] Confirm non-price-denominated indicators (RSI, MACD, ADX) do not show a currency prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)