### PR TITLE
feat: show cached DB prices instantly in group table (#312)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -141,6 +141,14 @@
 .flash-green { animation: flash-green 1.8s ease-out; }
 .flash-red   { animation: flash-red 1.8s ease-out; }
 
+@keyframes stale-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}
+.stale-price {
+  animation: stale-pulse 2.5s ease-in-out infinite;
+}
+
 @keyframes slide {
   0%   { transform: translateX(-100%); }
   100% { transform: translateX(400%); }


### PR DESCRIPTION
## Summary
- Show DB-cached prices immediately in group table instead of skeletons
- Seamlessly replace with live SSE quotes when they arrive
- Subtle pulse animation during market hours to indicate stale data
- No stale indicator when market is closed (DB prices are current)

Closes #312

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Group table shows prices immediately on load
- [ ] Live quotes replace DB prices with flash animation
- [ ] Stale indicator only shows during market hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)