### PR TITLE
cleanup: remove frontend dead code (#339)

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -21,7 +21,6 @@ export interface AssetCardProps {
   currency: string
   tags: TagBrief[]
   quote?: Quote
-  sparklinePeriod: string
   sparklineData?: SparklinePoint[]
   indicatorData?: IndicatorSummary
   onDelete: () => void
@@ -54,7 +53,6 @@ export function AssetCard({
   currency,
   tags,
   quote,
-  sparklinePeriod,
   sparklineData,
   indicatorData,
   onDelete,
@@ -113,7 +111,7 @@ export function AssetCard({
           )}
         </CardHeader>
         <CardContent className="pt-0 space-y-2">
-          {showSparkline && <DeferredSparkline symbol={symbol} period={sparklinePeriod} batchData={sparklineData} />}
+          {showSparkline && <DeferredSparkline batchData={sparklineData} />}
           {enabledCards.length > 0 && (
             <div className="grid grid-cols-2 gap-1.5 mt-1">
               {enabledCards.map((desc) => (

--- a/frontend/src/components/sparkline.tsx
+++ b/frontend/src/components/sparkline.tsx
@@ -4,13 +4,10 @@ import { Skeleton } from "@/components/ui/skeleton"
 import type { SparklinePoint } from "@/lib/api"
 
 export function SparklineChart({
-  period = "3mo",
   batchData,
 }: {
-  period?: string
   batchData?: SparklinePoint[]
 }) {
-  void period
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
 
@@ -89,8 +86,6 @@ export function SparklineChart({
  * the main thread and cause a visible freeze.
  */
 export function DeferredSparkline(props: {
-  symbol: string
-  period?: string
   batchData?: SparklinePoint[]
 }) {
   const [isVisible, setIsVisible] = useState(false)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,7 +23,6 @@ import type {
   Tag,
   TagBrief,
   TagCreate,
-  TagUpdate,
   Thesis,
 } from "./types"
 
@@ -83,10 +82,6 @@ export const api = {
     list: () => request<Tag[]>("/tags"),
     create: (data: TagCreate) =>
       request<Tag>("/tags", { method: "POST", body: JSON.stringify(data) }),
-    update: (id: number, data: TagUpdate) =>
-      request<Tag>(`/tags/${id}`, { method: "PUT", body: JSON.stringify(data) }),
-    delete: (id: number) =>
-      request<void>(`/tags/${id}`, { method: "DELETE" }),
     attach: (symbol: string, tagId: number) =>
       request<TagBrief[]>(`/assets/${symbol}/tags/${tagId}`, { method: "POST" }),
     detach: (symbol: string, tagId: number) =>

--- a/frontend/src/lib/chart-utils.ts
+++ b/frontend/src/lib/chart-utils.ts
@@ -14,7 +14,7 @@ export const STACK_COLORS = [
   "#c084fc", // purple-400
 ]
 
-export function themeColors(isDark: boolean) {
+function themeColors(isDark: boolean) {
   return {
     bg: isDark ? "#18181b" : "#ffffff",
     text: isDark ? "#a1a1aa" : "#71717a",
@@ -24,7 +24,7 @@ export function themeColors(isDark: boolean) {
   }
 }
 
-export function getChartTheme() {
+function getChartTheme() {
   return themeColors(document.documentElement.classList.contains("dark"))
 }
 

--- a/frontend/src/lib/icon-utils.ts
+++ b/frontend/src/lib/icon-utils.ts
@@ -15,7 +15,7 @@ export function toKebab(name: string): string {
  * Convert kebab-case stored name to PascalCase for lookup.
  * e.g. "bar-chart-3" → "BarChart3"
  */
-export function toPascal(name: string): string {
+function toPascal(name: string): string {
   return name.replace(/(^|-)([a-z0-9])/g, (_, _sep, char) => char.toUpperCase())
 }
 

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -344,11 +344,6 @@ export function extractMacdValues(values?: Record<string, number | string | null
   } : undefined
 }
 
-/** Check whether an indicator's values are denominated in the asset's currency. */
-export function isPriceDenominated(id: string): boolean {
-  return INDICATOR_REGISTRY.find((d) => d.id === id)?.priceDenominated === true
-}
-
 export function getSeriesByField(field: string): SeriesDescriptor | undefined {
   for (const desc of INDICATOR_REGISTRY) {
     const s = desc.series.find((ser) => ser.field === field)

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -182,11 +182,6 @@ export interface PseudoETFUpdate {
   base_date?: string
 }
 
-export interface PerformancePoint {
-  date: string
-  value: number
-}
-
 export interface PerformanceBreakdownPoint {
   date: string
   value: number

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -212,7 +212,6 @@ export function GroupPage({ groupId }: { groupId: number }) {
               currency={asset.currency}
               tags={asset.tags}
               quote={quotes[asset.symbol]}
-              sparklinePeriod={sparklinePeriod}
               sparklineData={batchSparklines?.[asset.symbol]}
               indicatorData={batchIndicators?.[asset.symbol]}
               onDelete={() => handleRemove(asset.symbol)}

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -193,24 +193,6 @@ export function SettingsPage() {
             checked={draft.compact_mode}
             onCheckedChange={(v) => change({ compact_mode: v })}
           />
-          <div className="flex items-center justify-between">
-            <Label>Decimal Places</Label>
-            <Select
-              value={String(draft.decimal_places)}
-              onValueChange={(v) => change({ decimal_places: Number(v) })}
-            >
-              <SelectTrigger className="w-28">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="0">0</SelectItem>
-                <SelectItem value="1">1</SelectItem>
-                <SelectItem value="2">2</SelectItem>
-                <SelectItem value="3">3</SelectItem>
-                <SelectItem value="4">4</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
         </CardContent>
       </Card>
       </div>


### PR DESCRIPTION
## Summary
- Remove `export` from `toPascal`, `themeColors`, `getChartTheme` (internal-only usage in same file)
- Delete `isPriceDenominated` function entirely (never called anywhere)
- Delete `PerformancePoint` type (unused; `PerformanceBreakdownPoint` used instead)
- Remove `api.tags.update`, `api.tags.delete` and unused `TagUpdate` import (no hooks or callers)
- Remove dead `period` prop from `SparklineChart` and dead `symbol`/`period` props from `DeferredSparkline`, plus `sparklinePeriod` propagation through `AssetCard`
- Remove `decimal_places` settings UI (value was never consumed by `formatPrice()` or indicator display)

Closes #339

## Test plan
- [x] `pnpm lint` passes (0 errors, 1 pre-existing warning)
- [x] `pnpm build` passes (TypeScript + Vite)
- [ ] Verify sparkline charts still render in card view
- [ ] Verify settings page renders without decimal places dropdown
- [ ] Verify tag creation still works (only `update`/`delete` removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)