### PR TITLE
chore: backend dead code cleanup and test coverage gaps (#302)

### DIFF
--- a/backend/tests/integration/test_holdings.py
+++ b/backend/tests/integration/test_holdings.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 from app.services.compute.indicators import bb_position
 from tests.helpers import make_price_df
 
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
 
 # ── Pure unit tests for bb_position ───────────────────────────────────
 

--- a/backend/tests/integration/test_quotes.py
+++ b/backend/tests/integration/test_quotes.py
@@ -3,9 +3,12 @@
 import asyncio
 import json
 
+import pytest
 from unittest.mock import patch
 
 from tests.conftest import TestSession
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 _MOCK_QUOTES = [

--- a/backend/tests/integration/test_settings.py
+++ b/backend/tests/integration/test_settings.py
@@ -1,14 +1,14 @@
 import pytest
 
+pytestmark = pytest.mark.asyncio(loop_scope="function")
 
-@pytest.mark.anyio
+
 async def test_get_empty(client):
     resp = await client.get("/api/settings")
     assert resp.status_code == 200
     assert resp.json() == {"data": {}}
 
 
-@pytest.mark.anyio
 async def test_put(client):
     payload = {"data": {"theme": "dark", "compact_mode": True}}
     resp = await client.put("/api/settings", json=payload)
@@ -17,7 +17,6 @@ async def test_put(client):
     assert resp.json()["data"]["compact_mode"] is True
 
 
-@pytest.mark.anyio
 async def test_put_get_roundtrip(client):
     payload = {"data": {"chart_type": "line", "decimal_places": 4}}
     await client.put("/api/settings", json=payload)
@@ -26,7 +25,6 @@ async def test_put_get_roundtrip(client):
     assert resp.json()["data"] == {"chart_type": "line", "decimal_places": 4}
 
 
-@pytest.mark.anyio
 async def test_put_overwrites(client):
     await client.put("/api/settings", json={"data": {"theme": "dark"}})
     await client.put("/api/settings", json={"data": {"theme": "light", "extra": 1}})

--- a/backend/tests/services/test_currency_service.py
+++ b/backend/tests/services/test_currency_service.py
@@ -1,0 +1,119 @@
+"""Tests for the currency lookup service (cache + DB integration)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.models.currency import Currency
+from app.services.currency_service import _cache, load_cache, lookup, ensure_currency
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+# ---------------------------------------------------------------------------
+# lookup (pure in-memory, relies on cache populated by conftest setup_db)
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_known_currency():
+    """Known currencies return their display code and divisor."""
+    display, divisor = lookup("USD")
+    assert display == "USD"
+    assert divisor == 1
+
+
+def test_lookup_subunit_gbp():
+    """Subunit GBp maps to GBP with divisor 100."""
+    display, divisor = lookup("GBp")
+    assert display == "GBP"
+    assert divisor == 100
+
+
+def test_lookup_subunit_gbx():
+    """Subunit GBX maps to GBP with divisor 100."""
+    display, divisor = lookup("GBX")
+    assert display == "GBP"
+    assert divisor == 100
+
+
+def test_lookup_subunit_ila():
+    """Subunit ILA maps to ILS with divisor 100."""
+    display, divisor = lookup("ILA")
+    assert display == "ILS"
+    assert divisor == 100
+
+
+def test_lookup_subunit_zac():
+    """Subunit ZAc maps to ZAR with divisor 100."""
+    display, divisor = lookup("ZAc")
+    assert display == "ZAR"
+    assert divisor == 100
+
+
+def test_lookup_unknown_falls_back():
+    """Unknown codes fall back to (raw_code, 1)."""
+    display, divisor = lookup("UNKNOWN_XYZ")
+    assert display == "UNKNOWN_XYZ"
+    assert divisor == 1
+
+
+# ---------------------------------------------------------------------------
+# load_cache (async, uses the test DB seeded by conftest)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_cache_populates(db):
+    """load_cache fills the module-level cache from the DB."""
+    _cache.clear()
+    assert len(_cache) == 0
+
+    await load_cache(db)
+
+    assert len(_cache) > 0
+    # Seeded currencies should be present
+    assert "USD" in _cache
+    assert "GBp" in _cache
+
+
+async def test_load_cache_includes_subunit_safety_net(db):
+    """Even if DB is missing subunit entries, safety net fills them in."""
+    # Clear the DB currencies and reload
+    from sqlalchemy import delete
+    await db.execute(delete(Currency))
+    await db.commit()
+
+    await load_cache(db)
+
+    # Subunit safety net should still be present
+    assert _cache.get("GBp") == ("GBP", 100)
+    assert _cache.get("GBX") == ("GBP", 100)
+    assert _cache.get("ILA") == ("ILS", 100)
+    assert _cache.get("ZAc") == ("ZAR", 100)
+
+
+# ---------------------------------------------------------------------------
+# ensure_currency (async, auto-registers unknown codes)
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_currency_noop_for_known(db):
+    """ensure_currency is a no-op when the code is already in the cache."""
+    cache_size_before = len(_cache)
+    await ensure_currency(db, "USD")
+    assert len(_cache) == cache_size_before
+
+
+async def test_ensure_currency_registers_unknown(db):
+    """ensure_currency inserts a new code into DB and cache."""
+    assert "NEW_CODE" not in _cache
+
+    await ensure_currency(db, "NEW_CODE")
+
+    assert "NEW_CODE" in _cache
+    assert _cache["NEW_CODE"] == ("NEW_CODE", 1)
+
+    # Verify it was persisted to the DB
+    from sqlalchemy import select
+    result = await db.execute(select(Currency).where(Currency.code == "NEW_CODE"))
+    row = result.scalar_one()
+    assert row.display_code == "NEW_CODE"
+    assert row.divisor == 1

--- a/backend/tests/services/test_indicators.py
+++ b/backend/tests/services/test_indicators.py
@@ -15,22 +15,7 @@ from app.services.compute.indicators import (
     rsi,
     sma,
 )
-
-
-def _make_price_df(n: int = 100, start_price: float = 100.0) -> pd.DataFrame:
-    """Generate synthetic price data for testing."""
-    np.random.seed(42)
-    dates = pd.date_range("2024-01-01", periods=n, freq="B")
-    returns = np.random.normal(0.001, 0.02, n)
-    prices = start_price * np.cumprod(1 + returns)
-
-    return pd.DataFrame({
-        "open": prices * (1 - np.random.uniform(0, 0.01, n)),
-        "high": prices * (1 + np.random.uniform(0, 0.02, n)),
-        "low": prices * (1 - np.random.uniform(0, 0.02, n)),
-        "close": prices,
-        "volume": np.random.randint(1_000_000, 10_000_000, n),
-    }, index=dates)
+from tests.helpers import make_price_df as _make_price_df
 
 
 def test_rsi_range():

--- a/backend/tests/services/test_price_service.py
+++ b/backend/tests/services/test_price_service.py
@@ -18,6 +18,7 @@ from app.services.price_service import (
     refresh_prices,
 )
 
+pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -1,10 +1,12 @@
 """Unit tests for search_service — DB-backed symbol directory with Yahoo fallback."""
 
+import pytest
 from unittest.mock import AsyncMock, patch
 
 from app.models.symbol_directory import SymbolDirectory
 from app.services.search_service import search_symbols, _parse_yahoo_results
 
+pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 def _yahoo_response(*items):


### PR DESCRIPTION
## Summary
- Remove dead `SUBUNIT_CURRENCIES` and `normalize_currency` from `yahoo.py`
- Remove redundant `ticker.price` call
- Deduplicate `_make_price_df` test helper (import from `tests/helpers.py`)
- Add `test_currency_service.py` with unit tests
- Standardize `pytestmark` across all test files

Closes #302

## Test plan
- [ ] All existing tests pass
- [ ] New currency service tests pass
- [ ] No dead code references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)