### PR TITLE
fix: replace non-null assertions with proper type narrowing (#308)

### DIFF
--- a/frontend/src/components/chart/chart-legends.tsx
+++ b/frontend/src/components/chart/chart-legends.tsx
@@ -61,12 +61,12 @@ export function Legend({ values, latest }: { values: LegendValues | null; latest
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs tabular-nums">
-      {v.o !== undefined && (
+      {v.o !== undefined && v.h !== undefined && v.l !== undefined && v.c !== undefined && (
         <>
           <span className="text-muted-foreground">O <span className={changeColor}>{v.o.toFixed(2)}</span></span>
-          <span className="text-muted-foreground">H <span className={changeColor}>{v.h!.toFixed(2)}</span></span>
-          <span className="text-muted-foreground">L <span className={changeColor}>{v.l!.toFixed(2)}</span></span>
-          <span className="text-muted-foreground">C <span className={changeColor}>{v.c!.toFixed(2)}</span></span>
+          <span className="text-muted-foreground">H <span className={changeColor}>{v.h.toFixed(2)}</span></span>
+          <span className="text-muted-foreground">L <span className={changeColor}>{v.l.toFixed(2)}</span></span>
+          <span className="text-muted-foreground">C <span className={changeColor}>{v.c.toFixed(2)}</span></span>
         </>
       )}
       {overlays.map((desc) => (

--- a/frontend/src/components/holdings-grid.tsx
+++ b/frontend/src/components/holdings-grid.tsx
@@ -68,7 +68,7 @@ export function HoldingsGrid({ rows, indicatorMap, indicatorsLoading, onRemove, 
               <th className="text-right text-xs font-medium text-muted-foreground px-2 py-1">Chg%</th>
               {SUMMARY_DESCRIPTORS.map((desc) => (
                 <th key={desc.id} className="text-right text-xs font-medium text-muted-foreground px-2 py-1">
-                  {desc.holdingSummary!.label}
+                  {desc.holdingSummary.label}
                 </th>
               ))}
               {hasRemove && <th className="w-8" />}
@@ -161,7 +161,7 @@ function HoldingRow({
               {chg.text ?? "\u2014"}
             </td>
             {SUMMARY_DESCRIPTORS.map((desc) => {
-              const hs = desc.holdingSummary!
+              const hs = desc.holdingSummary
               return (
                 <td key={desc.id} className="py-1 px-2 text-right">
                   <HoldingSummaryCell

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -72,6 +72,11 @@ export interface IndicatorDescriptor {
   priceDenominated?: boolean
 }
 
+/** Narrowed descriptor where holdingSummary is guaranteed present. */
+export type IndicatorDescriptorWithSummary = IndicatorDescriptor & {
+  holdingSummary: NonNullable<IndicatorDescriptor["holdingSummary"]>
+}
+
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
@@ -303,8 +308,10 @@ export function getDescriptorById(id: string): IndicatorDescriptor | undefined {
   return INDICATOR_REGISTRY.find((d) => d.id === id)
 }
 
-export function getHoldingSummaryDescriptors(): IndicatorDescriptor[] {
-  return INDICATOR_REGISTRY.filter((d) => d.holdingSummary != null)
+export function getHoldingSummaryDescriptors(): IndicatorDescriptorWithSummary[] {
+  return INDICATOR_REGISTRY.filter(
+    (d): d is IndicatorDescriptorWithSummary => d.holdingSummary != null,
+  )
 }
 
 /** Build sort options from registry: base fields + all sortable indicator fields. */


### PR DESCRIPTION
## Summary
- Add `IndicatorDescriptorWithSummary` narrowed type for holding summary descriptors
- Update `getHoldingSummaryDescriptors()` return type to eliminate `!` assertions
- Check all four OHLC values before use in chart legends

Closes #308

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] No `!` assertions remain on optional fields
- [ ] Holdings grid and chart legends render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)