### PR TITLE
fix: reproducible builds — pin pnpm, bound yahooquery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.28.2
 
       - uses: actions/setup-node@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build frontend
 FROM node:22-alpine AS frontend-build
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 WORKDIR /build
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.34.3
 sqlalchemy[asyncio]==2.0.41
 asyncpg==0.31.0
 alembic==1.15.2
-yahooquery>=2.3.7
+yahooquery>=2.3.7,<3.0
 pandas==2.2.3
 apscheduler==3.11.0
 pydantic-settings==2.9.1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:22-alpine AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 WORKDIR /app
 
 # Install dependencies

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -18,7 +18,7 @@ export default defineConfig([
       jsxA11y.flatConfigs.recommended,
     ],
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 2022,
       globals: globals.browser,
     },
     rules: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
-    "shadcn": "^3.8.4",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "tw-animate-css": "^1.4.0"
@@ -43,6 +42,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "shadcn": "^3.8.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       react-router-dom:
         specifier: ^7.13.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      shadcn:
-        specifier: ^3.8.4
-        version: 3.8.4(@types/node@24.10.12)(typescript@5.9.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -102,6 +99,9 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
+      shadcn:
+        specifier: ^3.8.4
+        version: 3.8.4(@types/node@24.10.12)(typescript@5.9.3)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- **Pin pnpm to 10.28.2** in `Dockerfile`, `frontend/Dockerfile`, and `.github/workflows/ci.yaml` — replaces `pnpm@latest` which could silently break builds on a pnpm major release
- **Bound yahooquery** to `>=2.3.7,<3.0` in `backend/requirements.txt` — was the only unbounded dependency
- **Move shadcn to devDependencies** in `frontend/package.json` — CLI code-gen tool does not belong in runtime dependencies
- **Align ESLint ecmaVersion to 2022** in `frontend/eslint.config.js` — matches the TypeScript `ES2022` target

Closes #343

## Test plan
- [ ] CI passes lint + build + backend tests
- [ ] Docker image builds successfully with pinned pnpm version
- [ ] No runtime regressions from shadcn move (it is only used as a CLI tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)