### PR TITLE
fix: backend error handling and input validation (#300)

### DIFF
--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -1,10 +1,14 @@
-from fastapi import APIRouter, Depends
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.schemas.group import GroupAddAssets, GroupCreate, GroupResponse, GroupUpdate
 from app.services import group_service
 from app.services.compute.group import compute_and_cache_indicators, get_batch_sparklines
+
+PeriodType = Literal["1mo", "3mo", "6mo", "1y", "2y", "5y"]
 
 router = APIRouter(prefix="/api/groups", tags=["groups"])
 
@@ -47,7 +51,7 @@ async def remove_asset_from_group(group_id: int, asset_id: int, db: AsyncSession
 @router.get("/{group_id}/sparklines", summary="Batch close prices for group assets")
 async def group_sparklines(
     group_id: int,
-    period: str = "3mo",
+    period: PeriodType = Query("3mo"),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, list[dict]]:
     """Return close-price sparkline data for every asset in the group."""

--- a/backend/app/routers/portfolio.py
+++ b/backend/app/routers/portfolio.py
@@ -1,11 +1,14 @@
 from datetime import date
+from typing import Literal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.services.compute.portfolio import compute_performers, compute_portfolio_index
+
+PeriodType = Literal["1mo", "3mo", "6mo", "1y", "2y", "5y"]
 
 router = APIRouter(prefix="/api/portfolio", tags=["portfolio"])
 
@@ -26,12 +29,12 @@ class AssetPerformance(BaseModel):
 
 
 @router.get("/index", response_model=PortfolioIndexResponse, summary="Get composite portfolio index")
-async def get_portfolio_index(period: str = "1y", db: AsyncSession = Depends(get_db)):
+async def get_portfolio_index(period: PeriodType = Query("1y"), db: AsyncSession = Depends(get_db)):
     """Compute equal-weight composite index of all grouped assets."""
     return await compute_portfolio_index(db, period)
 
 
 @router.get("/performers", response_model=list[AssetPerformance], summary="Get top and bottom performers by return")
-async def get_performers(period: str = "1y", db: AsyncSession = Depends(get_db)):
+async def get_performers(period: PeriodType = Query("1y"), db: AsyncSession = Depends(get_db)):
     """Return grouped assets ranked by period return (best first)."""
     return await compute_performers(db, period)

--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -6,11 +8,13 @@ from app.services.entity_lookups import find_asset, get_asset
 from app.schemas.price import AssetDetailResponse, IndicatorResponse, PriceResponse
 from app.services import price_service
 
+PeriodType = Literal["1mo", "3mo", "6mo", "1y", "2y", "5y"]
+
 router = APIRouter(prefix="/api/assets/{symbol}", tags=["prices"])
 
 
 @router.get("/prices", response_model=list[PriceResponse], summary="Get OHLCV price history")
-async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
+async def get_prices(symbol: str, period: PeriodType = Query("3mo"), db: AsyncSession = Depends(get_db)):
     """Return daily OHLCV price history for a symbol.
 
     For tracked assets, prices are read from the database (and auto-synced
@@ -25,7 +29,7 @@ async def get_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depend
 
 
 @router.get("/indicators", response_model=list[IndicatorResponse], summary="Get technical indicators (RSI, SMA, MACD, Bollinger, ATR, ADX)")
-async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
+async def get_indicators(symbol: str, period: PeriodType = Query("3mo"), db: AsyncSession = Depends(get_db)):
     """Return daily indicator time series for a symbol.
 
     Includes RSI (14), SMA 20/50, Bollinger Bands (20, 2σ), MACD (12/26/9),
@@ -40,7 +44,7 @@ async def get_indicators(symbol: str, period: str = "3mo", db: AsyncSession = De
 
 
 @router.get("/detail", response_model=AssetDetailResponse, summary="Get prices and indicators in one call")
-async def get_detail(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
+async def get_detail(symbol: str, period: PeriodType = Query("3mo"), db: AsyncSession = Depends(get_db)):
     """Return both OHLCV prices and technical indicators for a symbol in a single request.
 
     Avoids the need for parallel `/prices` + `/indicators` calls from the frontend,
@@ -53,7 +57,7 @@ async def get_detail(symbol: str, period: str = "3mo", db: AsyncSession = Depend
 
 
 @router.post("/refresh", status_code=200, summary="Force-refresh prices from Yahoo Finance")
-async def refresh_prices(symbol: str, period: str = "3mo", db: AsyncSession = Depends(get_db)):
+async def refresh_prices(symbol: str, period: PeriodType = Query("3mo"), db: AsyncSession = Depends(get_db)):
     """Force a re-sync of price data from Yahoo Finance for a tracked asset.
 
     Returns the number of price points upserted.

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -56,7 +56,7 @@ async def _fetch_ephemeral(symbol: str, period: str, warmup: bool = False) -> pd
     start_date = date.today() - timedelta(days=days)
     try:
         df = await fetch_history(symbol.upper(), start=start_date, end=date.today())
-    except (ValueError, Exception):
+    except (ValueError, KeyError):
         raise HTTPException(404, f"No price data available for {symbol}")
 
     if df.empty:

--- a/backend/app/services/pseudo_etf_service.py
+++ b/backend/app/services/pseudo_etf_service.py
@@ -30,9 +30,14 @@ async def get_pseudo_etf_detail(db: AsyncSession, etf_id: int):
     return await get_pseudo_etf(etf_id, db)
 
 
+UPDATABLE_FIELDS = {"name", "description", "base_date"}
+
+
 async def update_pseudo_etf(db: AsyncSession, etf_id: int, data: dict):
     etf = await get_pseudo_etf(etf_id, db)
     for field, value in data.items():
+        if field not in UPDATABLE_FIELDS:
+            raise HTTPException(400, f"Field '{field}' is not updatable")
         setattr(etf, field, value)
     return await PseudoEtfRepository(db).save(etf)
 


### PR DESCRIPTION
## Summary
- Narrow exception catch in `_fetch_ephemeral` to `ValueError, KeyError` only — unexpected errors now propagate as 500s
- Add `Literal` type validation for `period` query parameter across all endpoints
- Add `UPDATABLE_FIELDS` allowlist to `update_pseudo_etf`

Closes #300

## Test plan
- [ ] Existing backend tests pass
- [ ] Invalid period values return 422
- [ ] Unexpected errors in Yahoo fetch propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)