### PR TITLE
fix: extract shared indicator computation and fix empty prices guard

### DIFF
--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -108,8 +108,6 @@ async def compute_and_cache_indicators(
         snapshot = build_indicator_snapshot(compute_indicators(df))
         out[symbol] = snapshot
 
-    # Store in cache (single-entry — only latest key matters)
-    _indicator_cache.clear()
     _indicator_cache.set_value(cache_key, out)
 
     return out


### PR DESCRIPTION
## Summary
- **DRY refactor**: Extract `_compute_or_cached_indicators()` helper in `price_service.py` to eliminate duplicated cache-key construction, `_ensure_prices` + `_ensure_warmup_prices` flow, and `compute_indicators` + `_df_to_indicator_rows` pipeline between `get_indicators()` and `get_detail()`.
- **Empty prices guard**: Add a second `if not prices` check after re-fetch in `_ensure_prices()` to prevent `IndexError` on `prices[-1].date` when sync reports success but re-fetch returns empty. Also remove the now-unnecessary `if prices else None` fallback since `_ensure_prices` guarantees a non-empty list on success.
- **Group cache fix**: Remove `_indicator_cache.clear()` call in `compute/group.py` that was destroying concurrent group caches. TTL-based eviction handles staleness without wiping unrelated entries.

Closes #334

## Test plan
- [x] All 307 existing tests pass (`pytest -x -q`)
- [ ] Verify indicator cache hits still work correctly for both `get_indicators` and `get_detail` endpoints
- [ ] Verify group page loads with multiple groups don't interfere with each other's indicator caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)