### PR TITLE
fix: ADX color in group table + extract resolveAdxColor (#288, #289)

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -12,6 +12,7 @@ import {
   getNumericValue,
   getCardDescriptors,
   resolveThresholdColor,
+  resolveAdxColor,
   type IndicatorDescriptor,
 } from "@/lib/indicator-registry"
 import { usePriceFlash } from "@/lib/use-price-flash"
@@ -32,21 +33,6 @@ export interface AssetCardProps {
   onHover: () => void
   showSparkline: boolean
   indicatorVisibility: Record<string, boolean>
-}
-
-/** Resolve the ADX color class based on strength + direction. */
-function resolveAdxColor(
-  adx: number,
-  values: Record<string, number | string | null>,
-): string {
-  if (adx < 20) return "text-zinc-400"
-  if (adx < 25) return "text-yellow-500"
-  const plusDi = getNumericValue(values, "plus_di")
-  const minusDi = getNumericValue(values, "minus_di")
-  if (plusDi != null && minusDi != null) {
-    return plusDi > minusDi ? "text-emerald-500" : "text-red-500"
-  }
-  return "text-foreground"
 }
 
 function MiniIndicatorCard({

--- a/frontend/src/components/chart/indicator-cards.tsx
+++ b/frontend/src/components/chart/indicator-cards.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog"
 import {
   resolveThresholdColor,
+  resolveAdxColor,
   getNumericValue,
   type IndicatorDescriptor,
 } from "@/lib/indicator-registry"
@@ -33,20 +34,6 @@ const CARD_HELP: Record<string, string> = {
 // Card value display
 // ---------------------------------------------------------------------------
 
-/** Resolve the ADX color class based on strength + direction. */
-function resolveAdxColor(
-  adx: number,
-  values: Record<string, number | undefined>,
-): string {
-  if (adx < 20) return "text-zinc-400"           // no meaningful trend
-  if (adx < 25) return "text-yellow-500"          // emerging trend
-  const plusDi = getNumericValue(values as Record<string, number | null>, "plus_di")
-  const minusDi = getNumericValue(values as Record<string, number | null>, "minus_di")
-  if (plusDi != null && minusDi != null) {
-    return plusDi > minusDi ? "text-emerald-500" : "text-red-500"
-  }
-  return "text-foreground"
-}
 
 function CardValue({
   descriptor,
@@ -68,7 +55,7 @@ function CardValue({
   }
 
   const colorClass = descriptor.id === "adx"
-    ? resolveAdxColor(mainVal, values)
+    ? resolveAdxColor(mainVal, values as Record<string, number | string | null>)
     : resolveThresholdColor(mainSeries.thresholdColors, mainVal)
 
   return (

--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -29,6 +29,7 @@ import {
   getSeriesByField,
   getCardDescriptors,
   resolveThresholdColor,
+  resolveAdxColor,
 } from "@/lib/indicator-registry"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useAssetDetail, useAnnotations } from "@/lib/queries"
@@ -434,7 +435,9 @@ function TableRow({
           }
           const val = getNumericValue(indicator?.values, field)
           const series = getSeriesByField(field)
-          const colorClass = resolveThresholdColor(series?.thresholdColors, val)
+          const colorClass = field === "adx" && val != null && indicator?.values
+            ? resolveAdxColor(val, indicator.values)
+            : resolveThresholdColor(series?.thresholdColors, val)
           const decimals = val != null && Math.abs(val) >= 100 ? 0 : 2
           return (
             <td key={field} className={`${py} px-3 text-right text-sm tabular-nums`}>

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -344,3 +344,24 @@ export function getSeriesByField(field: string): SeriesDescriptor | undefined {
   }
   return undefined
 }
+
+/**
+ * Resolve the ADX color class based on trend strength + DI direction.
+ *
+ * - ADX < 20  → gray (no meaningful trend)
+ * - ADX 20-25 → yellow (emerging trend)
+ * - ADX >= 25 → green (+DI > -DI, bullish) or red (-DI > +DI, bearish)
+ */
+export function resolveAdxColor(
+  adx: number,
+  values: Record<string, number | string | null>,
+): string {
+  if (adx < 20) return "text-zinc-400"
+  if (adx < 25) return "text-yellow-500"
+  const plusDi = getNumericValue(values, "plus_di")
+  const minusDi = getNumericValue(values, "minus_di")
+  if (plusDi != null && minusDi != null) {
+    return plusDi > minusDi ? "text-emerald-500" : "text-red-500"
+  }
+  return "text-foreground"
+}


### PR DESCRIPTION
## Summary
- Extracts `resolveAdxColor` to `indicator-registry.ts` as a single source of truth, removing duplicate implementations from `indicator-cards.tsx` and `asset-card.tsx` (#289)
- Fixes ADX color in group table to account for +DI/-DI direction instead of using generic threshold coloring (#288): ADX >= 25 shows green when +DI > -DI (bullish) and red when -DI > +DI (bearish), ADX 20-25 shows yellow, ADX < 20 shows gray

## Test plan
- [ ] Verify ADX column in group table shows correct directional colors (green for bullish strong trend, red for bearish strong trend, yellow for emerging, gray for weak)
- [ ] Verify asset card ADX mini-indicator still colors correctly
- [ ] Verify indicator cards in expanded row / detail page still show correct ADX colors
- [ ] `pnpm run build` passes (TypeScript + Vite)
- [ ] `pnpm run lint` passes

Closes #288, closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)