### PR TITLE
fix: production Docker hardening — restart policy, BigInteger, non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,13 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY backend/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend/ .
 COPY --from=frontend-build /build/dist ./static
 
+RUN adduser --disabled-password --gecos "" appuser
+
 EXPOSE 8000
+USER appuser
 CMD ["sh", "-c", "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = postgresql+asyncpg://fibenchi:fibenchi@db:5432/fibenchi
+sqlalchemy.url = driver://user:pass@localhost/dbname
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/alembic/versions/0008_change_volume_to_biginteger.py
+++ b/backend/alembic/versions/0008_change_volume_to_biginteger.py
@@ -1,0 +1,37 @@
+"""Change volume column to BigInteger
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-02-19
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0008"
+down_revision: Union[str, None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "price_history",
+        "volume",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "price_history",
+        "volume",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+    )

--- a/backend/app/models/price.py
+++ b/backend/app/models/price.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from sqlalchemy import Date, ForeignKey, Integer, Numeric, UniqueConstraint
+from sqlalchemy import BigInteger, Date, ForeignKey, Numeric, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -17,7 +17,7 @@ class PriceHistory(Base):
     high: Mapped[float] = mapped_column(Numeric(12, 4))
     low: Mapped[float] = mapped_column(Numeric(12, 4))
     close: Mapped[float] = mapped_column(Numeric(12, 4))
-    volume: Mapped[int] = mapped_column(Integer)
+    volume: Mapped[int] = mapped_column(BigInteger)
 
     asset: Mapped["Asset"] = relationship(back_populates="prices")
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgres:16-alpine
+    restart: unless-stopped
     environment:
       POSTGRES_USER: fibenchi
       POSTGRES_PASSWORD: fibenchi
@@ -15,11 +16,18 @@ services:
 
   app:
     build: .
+    restart: unless-stopped
     environment:
       DATABASE_URL: postgresql+asyncpg://fibenchi:fibenchi@db:5432/fibenchi
       REFRESH_CRON: ${REFRESH_CRON:-0 23 * * *}
     ports:
       - "18000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U fibenchi"]
       interval: 5s
@@ -24,6 +24,12 @@ services:
       - "18000:8000"
     volumes:
       - ./backend:/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     depends_on:
       db:
         condition: service_healthy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,9 +19,3 @@ FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN pnpm build
-
-# Production
-FROM nginx:alpine AS prod
-COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- Add `restart: unless-stopped` to both services in `docker-compose.prod.yaml` so crashed services recover automatically
- Change `volume` column from `Integer` (32-bit, max ~2.1B) to `BigInteger` (64-bit) in both the SQLAlchemy model and a new Alembic migration (`0008`), preventing overflow on high-volume stocks
- Add non-root `appuser` to production `Dockerfile` to reduce container attack surface
- Add `--no-cache-dir` to `pip install` in production `Dockerfile` to reduce image size
- Add backend healthcheck (`/api/health`) to both `docker-compose.yaml` and `docker-compose.prod.yaml`
- Bind PostgreSQL to `127.0.0.1` in dev `docker-compose.yaml` instead of `0.0.0.0`
- Replace hardcoded DB credentials in `alembic.ini` with a placeholder (runtime override via `env.py` is unaffected)
- Remove dead nginx `prod` stage from `frontend/Dockerfile` that was never referenced

Closes #342

## Test plan
- [ ] Verify `docker compose -f docker-compose.prod.yaml config` parses without errors
- [ ] Verify `docker compose config` parses without errors
- [ ] Verify the production Docker image builds successfully
- [ ] Verify `alembic upgrade head` applies migration 0008 (volume column type change)
- [ ] Verify the backend starts as non-root user inside the production container
- [ ] Verify backend healthcheck reports healthy after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)