### PR TITLE
feat: make sidebar collapsible (#287)

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,9 +1,37 @@
 import { useState } from "react"
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom"
-import { LayoutDashboard, LineChart, Settings, Star, FolderOpen, Plus, X } from "lucide-react"
+import {
+  LayoutDashboard,
+  LineChart,
+  Settings,
+  Star,
+  FolderOpen,
+  Plus,
+  X,
+} from "lucide-react"
 import { useQuoteStatus } from "@/lib/quote-stream"
 import { CommandSearch } from "@/components/command-search"
 import { useGroups, useCreateGroup } from "@/lib/queries"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+  useSidebar,
+} from "@/components/ui/sidebar"
 import { Input } from "@/components/ui/input"
 
 const topNavItems = [
@@ -12,39 +40,10 @@ const topNavItems = [
 ]
 
 const STATUS_CONFIG = {
-  connecting: { color: "bg-yellow-500", label: "Connecting…" },
+  connecting: { color: "bg-yellow-500", label: "Connecting..." },
   connected: { color: "bg-green-500", label: "Live" },
-  reconnecting: { color: "bg-yellow-500 animate-pulse", label: "Reconnecting…" },
+  reconnecting: { color: "bg-yellow-500 animate-pulse", label: "Reconnecting..." },
 } as const
-
-function NavLink({ to, label, icon: Icon, active, badge }: {
-  to: string
-  label: string
-  icon: React.ElementType
-  active: boolean
-  badge?: number
-}) {
-  return (
-    <Link
-      to={to}
-      className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-        active
-          ? "bg-primary text-primary-foreground"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground"
-      }`}
-    >
-      <Icon className="h-4 w-4" />
-      <span className="truncate">{label}</span>
-      {badge != null && badge > 0 && (
-        <span className={`ml-auto text-xs tabular-nums ${
-          active ? "text-primary-foreground/70" : "text-muted-foreground"
-        }`}>
-          {badge}
-        </span>
-      )}
-    </Link>
-  )
-}
 
 function GroupsSection() {
   const { data: groups } = useGroups()
@@ -53,123 +52,202 @@ function GroupsSection() {
   const navigate = useNavigate()
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState("")
+  const { state } = useSidebar()
 
   const handleCreate = () => {
     const name = newName.trim()
     if (!name) return
-    createGroup.mutate({ name }, {
-      onSuccess: (group) => {
-        setNewName("")
-        setCreating(false)
-        navigate(`/groups/${group.id}`)
+    createGroup.mutate(
+      { name },
+      {
+        onSuccess: (group) => {
+          setNewName("")
+          setCreating(false)
+          navigate(`/groups/${group.id}`)
+        },
       },
-    })
+    )
   }
 
   if (!groups) return null
 
   const defaultGroup = groups.find((g) => g.is_default)
   const customGroups = groups.filter((g) => !g.is_default)
+  const isCollapsed = state === "collapsed"
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center justify-between px-3 pt-3 pb-1">
-        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Groups
-        </span>
-        <button
+    <SidebarGroup>
+      <SidebarGroupLabel>Groups</SidebarGroupLabel>
+      {!isCollapsed && (
+        <SidebarGroupAction
           onClick={() => setCreating(!creating)}
-          className="text-muted-foreground hover:text-foreground transition-colors"
+          title={creating ? "Cancel" : "New group"}
         >
-          {creating ? <X className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
-        </button>
-      </div>
-
-      {creating && (
-        <div className="px-2 pb-1">
-          <Input
-            placeholder="Group name"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleCreate()
-              if (e.key === "Escape") { setCreating(false); setNewName("") }
-            }}
-            autoFocus
-            className="h-8 text-sm"
-          />
-        </div>
+          {creating ? <X /> : <Plus />}
+        </SidebarGroupAction>
       )}
-
-      {/* Default group — always first */}
-      {defaultGroup && (
-        <NavLink
-          to={`/groups/${defaultGroup.id}`}
-          label={defaultGroup.name}
-          icon={Star}
-          active={location.pathname === `/groups/${defaultGroup.id}` || location.pathname === "/watchlist"}
-          badge={defaultGroup.assets.length}
-        />
-      )}
-
-      {/* Custom groups */}
-      {customGroups.map((group) => (
-        <NavLink
-          key={group.id}
-          to={`/groups/${group.id}`}
-          label={group.name}
-          icon={FolderOpen}
-          active={location.pathname === `/groups/${group.id}`}
-          badge={group.assets.length}
-        />
-      ))}
-    </div>
+      <SidebarGroupContent>
+        {creating && !isCollapsed && (
+          <div className="px-2 pb-1">
+            <Input
+              placeholder="Group name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleCreate()
+                if (e.key === "Escape") {
+                  setCreating(false)
+                  setNewName("")
+                }
+              }}
+              autoFocus
+              className="h-7 text-xs"
+            />
+          </div>
+        )}
+        <SidebarMenu>
+          {defaultGroup && (
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={
+                  location.pathname === `/groups/${defaultGroup.id}` ||
+                  location.pathname === "/watchlist"
+                }
+                tooltip={defaultGroup.name}
+              >
+                <Link to={`/groups/${defaultGroup.id}`}>
+                  <Star />
+                  <span>{defaultGroup.name}</span>
+                </Link>
+              </SidebarMenuButton>
+              {defaultGroup.assets.length > 0 && (
+                <SidebarMenuBadge>{defaultGroup.assets.length}</SidebarMenuBadge>
+              )}
+            </SidebarMenuItem>
+          )}
+          {customGroups.map((group) => (
+            <SidebarMenuItem key={group.id}>
+              <SidebarMenuButton
+                asChild
+                isActive={location.pathname === `/groups/${group.id}`}
+                tooltip={group.name}
+              >
+                <Link to={`/groups/${group.id}`}>
+                  <FolderOpen />
+                  <span>{group.name}</span>
+                </Link>
+              </SidebarMenuButton>
+              {group.assets.length > 0 && (
+                <SidebarMenuBadge>{group.assets.length}</SidebarMenuBadge>
+              )}
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
   )
 }
 
-export function Layout() {
+function AppSidebar() {
   const location = useLocation()
   const quoteStatus = useQuoteStatus()
 
   return (
-    <div className="flex h-screen bg-background">
-      <aside className="flex w-56 flex-col border-r bg-card">
-        <div className="flex h-14 items-center border-b px-4">
-          <Link to="/" className="text-lg font-bold text-foreground">
-            fibenchi
-          </Link>
-        </div>
-        <nav className="flex-1 overflow-auto p-2 space-y-1">
-          {topNavItems.map(({ to, label, icon }) => (
-            <NavLink
-              key={to}
-              to={to}
-              label={label}
-              icon={icon}
-              active={to === "/" ? location.pathname === "/" : location.pathname.startsWith(to)}
-            />
-          ))}
-          <GroupsSection />
-        </nav>
-        <div className="border-t p-2 space-y-1">
-          <NavLink
-            to="/settings"
-            label="Settings"
-            icon={Settings}
-            active={location.pathname === "/settings"}
-          />
-          <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground">
-            <span className={`h-2 w-2 rounded-full ${STATUS_CONFIG[quoteStatus].color}`} />
-            {STATUS_CONFIG[quoteStatus].label}
+    <Sidebar collapsible="icon">
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" asChild tooltip="fibenchi">
+              <Link to="/">
+                <div className="bg-primary text-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg text-sm font-bold">
+                  f
+                </div>
+                <span className="text-lg font-bold">fibenchi</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {topNavItems.map(({ to, label, icon: Icon }) => (
+                <SidebarMenuItem key={to}>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={
+                      to === "/"
+                        ? location.pathname === "/"
+                        : location.pathname.startsWith(to)
+                    }
+                    tooltip={label}
+                  >
+                    <Link to={to}>
+                      <Icon />
+                      <span>{label}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <GroupsSection />
+      </SidebarContent>
+
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              isActive={location.pathname === "/settings"}
+              tooltip="Settings"
+            >
+              <Link to="/settings">
+                <Settings />
+                <span>Settings</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="sm" className="cursor-default hover:bg-transparent" tooltip={STATUS_CONFIG[quoteStatus].label}>
+              <span
+                className={`h-2 w-2 shrink-0 rounded-full ${STATUS_CONFIG[quoteStatus].color}`}
+              />
+              <span className="text-xs text-muted-foreground">
+                {STATUS_CONFIG[quoteStatus].label}
+              </span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+
+      <SidebarRail />
+    </Sidebar>
+  )
+}
+
+export function Layout() {
+  return (
+    <SidebarProvider>
+      <TooltipProvider delayDuration={0}>
+        <AppSidebar />
+        <SidebarInset>
+          <header className="flex h-14 items-center gap-2 border-b px-4">
+            <SidebarTrigger className="-ml-1" />
+            <div className="flex-1">
+              <CommandSearch />
+            </div>
+          </header>
+          <div className="flex-1 overflow-auto">
+            <Outlet />
           </div>
-        </div>
-      </aside>
-      <main className="flex-1 overflow-auto">
-        <div className="flex h-14 items-center border-b px-6">
-          <CommandSearch />
-        </div>
-        <Outlet />
-      </main>
-    </div>
+        </SidebarInset>
+      </TooltipProvider>
+    </SidebarProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Replace the static `<aside>` sidebar with the existing shadcn `Sidebar` component (`components/ui/sidebar.tsx`)
- Sidebar collapses to an icon-only rail via toggle button, keyboard shortcut (Ctrl+B), or dragging the rail edge
- Collapsed state persists across navigations via cookie (`sidebar_state`)
- On mobile (<768px), sidebar renders as a sheet overlay instead of an inline panel
- Groups section, nav items, settings, and quote status all adapt to collapsed state with tooltip labels

## Test plan
- [ ] Toggle sidebar via the panel-left icon button in the header bar
- [ ] Toggle sidebar via Ctrl+B (or Cmd+B on macOS) keyboard shortcut
- [ ] Verify collapsed state shows icon-only navigation with tooltips on hover
- [ ] Verify sidebar state persists after page navigation (check `sidebar_state` cookie)
- [ ] Verify mobile breakpoint (<768px) renders sidebar as a slide-out sheet overlay
- [ ] Verify Groups section hides the "new group" input and group action button when collapsed
- [ ] Verify drag-to-collapse works via the SidebarRail edge
- [ ] Verify all navigation links (Overview, Pseudo-ETFs, groups, Settings) still work correctly
- [ ] Verify quote status dot and label display in sidebar footer

:robot: Generated with [Claude Code](https://claude.com/claude-code)