### PR TITLE
fix: backend service cleanups — currency DRY, update_group null, validation

### DIFF
--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -36,7 +36,7 @@ async def get_group_detail(group_id: int, db: AsyncSession = Depends(get_db)):
 
 @router.put("/{group_id}", response_model=GroupResponse, summary="Update a group")
 async def update_group(group_id: int, data: GroupUpdate, db: AsyncSession = Depends(get_db)):
-    return await group_service.update_group(db, group_id, data.name, data.description, data.icon)
+    return await group_service.update_group(db, group_id, data.model_dump(exclude_unset=True))
 
 
 @router.delete("/{group_id}", status_code=204, summary="Delete a group")

--- a/backend/app/schemas/annotation.py
+++ b/backend/app/schemas/annotation.py
@@ -1,6 +1,9 @@
 import datetime
+import re
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 
 class AnnotationCreate(BaseModel):
@@ -8,6 +11,13 @@ class AnnotationCreate(BaseModel):
     title: str = Field(description="Short annotation title")
     body: str | None = Field(default=None, description="Optional extended body text (Markdown supported)")
     color: str = Field(default="#3b82f6", description="Marker colour as a hex code")
+
+    @field_validator("color")
+    @classmethod
+    def validate_hex_color(cls, v: str) -> str:
+        if not _HEX_COLOR_RE.match(v):
+            raise ValueError("color must be a valid hex code (e.g. '#3b82f6')")
+        return v
 
 
 class AnnotationResponse(BaseModel):

--- a/backend/app/schemas/tag.py
+++ b/backend/app/schemas/tag.py
@@ -1,18 +1,35 @@
 import datetime
+import re
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.schemas.asset import AssetResponse
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 
 class TagCreate(BaseModel):
     name: str = Field(description="Unique tag label (e.g. 'tech', 'dividend')")
     color: str = Field(default="#3b82f6", description="Hex colour code for the badge")
 
+    @field_validator("color")
+    @classmethod
+    def validate_hex_color(cls, v: str) -> str:
+        if not _HEX_COLOR_RE.match(v):
+            raise ValueError("color must be a valid hex code (e.g. '#3b82f6')")
+        return v
+
 
 class TagUpdate(BaseModel):
     name: str | None = Field(default=None, description="New tag label")
     color: str | None = Field(default=None, description="New hex colour code")
