### PR TITLE
fix: add thread-safe locking to TTLCache for yahoo.py holdings cache

### DIFF
--- a/backend/app/services/yahoo.py
+++ b/backend/app/services/yahoo.py
@@ -14,7 +14,7 @@ from app.utils import TTLCache, async_threadable
 logger = logging.getLogger(__name__)
 
 # In-memory TTL cache for ETF holdings (holdings change quarterly at most)
-_holdings_cache: TTLCache = TTLCache(default_ttl=86400, max_size=100)
+_holdings_cache: TTLCache = TTLCache(default_ttl=86400, max_size=100, thread_safe=True)
 
 # Fallback mapping from Yahoo Finance exchange suffixes to ISO 4217 currency codes.
 # Used when ticker.price doesn't return currency data for a symbol.


### PR DESCRIPTION
## Summary
- Adds an optional `thread_safe` parameter to `TTLCache` that wraps `get_value`, `set_value`, and `clear` in a `threading.Lock`
- Enables `thread_safe=True` on `_holdings_cache` in `yahoo.py`, which is accessed from thread pool workers via `@async_threadable` / `asyncio.to_thread()`
- Existing async-only caches (`price_service.py`, `group.py`) are unaffected — they default to `thread_safe=False` and pay no locking overhead

## Test plan
- [x] All 307 backend tests pass (`pytest --timeout=30 -x`)
- [ ] Verify no regressions in ETF holdings fetching on dev environment

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)