### PR TITLE
fix: API client Content-Type on bodyless requests + remove dead code (#309)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,7 +43,10 @@ function qs(params: Record<string, string | undefined>): string {
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     ...init,
-    headers: { "Content-Type": "application/json", ...init?.headers },
+    headers: {
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+      ...init?.headers,
+    },
   })
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText)
@@ -65,8 +68,6 @@ export const api = {
     list: () => request<Asset[]>("/assets"),
     create: (data: AssetCreate) =>
       request<Asset>("/assets", { method: "POST", body: JSON.stringify(data) }),
-    delete: (symbol: string) =>
-      request<void>(`/assets/${symbol}`, { method: "DELETE" }),
   },
   prices: {
     detail: (symbol: string, period?: string) =>


### PR DESCRIPTION
## Summary
- Only set `Content-Type: application/json` when request has a body
- Remove unused `api.assets.delete` method

Closes #309

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] GET/DELETE requests no longer send Content-Type header
- [ ] No references to removed method

🤖 Generated with [Claude Code](https://claude.com/claude-code)