### PR TITLE
improvement: add Pydantic response models to undocumented endpoints (#311)

### DIFF
--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.schemas.group import GroupAddAssets, GroupCreate, GroupResponse, GroupUpdate
+from app.schemas.price import IndicatorSnapshotBase, SparklinePointResponse
 from app.services import group_service
 from app.services.compute.group import compute_and_cache_indicators, get_batch_sparklines
 
@@ -48,20 +49,20 @@ async def remove_asset_from_group(group_id: int, asset_id: int, db: AsyncSession
     return await group_service.remove_asset(db, group_id, asset_id)
 
 
-@router.get("/{group_id}/sparklines", summary="Batch close prices for group assets")
+@router.get("/{group_id}/sparklines", response_model=dict[str, list[SparklinePointResponse]], summary="Batch close prices for group assets")
 async def group_sparklines(
     group_id: int,
     period: PeriodType = Query("3mo"),
     db: AsyncSession = Depends(get_db),
-) -> dict[str, list[dict]]:
+):
     """Return close-price sparkline data for every asset in the group."""
     return await get_batch_sparklines(db, period, group_id=group_id)
 
 
-@router.get("/{group_id}/indicators", summary="Batch indicators for group assets")
+@router.get("/{group_id}/indicators", response_model=dict[str, IndicatorSnapshotBase], summary="Batch indicators for group assets")
 async def group_indicators(
     group_id: int,
     db: AsyncSession = Depends(get_db),
-) -> dict[str, dict]:
+):
     """Return the latest indicator snapshot for every asset in the group."""
     return await compute_and_cache_indicators(db, group_id=group_id)

--- a/backend/app/routers/portfolio.py
+++ b/backend/app/routers/portfolio.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.models.asset import AssetType
 from app.services.compute.portfolio import compute_performers, compute_portfolio_index
 
 PeriodType = Literal["1mo", "3mo", "6mo", "1y", "2y", "5y"]
@@ -24,7 +25,7 @@ class PortfolioIndexResponse(BaseModel):
 class AssetPerformance(BaseModel):
     symbol: str
     name: str
-    type: str
+    type: AssetType
     change_pct: float
 
 

--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.services.entity_lookups import find_asset, get_asset
-from app.schemas.price import AssetDetailResponse, IndicatorResponse, PriceResponse
+from app.schemas.price import AssetDetailResponse, IndicatorResponse, PriceResponse, RefreshResponse
 from app.services import price_service
 
 PeriodType = Literal["1mo", "3mo", "6mo", "1y", "2y", "5y"]
@@ -56,7 +56,7 @@ async def get_detail(symbol: str, period: PeriodType = Query("3mo"), db: AsyncSe
     return await price_service.get_detail(db, asset, symbol, period)
 
 
-@router.post("/refresh", status_code=200, summary="Force-refresh prices from Yahoo Finance")
+@router.post("/refresh", response_model=RefreshResponse, status_code=200, summary="Force-refresh prices from Yahoo Finance")
 async def refresh_prices(symbol: str, period: PeriodType = Query("3mo"), db: AsyncSession = Depends(get_db)):
     """Force a re-sync of price data from Yahoo Finance for a tracked asset.
 

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -2,12 +2,13 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.schemas.search import SymbolSearchResponse
 from app.services import search_service
 
 router = APIRouter(prefix="/api/search", tags=["search"])
 
 
-@router.get("")
+@router.get("", response_model=list[SymbolSearchResponse])
 async def search_symbols(
     q: str = Query(..., min_length=1, max_length=50),
     db: AsyncSession = Depends(get_db),

--- a/backend/app/schemas/price.py
+++ b/backend/app/schemas/price.py
@@ -58,3 +58,13 @@ class IndicatorSnapshotBase(BaseModel):
 class HoldingIndicatorResponse(IndicatorSnapshotBase):
     symbol: str = Field(description="Holding ticker symbol")
     currency: str = Field(default="USD", description="ISO 4217 currency code")
+
+
+class SparklinePointResponse(BaseModel):
+    date: str = Field(description="Trading date as ISO 8601 string")
+    close: float = Field(description="Closing price")
+
+
+class RefreshResponse(BaseModel):
+    symbol: str = Field(description="Ticker symbol that was refreshed")
+    synced: int = Field(description="Number of price points upserted")

--- a/backend/app/schemas/search.py
+++ b/backend/app/schemas/search.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+
+class SymbolSearchResponse(BaseModel):
+    symbol: str = Field(description="Ticker symbol (e.g. AAPL)")
+    name: str = Field(description="Company or fund name")
+    exchange: str = Field(description="Exchange name (e.g. NasdaqGS)")
+    type: str = Field(description="Asset type: stock or etf")


### PR DESCRIPTION
## Summary
- Add `SymbolSearchResponse` schema for search endpoint
- Add response models to sparkline and indicator group endpoints
- Add `RefreshResponse` to price refresh endpoint
- Use `AssetType` enum in `AssetPerformance`

Closes #311

## Test plan
- [ ] All existing tests pass
- [ ] OpenAPI docs show proper schemas for all endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)