### PR TITLE
fix: MACD crosshair snaps to MACD line instead of histogram (#332)

### DIFF
--- a/frontend/src/components/chart/chart-builders.ts
+++ b/frontend/src/components/chart/chart-builders.ts
@@ -155,8 +155,8 @@ export function createSubChart(
     }
   }
 
-  // Snap field = first data series field
-  const snapField = descriptor.series[0]?.field ?? descriptor.fields[0]
+  // Snap field: prefer explicit override, then fall back to first data series field
+  const snapField = descriptor.snapField ?? descriptor.series[0]?.field ?? descriptor.fields[0]
 
   return { chart, descriptorId: descriptor.id, seriesMap, thresholdSeries, snapField }
 }

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -68,6 +68,8 @@ export interface IndicatorDescriptor {
   }
   /** When true, this indicator also renders as a card (in addition to its primary placement). */
   cardEligible?: boolean
+  /** Override the default crosshair snap target (defaults to series[0].field). */
+  snapField?: string
   /** When true, the indicator's values are denominated in the asset's currency (e.g. ATR). */
   priceDenominated?: boolean
 }
@@ -190,6 +192,7 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
       colorMap: { bullish: "text-emerald-500", bearish: "text-red-500" },
     },
     cardEligible: true,
+    snapField: "macd",
   },
   {
     id: "atr",


### PR DESCRIPTION
## Summary
- Adds optional `snapField` property to `IndicatorDescriptor` type to allow subchart descriptors to override which series the crosshair magnetically snaps to
- Sets `snapField: "macd"` on the MACD descriptor so the crosshair snaps to the MACD line instead of the histogram (which was `series[0]` due to render-order)
- Updates `createSubChart()` to prefer `descriptor.snapField` over the default `series[0].field`

Closes #332

## Test plan
- [ ] Open any asset detail page with MACD subchart enabled
- [ ] Move the crosshair over the MACD subchart and verify it snaps to the MACD line (blue), not the histogram bars
- [ ] Verify RSI subchart crosshair behavior is unchanged (still snaps to RSI line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)