### PR TITLE
fix: exclude RSI/MACD cards when sub-charts are present

### DIFF
--- a/frontend/src/components/expanded-asset-chart.tsx
+++ b/frontend/src/components/expanded-asset-chart.tsx
@@ -8,7 +8,8 @@ import { getCardDescriptors } from "@/lib/indicator-registry"
 import { useAssetDetail, useAnnotations } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
 
-const CARD_DESCRIPTORS = getCardDescriptors()
+const CARD_DESCRIPTORS_ALL = getCardDescriptors()
+const CARD_DESCRIPTORS_EXCLUSIVE = getCardDescriptors(true)
 
 interface ExpandedAssetChartProps {
   symbol: string
@@ -34,7 +35,8 @@ export function ExpandedAssetChart({ symbol, currency, compact = false }: Expand
   const indicators = detail?.indicators
   const { data: annotations } = useAnnotations(symbol)
 
-  const enabledCards = CARD_DESCRIPTORS.filter(
+  const cardDescs = compact ? CARD_DESCRIPTORS_ALL : CARD_DESCRIPTORS_EXCLUSIVE
+  const enabledCards = cardDescs.filter(
     (d) => settings.detail_indicator_visibility[d.id] !== false,
   )
 

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -7,7 +7,7 @@ import { IndicatorCards } from "./chart/indicator-cards"
 import { getSubChartDescriptors, getCardDescriptors } from "@/lib/indicator-registry"
 
 const SUB_CHART_DESCRIPTORS = getSubChartDescriptors()
-const CARD_DESCRIPTORS = getCardDescriptors()
+const CARD_DESCRIPTORS = getCardDescriptors(true)
 
 interface PriceChartProps {
   prices: Price[]

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -292,8 +292,10 @@ export function getSubChartDescriptors(): IndicatorDescriptor[] {
   return INDICATOR_REGISTRY.filter((d) => d.placement === "subchart")
 }
 
-export function getCardDescriptors(): IndicatorDescriptor[] {
-  return INDICATOR_REGISTRY.filter((d) => d.placement === "card" || d.cardEligible)
+export function getCardDescriptors(excludeSubcharts = false): IndicatorDescriptor[] {
+  return INDICATOR_REGISTRY.filter((d) =>
+    d.placement === "card" || (!excludeSubcharts && d.cardEligible),
+  )
 }
 
 export function getAllIndicatorFields(): string[] {


### PR DESCRIPTION
## Summary
- Add `excludeSubcharts` parameter to `getCardDescriptors()` in the indicator registry
- When `true`, only returns `placement === "card"` indicators (ATR, ADX), excluding `cardEligible` subchart indicators (RSI, MACD)
- `price-chart.tsx` and non-compact `expanded-asset-chart.tsx` pass `true` since they render RSI/MACD sub-charts
- Group page compact cards still show all four indicators (unchanged)

Closes #323

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` clean (0 errors)
- [ ] Manual: asset detail page shows only ATR + ADX cards (RSI/MACD remain as sub-charts)
- [ ] Manual: holdings expansion shows only ATR + ADX cards
- [ ] Manual: group page expanded rows still show all four indicator cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)