### PR TITLE
chore: frontend minor code cleanup (#310)

### DIFF
--- a/frontend/src/components/chart/pseudo-etf-charts.tsx
+++ b/frontend/src/components/chart/pseudo-etf-charts.tsx
@@ -6,7 +6,7 @@ import {
   LineSeries,
   HistogramSeries,
 } from "lightweight-charts"
-import { baseChartOptions, getChartTheme, STACK_COLORS } from "@/lib/chart-utils"
+import { baseChartOptions, STACK_COLORS } from "@/lib/chart-utils"
 import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
 import type { PerformanceBreakdownPoint } from "@/lib/api"
 
@@ -96,9 +96,8 @@ export function PerformanceOverlayChart({
     }
 
     // Dashed base value reference line
-    const chartTheme = getChartTheme()
     const baseLine = chart.addSeries(LineSeries, {
-      color: chartTheme.dark ? "rgba(161, 161, 170, 0.5)" : "rgba(113, 113, 122, 0.5)",
+      color: theme.dark ? "rgba(161, 161, 170, 0.5)" : "rgba(113, 113, 122, 0.5)",
       lineWidth: 1,
       lineStyle: 2,
       priceLineVisible: false,

--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -232,7 +232,7 @@ function SortableHeader({
 
   return (
     <th
-      className={`text-${align} text-xs font-medium px-3 py-2 ${
+      className={`${align === "right" ? "text-right" : "text-left"} text-xs font-medium px-3 py-2 ${
         onSort ? "cursor-pointer select-none hover:text-foreground" : ""
       } ${active ? "text-foreground" : "text-muted-foreground"}`}
       onClick={() => onSort?.(sortKey)}

--- a/frontend/src/components/sparkline.tsx
+++ b/frontend/src/components/sparkline.tsx
@@ -7,7 +7,6 @@ export function SparklineChart({
   period = "3mo",
   batchData,
 }: {
-  symbol: string
   period?: string
   batchData?: SparklinePoint[]
 }) {

--- a/frontend/src/lib/chart-utils.ts
+++ b/frontend/src/lib/chart-utils.ts
@@ -14,15 +14,18 @@ export const STACK_COLORS = [
   "#c084fc", // purple-400
 ]
 
-export function getChartTheme() {
-  const dark = document.documentElement.classList.contains("dark")
+export function themeColors(isDark: boolean) {
   return {
-    bg: dark ? "#18181b" : "#ffffff",
-    text: dark ? "#a1a1aa" : "#71717a",
-    grid: dark ? "#27272a" : "#f4f4f5",
-    border: dark ? "#3f3f46" : "#e4e4e7",
-    dark,
+    bg: isDark ? "#18181b" : "#ffffff",
+    text: isDark ? "#a1a1aa" : "#71717a",
+    grid: isDark ? "#27272a" : "#f4f4f5",
+    border: isDark ? "#3f3f46" : "#e4e4e7",
+    dark: isDark,
   }
+}
+
+export function getChartTheme() {
+  return themeColors(document.documentElement.classList.contains("dark"))
 }
 
 export function useChartTheme() {
@@ -41,16 +44,7 @@ export function useChartTheme() {
     return () => observer.disconnect()
   }, [])
 
-  return useMemo(
-    () => ({
-      bg: isDark ? "#18181b" : "#ffffff",
-      text: isDark ? "#a1a1aa" : "#71717a",
-      grid: isDark ? "#27272a" : "#f4f4f5",
-      border: isDark ? "#3f3f46" : "#e4e4e7",
-      dark: isDark,
-    }),
-    [isDark]
-  )
+  return useMemo(() => themeColors(isDark), [isDark])
 }
 
 export type ChartTheme = ReturnType<typeof useChartTheme>

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -2,12 +2,10 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   USD: "$",
   EUR: "\u20ac",
   GBP: "\u00a3",
-  GBp: "\u00a3",
   GBX: "\u00a3",
   ILS: "\u20aa",
   ILA: "\u20aa",
   ZAR: "R",
-  ZAc: "R",
   JPY: "\u00a5",
   CHF: "CHF\u00a0",
 }
@@ -30,7 +28,7 @@ export function formatChangePct(v: number | null): { text: string | null; classN
   const sign = v >= 0 ? "+" : ""
   return {
     text: `${sign}${v.toFixed(2)}%`,
-    className: v >= 0 ? "text-emerald-500" : "text-red-500",
+    className: changeColor(v),
   }
 }
 

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -25,7 +25,6 @@ export const keys = {
   portfolioIndex: (period?: string) => ["portfolio-index", period] as const,
   portfolioPerformers: (period?: string) => ["portfolio-performers", period] as const,
   assets: ["assets"] as const,
-  asset: (symbol: string) => ["assets", symbol] as const,
   assetDetail: (symbol: string, period?: string) => ["asset-detail", symbol, period] as const,
   etfHoldings: (symbol: string) => ["etf-holdings", symbol] as const,
   holdingsIndicators: (symbol: string) => ["holdings-indicators", symbol] as const,
@@ -351,6 +350,7 @@ export function usePseudoEtf(id: number) {
     queryKey: keys.pseudoEtf(id),
     queryFn: () => api.pseudoEtfs.get(id),
     enabled: !!id,
+    staleTime: STALE_5MIN,
   })
 }
 
@@ -406,6 +406,7 @@ export function usePseudoEtfPerformance(id: number) {
     queryKey: keys.pseudoEtfPerformance(id),
     queryFn: () => api.pseudoEtfs.performance(id),
     enabled: !!id,
+    staleTime: STALE_5MIN,
   })
 }
 
@@ -424,6 +425,7 @@ export function usePseudoEtfThesis(id: number) {
     queryKey: keys.pseudoEtfThesis(id),
     queryFn: () => api.pseudoEtfs.thesis.get(id),
     enabled: !!id,
+    staleTime: STALE_5MIN,
   })
 }
 
@@ -440,6 +442,7 @@ export function usePseudoEtfAnnotations(id: number) {
     queryKey: keys.pseudoEtfAnnotations(id),
     queryFn: () => api.pseudoEtfs.annotations.list(id),
     enabled: !!id,
+    staleTime: STALE_5MIN,
   })
 }
 

--- a/frontend/src/pages/portfolio.tsx
+++ b/frontend/src/pages/portfolio.tsx
@@ -8,7 +8,6 @@ import { ChartSkeleton } from "@/components/chart-skeleton"
 import { PeriodSelector } from "@/components/period-selector"
 import { usePortfolioIndex, usePortfolioPerformers, usePrefetchAssetDetail } from "@/lib/queries"
 import { formatChangePct, changeColor } from "@/lib/format"
-import { getChartTheme } from "@/lib/chart-utils"
 import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
 import type { AssetPerformance } from "@/lib/api"
 
@@ -49,12 +48,10 @@ export function PortfolioPage() {
 function PortfolioChart({ dates, values, up }: { dates: string[]; values: number[]; up: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
-  const { startLifecycle } = useChartLifecycle(containerRef, [chartRef])
+  const { theme, startLifecycle } = useChartLifecycle(containerRef, [chartRef])
 
   useEffect(() => {
     if (!containerRef.current || !dates.length) return
-
-    const theme = getChartTheme()
 
     const chart = createChart(containerRef.current, {
       width: containerRef.current.clientWidth,


### PR DESCRIPTION
## Summary
- Remove unused `symbol` prop from `SparklineChart` and dead `keys.asset` from queries
- Extract shared `themeColors()` function in chart-utils to deduplicate color maps
- Replace snapshot `getChartTheme()` with reactive `theme` from `useChartLifecycle` in portfolio and pseudo-ETF charts
- Fix dynamic Tailwind class `text-${align}` in group-table with safe conditional expression
- Add consistent `staleTime: STALE_5MIN` to pseudo-ETF query hooks missing it
- Have `formatChangePct` call `changeColor()` instead of reimplementing the logic
- Remove dead mixed-case currency keys (`GBp`, `ZAc`) unreachable due to `toUpperCase()`

Closes #310

## Test plan
- [ ] TypeScript compiles cleanly (only pre-existing `react-markdown` type issue remains)
- [ ] Charts render with correct theme colors in both light and dark mode
- [ ] Group table headers align correctly
- [ ] No visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)