### PR TITLE
fix: SSE quote stream handles disconnect with auto-reconnect (#303)

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -43,6 +43,7 @@ const STATUS_CONFIG = {
   connecting: { color: "bg-yellow-500", label: "Connecting..." },
   connected: { color: "bg-green-500", label: "Live" },
   reconnecting: { color: "bg-yellow-500 animate-pulse", label: "Reconnecting..." },
+  disconnected: { color: "bg-red-500", label: "Disconnected" },
 } as const
 
 function GroupsSection() {


### PR DESCRIPTION
## Summary
- Add `disconnected` status variant to `ConnectionStatus` type
- Handle `EventSource.CLOSED` state in `onerror` handler with exponential backoff reconnection (1s -> 2s -> 4s -> ... -> 30s cap)
- Add disconnected state to sidebar status indicator (red dot + "Disconnected" label)

Closes #303

## Test plan
- [ ] TypeScript compiles cleanly (pre-existing `react-markdown` type error only)
- [ ] Status indicator shows red "Disconnected" when stream closes
- [ ] Auto-reconnect fires with exponential backoff after disconnect
- [ ] Backoff resets on successful reconnection
- [ ] Cleanup on unmount cancels pending reconnect timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)