### PR TITLE
fix: UI polish — confirmation dialogs, accessibility (#307)

### DIFF
--- a/frontend/src/components/annotations-list.tsx
+++ b/frontend/src/components/annotations-list.tsx
@@ -96,6 +96,7 @@ export function AnnotationsList({ annotations, onCreate, onDelete, isCreating }:
               variant="ghost"
               size="icon"
               className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+              aria-label="Delete annotation"
               onClick={() => onDelete(a.id)}
             >
               <Trash2 className="h-3 w-3" />

--- a/frontend/src/components/holdings-grid.tsx
+++ b/frontend/src/components/holdings-grid.tsx
@@ -175,6 +175,7 @@ function HoldingRow({
               variant="ghost"
               size="icon"
               className="h-5 w-5 opacity-0 group-hover/row:opacity-100 transition-opacity"
+              aria-label={`Remove ${row.symbol}`}
               onClick={(e) => {
                 e.stopPropagation()
                 onRemove()

--- a/frontend/src/components/market-status-dot.tsx
+++ b/frontend/src/components/market-status-dot.tsx
@@ -1,7 +1,6 @@
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
@@ -27,17 +26,15 @@ export function MarketStatusDot({
   const config = (marketState && STATE_CONFIG[marketState]) || DEFAULT_CONFIG
 
   return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={cn("inline-block h-2 w-2 rounded-full shrink-0", config.color, className)}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          {config.label}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <span
+          className={cn("inline-block h-2 w-2 rounded-full shrink-0", config.color, className)}
+        />
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {config.label}
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/frontend/src/components/tag-input.tsx
+++ b/frontend/src/components/tag-input.tsx
@@ -91,10 +91,20 @@ export function TagInput({
             setOpen(true)
           }}
           onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              setOpen(false)
+              ;(e.target as HTMLInputElement).blur()
+            }
+          }}
+          role="combobox"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
           className="h-8 text-sm"
         />
         {open && (search || filtered.length > 0) && (
-          <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md">
+          <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover shadow-md" role="listbox">
             <div className="max-h-48 overflow-y-auto p-1">
               {filtered.map((tag) => (
                 <button

--- a/frontend/src/pages/groups.tsx
+++ b/frontend/src/pages/groups.tsx
@@ -7,6 +7,17 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import {
   useGroups,
   useCreateGroup,
   useUpdateGroup,
@@ -139,20 +150,33 @@ function GroupCard({ group }: { group: Group }) {
         )}
         {!editing && (
           <div className="flex gap-1">
-            <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => setAddingAsset(!addingAsset)}>
+            <Button size="icon" variant="ghost" className="h-7 w-7" aria-label="Add asset to group" onClick={() => setAddingAsset(!addingAsset)}>
               <UserPlus className="h-3.5 w-3.5" />
             </Button>
-            <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => setEditing(true)}>
+            <Button size="icon" variant="ghost" className="h-7 w-7" aria-label="Edit group" onClick={() => setEditing(true)}>
               <Pencil className="h-3.5 w-3.5" />
             </Button>
-            <Button
-              size="icon"
-              variant="ghost"
-              className="h-7 w-7"
-              onClick={() => deleteGroup.mutate(group.id)}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button size="icon" variant="ghost" className="h-7 w-7" aria-label="Delete group">
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete group</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to delete &ldquo;{group.name}&rdquo;? This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction variant="destructive" onClick={() => deleteGroup.mutate(group.id)}>
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         )}
       </CardHeader>
@@ -175,6 +199,7 @@ function GroupCard({ group }: { group: Group }) {
                 variant="ghost"
                 size="icon"
                 className="h-5 w-5 opacity-0 group-hover/asset:opacity-100 transition-opacity"
+                aria-label={`Remove ${asset.symbol} from group`}
                 onClick={() => removeAsset.mutate({ groupId: group.id, assetId: asset.id })}
               >
                 <X className="h-3 w-3" />

--- a/frontend/src/pages/pseudo-etfs.tsx
+++ b/frontend/src/pages/pseudo-etfs.tsx
@@ -7,6 +7,17 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import {
   usePseudoEtfs,
   useCreatePseudoEtf,
   useUpdatePseudoEtf,
@@ -140,12 +151,30 @@ function EtfCard({ etf }: { etf: PseudoETF }) {
         )}
         {!editing && (
           <div className="flex gap-1">
-            <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => setEditing(true)}>
+            <Button size="icon" variant="ghost" className="h-7 w-7" aria-label="Edit pseudo-ETF" onClick={() => setEditing(true)}>
               <Pencil className="h-3.5 w-3.5" />
             </Button>
-            <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => deleteEtf.mutate(etf.id)}>
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button size="icon" variant="ghost" className="h-7 w-7" aria-label="Delete pseudo-ETF">
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete pseudo-ETF</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to delete &ldquo;{etf.name}&rdquo;? This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction variant="destructive" onClick={() => deleteEtf.mutate(etf.id)}>
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         )}
       </CardHeader>


### PR DESCRIPTION
## Summary
- Add confirmation dialogs for destructive delete actions in groups and pseudo-ETFs
- Remove redundant `TooltipProvider` from `MarketStatusDot` (global provider in Layout suffices)
- Add `aria-label` to all icon-only buttons for screen reader accessibility
- Add Escape key handler to TagInput for keyboard dismissal

Closes #307

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Delete actions show confirmation before executing
- [ ] Tooltips still appear on market status dots
- [ ] Screen reader announces button purposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)