### PR TITLE
refactor: extract change percent color helper to lib/format (#292)

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -7,7 +7,7 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { DeferredSparkline } from "@/components/sparkline"
 import { TagBadge } from "@/components/tag-badge"
 import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary } from "@/lib/api"
-import { formatPrice, currencySymbol } from "@/lib/format"
+import { formatPrice, currencySymbol, changeColor } from "@/lib/format"
 import {
   getNumericValue,
   getCardDescriptors,
@@ -127,8 +127,7 @@ export function AssetCard({
   )
   const lastPrice = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
-  const changeColor =
-    changePct != null ? (changePct >= 0 ? "text-emerald-500" : "text-red-500") : "text-muted-foreground"
+  const changeCls = changeColor(changePct)
 
   const [priceRef, pctRef] = usePriceFlash(lastPrice)
 
@@ -157,7 +156,7 @@ export function AssetCard({
           <div className="flex items-center justify-between">
             <p className="text-xs text-muted-foreground truncate">{name}</p>
             {changePct != null ? (
-              <span ref={pctRef} className={`text-xs font-medium tabular-nums rounded px-1 -mx-1 ${changeColor}`}>
+              <span ref={pctRef} className={`text-xs font-medium tabular-nums rounded px-1 -mx-1 ${changeCls}`}>
                 {changePct >= 0 ? "+" : ""}
                 {changePct.toFixed(2)}%
               </span>

--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -21,7 +21,7 @@ import {
 import { ArrowUp, ArrowDown } from "lucide-react"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
 import type { GroupSortBy, SortDir } from "@/lib/settings"
-import { formatPrice } from "@/lib/format"
+import { formatPrice, changeColor } from "@/lib/format"
 import {
   getNumericValue,
   extractMacdValues,
@@ -334,8 +334,7 @@ function TableRow({
 }) {
   const lastPrice = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
-  const changeColor =
-    changePct != null ? (changePct >= 0 ? "text-emerald-500" : "text-red-500") : "text-muted-foreground"
+  const changeCls = changeColor(changePct)
 
   const [priceRef, pctRef] = usePriceFlash(lastPrice)
   const py = compactMode ? "py-1.5" : "py-2.5"
@@ -397,7 +396,7 @@ function TableRow({
         {isColumnVisible(columnSettings, "change_pct") && (
           <td className={`${py} px-3 text-right tabular-nums`}>
             {changePct != null ? (
-              <span ref={pctRef} className={`font-medium rounded px-1 -mx-1 ${changeColor}`}>
+              <span ref={pctRef} className={`font-medium rounded px-1 -mx-1 ${changeCls}`}>
                 {changePct >= 0 ? "+" : ""}
                 {changePct.toFixed(2)}%
               </span>

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -20,6 +20,11 @@ export function formatPrice(value: number, currency: string, decimals = 2): stri
   return `${currencySymbol(currency)}${value.toFixed(decimals)}`
 }
 
+export function changeColor(pct: number | null | undefined): string {
+  if (pct == null) return "text-muted-foreground"
+  return pct >= 0 ? "text-emerald-500" : "text-red-500"
+}
+
 export function formatChangePct(v: number | null): { text: string | null; className: string } {
   if (v === null) return { text: null, className: "" }
   const sign = v >= 0 ? "+" : ""


### PR DESCRIPTION
## Summary
- Extracts the repeated `changePct >= 0 ? "text-emerald-500" : "text-red-500"` ternary into a shared `changeColor(pct)` helper in `lib/format.ts`
- Updates `asset-card.tsx` and `group-table.tsx` to import and use the helper instead of inline logic
- The helper handles `null`/`undefined` by returning `"text-muted-foreground"`

## Test plan
- [x] `tsc --noEmit` passes (zero errors)
- [ ] `pnpm run build` and `pnpm run lint` pass in CI (local env has pre-existing missing deps: `eslint-plugin-jsx-a11y`, `react-markdown`)
- [ ] Visual check: change percent colors unchanged on dashboard card and group table views

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)