+
+    @field_validator("color")
+    @classmethod
+    def validate_hex_color(cls, v: str | None) -> str | None:
+        if v is not None and not _HEX_COLOR_RE.match(v):
+            raise ValueError("color must be a valid hex code (e.g. '#3b82f6')")
+        return v
 
 
 class TagResponse(BaseModel):

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -42,8 +42,8 @@ async def create_asset(
         if not name:
             raise HTTPException(404, f"Symbol {symbol} not found on Yahoo Finance")
         # Name was provided manually — proceed with exchange-suffix currency fallback
-        from app.services.yahoo import _currency_from_suffix
-        currency = _currency_from_suffix(symbol) or "USD"
+        from app.services.yahoo import currency_from_suffix
+        currency = currency_from_suffix(symbol) or "USD"
     else:
         # Store raw Yahoo currency code (e.g. "GBp") — the currencies table
         # provides display_code and divisor via lookup.

--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 import pandas as pd
 
-from app.services.yahoo import batch_fetch_currencies, batch_fetch_history
+from app.services.yahoo import _batch_fetch_history_sync, batch_fetch_currencies
 from app.utils import async_threadable
 
 
@@ -327,7 +327,7 @@ def compute_batch_indicator_snapshots(
     if not symbols:
         return []
 
-    histories = batch_fetch_history(symbols, period="3mo")
+    histories = _batch_fetch_history_sync(symbols, period="3mo")
     currencies = batch_fetch_currencies(symbols)
 
     results = []

--- a/backend/app/services/currency_service.py
+++ b/backend/app/services/currency_service.py
@@ -59,5 +59,9 @@ async def ensure_currency(db: AsyncSession, raw_code: str) -> None:
     currency = Currency(code=raw_code, display_code=raw_code, divisor=1)
     db.add(currency)
     await db.flush()
+    # Cache is updated eagerly (before the caller commits). This is safe because
+    # the caller is responsible for committing the transaction — if it rolls back,
+    # the stale cache entry merely maps to (raw_code, 1) which is the same
+    # fallback that lookup() would return for an unknown code anyway.
     _cache[raw_code] = (raw_code, 1)
     logger.info("Auto-registered unknown currency: %s", raw_code)

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -1,6 +1,5 @@
 """Sync price data from Yahoo Finance to the database."""
 
-import asyncio
 from datetime import date
 
 import pandas as pd
@@ -35,7 +34,7 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
 
     symbols = [a.symbol for a in assets]
     asset_map = {a.symbol: a.id for a in assets}
-    data = await asyncio.to_thread(batch_fetch_history, symbols, period=period)
+    data = await batch_fetch_history(symbols, period=period)
 
     counts = {}
     for sym, df in data.items():

--- a/backend/tests/integration/test_holdings.py
+++ b/backend/tests/integration/test_holdings.py
@@ -51,7 +51,7 @@ async def test_holdings_indicators_success(client):
 
     with (
         patch("app.services.holdings_service.fetch_etf_holdings", return_value=_MOCK_HOLDINGS),
-        patch("app.services.compute.indicators.batch_fetch_history", return_value=histories),
+        patch("app.services.compute.indicators._batch_fetch_history_sync", return_value=histories),
         patch("app.services.compute.indicators.batch_fetch_currencies", return_value={"AAPL": "USD", "MSFT": "USD"}),
     ):
         resp = await client.get("/api/assets/SPY/holdings/indicators")

--- a/backend/tests/services/test_yahoo_currency.py
+++ b/backend/tests/services/test_yahoo_currency.py
@@ -7,68 +7,68 @@ import pytest
 
 from app.services.yahoo import (
     EXCHANGE_CURRENCY_MAP,
-    _currency_from_suffix,
+    currency_from_suffix,
     _normalize_ohlcv_df,
 )
 
 
 class TestCurrencyFromSuffix:
-    """Tests for _currency_from_suffix exchange-suffix-to-currency mapping."""
+    """Tests for currency_from_suffix exchange-suffix-to-currency mapping."""
 
     def test_kospi_returns_krw(self):
-        assert _currency_from_suffix("006260.KS") == "KRW"
+        assert currency_from_suffix("006260.KS") == "KRW"
 
     def test_kosdaq_returns_krw(self):
-        assert _currency_from_suffix("035420.KQ") == "KRW"
+        assert currency_from_suffix("035420.KQ") == "KRW"
 
     def test_tokyo_returns_jpy(self):
-        assert _currency_from_suffix("7203.T") == "JPY"
+        assert currency_from_suffix("7203.T") == "JPY"
 
     def test_hong_kong_returns_hkd(self):
-        assert _currency_from_suffix("0700.HK") == "HKD"
+        assert currency_from_suffix("0700.HK") == "HKD"
 
     def test_xetra_returns_eur(self):
-        assert _currency_from_suffix("VWCE.DE") == "EUR"
+        assert currency_from_suffix("VWCE.DE") == "EUR"
 
     def test_london_returns_gbp(self):
-        assert _currency_from_suffix("HSBA.L") == "GBP"
+        assert currency_from_suffix("HSBA.L") == "GBP"
 
     def test_toronto_returns_cad(self):
-        assert _currency_from_suffix("RY.TO") == "CAD"
+        assert currency_from_suffix("RY.TO") == "CAD"
 
     def test_australia_returns_aud(self):
-        assert _currency_from_suffix("CBA.AX") == "AUD"
+        assert currency_from_suffix("CBA.AX") == "AUD"
 
     def test_india_nse_returns_inr(self):
-        assert _currency_from_suffix("RELIANCE.NS") == "INR"
+        assert currency_from_suffix("RELIANCE.NS") == "INR"
 
     def test_india_bse_returns_inr(self):
-        assert _currency_from_suffix("RELIANCE.BO") == "INR"
+        assert currency_from_suffix("RELIANCE.BO") == "INR"
 
     def test_shanghai_returns_cny(self):
-        assert _currency_from_suffix("600519.SS") == "CNY"
+        assert currency_from_suffix("600519.SS") == "CNY"
 
     def test_swiss_returns_chf(self):
-        assert _currency_from_suffix("NESN.SW") == "CHF"
+        assert currency_from_suffix("NESN.SW") == "CHF"
 
     def test_copenhagen_returns_dkk(self):
-        assert _currency_from_suffix("NOVO-B.CO") == "DKK"
+        assert currency_from_suffix("NOVO-B.CO") == "DKK"
 
     def test_oslo_returns_nok(self):
-        assert _currency_from_suffix("EQNR.OL") == "NOK"
+        assert currency_from_suffix("EQNR.OL") == "NOK"
 
     def test_stockholm_returns_sek(self):
-        assert _currency_from_suffix("VOLV-B.ST") == "SEK"
+        assert currency_from_suffix("VOLV-B.ST") == "SEK"
 
     def test_no_suffix_returns_none(self):
-        assert _currency_from_suffix("AAPL") is None
+        assert currency_from_suffix("AAPL") is None
 
     def test_unknown_suffix_returns_none(self):
-        assert _currency_from_suffix("FOO.ZZ") is None
+        assert currency_from_suffix("FOO.ZZ") is None
 
     def test_case_insensitive_suffix(self):
         """Suffix lookup handles case variations (e.g. '.ks' vs '.KS')."""
-        assert _currency_from_suffix("006260.ks") == "KRW"
+        assert currency_from_suffix("006260.ks") == "KRW"
 
     def test_all_map_entries_are_iso_4217_length(self):
         """All currency codes in the exchange map are 3 characters (ISO 4217)."""


### PR DESCRIPTION
## Summary
- **Currency DRY**: Extract `resolve_currency()` helper in `yahoo.py` to eliminate the 5x repeated fallback chain (`raw → lookup → suffix → USD`). Rename `_currency_from_suffix` to public `currency_from_suffix`.
- **update_group null fix**: Rewrite `update_group()` to accept a `data` dict via `model_dump(exclude_unset=True)` so clients can explicitly clear optional fields (description, icon) to `null` — matching the existing `update_pseudo_etf` pattern.
- **Color validation**: Add `field_validator("color")` with hex pattern `^#[0-9a-fA-F]{6}$` to `AnnotationCreate`, `TagCreate`, and `TagUpdate` schemas.
- **@async_threadable consistency**: Add decorator to `batch_fetch_history` and update all callers (`price_sync.py` uses `await` directly, `indicators.py` calls the sync implementation).
- **Documentation**: Add comment in `ensure_currency()` explaining the cache-before-commit timing assumption.

Closes #337

## Test plan
- [x] All 308 existing backend tests pass
- [x] Updated `test_group_service.py` tests to use new `data` dict signature
- [x] Added new test `test_update_group_can_clear_optional_field` verifying null-clearing works
- [x] Updated `test_yahoo_currency.py` to use renamed `currency_from_suffix`
- [x] Updated `test_holdings.py` to patch `_batch_fetch_history_sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)