### PR TITLE
refactor: extract shared price service helpers (DRY) (#301)

### DIFF
--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -4,14 +4,13 @@ from datetime import date, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import pandas as pd
-
 from app.constants import PERIOD_DAYS, WARMUP_DAYS
 from app.models import PriceHistory
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
 from app.repositories.price_repo import PriceRepository
 from app.services.compute.indicators import build_indicator_snapshot, compute_indicators
+from app.services.compute.utils import prices_to_df
 from app.utils import TTLCache
 
 # In-memory cache for batch indicator snapshots.
@@ -104,14 +103,7 @@ async def compute_and_cache_indicators(
             out[symbol] = {"values": {}}
             continue
 
-        df = pd.DataFrame([{
-            "date": p.date,
-            "open": float(p.open),
-            "high": float(p.high),
-            "low": float(p.low),
-            "close": float(p.close),
-            "volume": p.volume,
-        } for p in prices]).set_index("date")
+        df = prices_to_df(prices)
 
         snapshot = build_indicator_snapshot(compute_indicators(df))
         out[symbol] = snapshot

--- a/backend/app/services/compute/utils.py
+++ b/backend/app/services/compute/utils.py
@@ -1,0 +1,20 @@
+"""Shared utility functions for compute modules."""
+
+import pandas as pd
+
+from app.models import PriceHistory
+
+
+def prices_to_df(prices: list[PriceHistory]) -> pd.DataFrame:
+    """Convert a list of PriceHistory ORM objects to a pandas DataFrame.
+
+    Returns a DataFrame indexed by date with columns: open, high, low, close, volume.
+    """
+    return pd.DataFrame([{
+        "date": p.date,
+        "open": float(p.open),
+        "high": float(p.high),
+        "low": float(p.low),
+        "close": float(p.close),
+        "volume": p.volume,
+    } for p in prices]).set_index("date")

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -12,6 +12,7 @@ from app.models import Asset, PriceHistory
 from app.repositories.price_repo import PriceRepository
 from app.schemas.price import AssetDetailResponse, IndicatorResponse, PriceResponse
 from app.services.compute.indicators import INDICATOR_REGISTRY, compute_indicators, safe_round
+from app.services.compute.utils import prices_to_df
 from app.services.price_sync import sync_asset_prices, sync_asset_prices_range
 from app.services.yahoo import fetch_history
 from app.utils import TTLCache
@@ -93,15 +94,26 @@ async def _ensure_prices(db: AsyncSession, asset: Asset, period: str) -> list[Pr
     return prices
 
 
-def _prices_to_df(prices: list[PriceHistory]) -> pd.DataFrame:
-    return pd.DataFrame([{
-        "date": p.date,
-        "open": float(p.open),
-        "high": float(p.high),
-        "low": float(p.low),
-        "close": float(p.close),
-        "volume": p.volume,
-    } for p in prices]).set_index("date")
+async def _ensure_warmup_prices(
+    db: AsyncSession, asset: Asset, prices: list[PriceHistory], start: date,
+) -> list[PriceHistory]:
+    """Backfill warmup-period prices if the stored history doesn't reach far enough back.
+
+    Checks whether the earliest stored price is after the warmup start date.
+    If so, attempts to sync the missing range from Yahoo.  Returns the
+    (possibly updated) price list.
+    """
+    warmup_start = start - timedelta(days=WARMUP_DAYS)
+
+    if prices and prices[0].date > warmup_start:
+        if not _backfill_already_attempted(asset.id, warmup_start):
+            earliest_before = prices[0].date
+            await sync_asset_prices_range(db, asset, warmup_start, date.today())
+            prices = await PriceRepository(db).list_by_asset(asset.id)
+            if prices and prices[0].date >= earliest_before:
+                _earliest_date_cache.set_value(asset.id, prices[0].date)
+
+    return prices
 
 
 def _df_to_price_rows(df: pd.DataFrame, start: date) -> list[PriceResponse]:
@@ -159,17 +171,9 @@ async def get_indicators(db: AsyncSession, asset: Asset | None, symbol: str, per
         if cached is not None:
             return cached
 
-        warmup_start = start - timedelta(days=WARMUP_DAYS)
+        prices = await _ensure_warmup_prices(db, asset, prices, start)
 
-        if prices and prices[0].date > warmup_start:
-            if not _backfill_already_attempted(asset.id, warmup_start):
-                earliest_before = prices[0].date
-                await sync_asset_prices_range(db, asset, warmup_start, date.today())
-                prices = await PriceRepository(db).list_by_asset(asset.id)
-                if prices and prices[0].date >= earliest_before:
-                    _earliest_date_cache.set_value(asset.id, prices[0].date)
-
-        df = _prices_to_df(prices)
+        df = prices_to_df(prices)
     else:
         cache_key = None
         df = await _fetch_ephemeral(symbol, period, warmup=True)
@@ -195,16 +199,9 @@ async def get_detail(db: AsyncSession, asset: Asset | None, symbol: str, period:
         if cached is not None:
             return AssetDetailResponse(prices=price_rows, indicators=cached)
 
-        warmup_start = start - timedelta(days=WARMUP_DAYS)
-        if prices and prices[0].date > warmup_start:
-            if not _backfill_already_attempted(asset.id, warmup_start):
-                earliest_before = prices[0].date
-                await sync_asset_prices_range(db, asset, warmup_start, date.today())
-                prices = await PriceRepository(db).list_by_asset(asset.id)
-                if prices and prices[0].date >= earliest_before:
-                    _earliest_date_cache.set_value(asset.id, prices[0].date)
+        prices = await _ensure_warmup_prices(db, asset, prices, start)
 
-        df = _prices_to_df(prices)
+        df = prices_to_df(prices)
     else:
         cache_key = None
         df = await _fetch_ephemeral(symbol, period, warmup=True)


### PR DESCRIPTION
## Summary
- Extract `_prices_to_df` to shared `backend/app/services/compute/utils.py` module, removing duplication between `price_service.py` and `compute/group.py`
- Extract `_ensure_warmup_prices` helper in `price_service.py` to deduplicate the ~15-line warmup-backfill block repeated in `get_indicators` and `get_detail`

Closes #301

## Test plan
- [x] All 307 existing backend tests pass
- [ ] No behavioral changes — pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)