### PR TITLE
fix: frontend DRY — formatChangePct, indicatorsByTime, visibility checks

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -7,8 +7,8 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { DeferredSparkline } from "@/components/sparkline"
 import { TagBadge } from "@/components/tag-badge"
 import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary } from "@/lib/api"
-import { formatPrice, changeColor } from "@/lib/format"
-import { getCardDescriptors, type IndicatorDescriptor } from "@/lib/indicator-registry"
+import { formatPrice, changeColor, formatChangePct } from "@/lib/format"
+import { getCardDescriptors, isIndicatorVisible, type IndicatorDescriptor } from "@/lib/indicator-registry"
 import { IndicatorValue } from "@/components/indicator-value"
 import { usePriceFlash } from "@/lib/use-price-flash"
 
@@ -61,7 +61,7 @@ export function AssetCard({
   indicatorVisibility,
 }: AssetCardProps) {
   const enabledCards = CARD_DESCRIPTORS.filter(
-    (d) => indicatorVisibility[d.id] !== false,
+    (d) => isIndicatorVisible(indicatorVisibility, d.id),
   )
   const lastPrice = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
@@ -95,8 +95,7 @@ export function AssetCard({
             <p className="text-xs text-muted-foreground truncate">{name}</p>
             {changePct != null ? (
               <span ref={pctRef} className={`text-xs font-medium tabular-nums rounded px-1 -mx-1 ${changeCls}`}>
-                {changePct >= 0 ? "+" : ""}
-                {changePct.toFixed(2)}%
+                {formatChangePct(changePct).text}
               </span>
             ) : (
               <Skeleton className="h-3.5 w-12 rounded" />

--- a/frontend/src/components/chart/candlestick-chart.tsx
+++ b/frontend/src/components/chart/candlestick-chart.tsx
@@ -13,7 +13,7 @@ import {
 } from "./chart-builders"
 import { Legend } from "./chart-legends"
 import { useRegisterChart, useChartHoverValues, useChartData } from "./chart-sync-provider"
-import { getOverlayDescriptors } from "@/lib/indicator-registry"
+import { getOverlayDescriptors, isIndicatorVisible } from "@/lib/indicator-registry"
 
 interface CandlestickChartProps {
   annotations: Annotation[]
@@ -61,7 +61,7 @@ export function CandlestickChart({
   const { prices, indicators } = useChartData()
 
   const isVisible = useCallback(
-    (id: string) => indicatorVisibility?.[id] !== false,
+    (id: string) => isIndicatorVisible(indicatorVisibility, id),
     [indicatorVisibility],
   )
 

--- a/frontend/src/components/chart/chart-sync-provider.tsx
+++ b/frontend/src/components/chart/chart-sync-provider.tsx
@@ -12,6 +12,7 @@ import type { IChartApi } from "lightweight-charts"
 import type { Price, Indicator } from "@/lib/api"
 import type { LegendValues } from "./chart-legends"
 import { getAllIndicatorFields } from "@/lib/indicator-registry"
+import { buildIndicatorTimeMap } from "@/lib/chart-utils"
 import { useCrosshairTimeSync } from "./crosshair-time-sync"
 
 // ---------------------------------------------------------------------------
@@ -76,21 +77,12 @@ export function ChartSyncProvider({ prices, indicators, children }: ChartSyncPro
   useEffect(() => {
     closeByTime.current.clear()
     ohlcByTime.current.clear()
-    indicatorsByTime.current.clear()
 
     for (const p of prices) {
       closeByTime.current.set(p.date, p.close)
       ohlcByTime.current.set(p.date, { o: p.open, h: p.high, l: p.low, c: p.close })
     }
-    for (const i of indicators) {
-      const vals: Record<string, number> = {}
-      for (const [field, value] of Object.entries(i.values)) {
-        if (value != null && typeof value === "number") {
-          vals[field] = value
-        }
-      }
-      indicatorsByTime.current.set(i.date, vals)
-    }
+    indicatorsByTime.current = buildIndicatorTimeMap(indicators)
   }, [prices, indicators])
 
   const getValuesForTime = useCallback((key: string): LegendValues => {

--- a/frontend/src/components/chart/indicator-cards.tsx
+++ b/frontend/src/components/chart/indicator-cards.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { type IndicatorDescriptor } from "@/lib/indicator-registry"
+import { buildIndicatorTimeMap } from "@/lib/chart-utils"
 import { IndicatorValue } from "@/components/indicator-value"
 import { useChartHoverValues, useChartData } from "./chart-sync-provider"
 import { createSubChart, setSubChartData, type SubChartState } from "./chart-builders"
@@ -46,14 +47,7 @@ function ModalChart({
   // Build a time → indicator values lookup from the indicators array
   const indicatorsByTime = useRef(new Map<string, Record<string, number>>())
   useEffect(() => {
-    indicatorsByTime.current.clear()
-    for (const i of indicators) {
-      const vals: Record<string, number> = {}
-      for (const [field, value] of Object.entries(i.values)) {
-        if (value != null && typeof value === "number") vals[field] = value
-      }
-      indicatorsByTime.current.set(i.date, vals)
-    }
+    indicatorsByTime.current = buildIndicatorTimeMap(indicators)
   }, [indicators])
 
   useEffect(() => {

--- a/frontend/src/components/expanded-asset-chart.tsx
+++ b/frontend/src/components/expanded-asset-chart.tsx
@@ -4,7 +4,7 @@ import { CandlestickChart } from "@/components/chart/candlestick-chart"
 import { RsiChart } from "@/components/chart/rsi-chart"
 import { MacdChart } from "@/components/chart/macd-chart"
 import { IndicatorCards } from "@/components/chart/indicator-cards"
-import { getCardDescriptors } from "@/lib/indicator-registry"
+import { getCardDescriptors, isIndicatorVisible } from "@/lib/indicator-registry"
 import { useAssetDetail, useAnnotations } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
 
@@ -37,7 +37,7 @@ export function ExpandedAssetChart({ symbol, currency, compact = false }: Expand
 
   const cardDescs = compact ? CARD_DESCRIPTORS_ALL : CARD_DESCRIPTORS_EXCLUSIVE
   const enabledCards = cardDescs.filter(
-    (d) => settings.detail_indicator_visibility[d.id] !== false,
+    (d) => isIndicatorVisible(settings.detail_indicator_visibility, d.id),
   )
 
   if (isLoading || !prices?.length) {

--- a/frontend/src/components/group-table.tsx
+++ b/frontend/src/components/group-table.tsx
@@ -19,7 +19,7 @@ import {
 import { ArrowUp, ArrowDown } from "lucide-react"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
 import type { GroupSortBy, SortDir } from "@/lib/settings"
-import { formatPrice, changeColor } from "@/lib/format"
+import { formatPrice, changeColor, formatChangePct } from "@/lib/format"
 import {
   getNumericValue,
   extractMacdValues,
@@ -27,7 +27,9 @@ import {
   getSeriesByField,
   resolveThresholdColor,
   resolveAdxColor,
+  isIndicatorVisible,
 } from "@/lib/indicator-registry"
+import { toggleSetItem } from "@/lib/utils"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useSettings } from "@/lib/settings"
 
@@ -42,7 +44,7 @@ const BASE_COLUMN_DEFS: { key: string; label: string }[] = [
 
 /** Check whether a column is visible. Missing key = visible (opt-out model). */
 function isColumnVisible(columnSettings: Record<string, boolean>, key: string): boolean {
-  return columnSettings[key] !== false
+  return isIndicatorVisible(columnSettings, key)
 }
 
 interface GroupTableProps {
@@ -63,12 +65,7 @@ export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, 
   const columnSettings = settings.group_table_columns
 
   const toggleExpand = (symbol: string) => {
-    setExpandedSymbols((prev) => {
-      const next = new Set(prev)
-      if (next.has(symbol)) next.delete(symbol)
-      else next.add(symbol)
-      return next
-    })
+    setExpandedSymbols((prev) => toggleSetItem(prev, symbol))
   }
 
   const toggleColumn = (key: string) => {
@@ -373,8 +370,7 @@ function TableRow({
           <td className={`${py} px-3 text-right tabular-nums`}>
             {displayPct != null ? (
               <span ref={pctRef} className={`font-medium rounded px-1 -mx-1 ${changeCls} ${staleClass}`}>
-                {displayPct >= 0 ? "+" : ""}
-                {displayPct.toFixed(2)}%
+                {formatChangePct(displayPct).text}
               </span>
             ) : (
               <Skeleton className="h-4 w-12 ml-auto rounded" />

--- a/frontend/src/components/holdings-grid.tsx
+++ b/frontend/src/components/holdings-grid.tsx
@@ -6,6 +6,7 @@ import { IndicatorCell } from "@/components/indicator-cell"
 import { ExpandedAssetChart } from "@/components/expanded-asset-chart"
 import { formatPrice, formatChangePct } from "@/lib/format"
 import { getNumericValue, getStringValue, getHoldingSummaryDescriptors } from "@/lib/indicator-registry"
+import { toggleSetItem } from "@/lib/utils"
 
 export interface IndicatorData {
   currency: string
@@ -36,12 +37,7 @@ export function HoldingsGrid({ rows, indicatorMap, indicatorsLoading, onRemove, 
   const hasRemove = !!onRemove
 
   const toggleExpand = (key: string | number) => {
-    setExpandedKeys((prev) => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
+    setExpandedKeys((prev) => toggleSetItem(prev, key))
   }
 
   // base columns: chevron + symbol + name + % + price + chg% + indicator summary columns + optional remove

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -4,7 +4,7 @@ import { ChartSyncProvider } from "./chart/chart-sync-provider"
 import { CandlestickChart } from "./chart/candlestick-chart"
 import { SubChart } from "./chart/sub-chart"
 import { IndicatorCards } from "./chart/indicator-cards"
-import { getSubChartDescriptors, getCardDescriptors } from "@/lib/indicator-registry"
+import { getSubChartDescriptors, getCardDescriptors, isIndicatorVisible } from "@/lib/indicator-registry"
 
 const SUB_CHART_DESCRIPTORS = getSubChartDescriptors()
 const CARD_DESCRIPTORS = getCardDescriptors(true)
@@ -31,7 +31,7 @@ export function PriceChart({
   currency,
 }: PriceChartProps) {
   const isVisible = useCallback(
-    (id: string) => indicatorVisibility?.[id] !== false,
+    (id: string) => isIndicatorVisible(indicatorVisibility, id),
     [indicatorVisibility],
   )
 

--- a/frontend/src/lib/chart-utils.ts
+++ b/frontend/src/lib/chart-utils.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react"
 import { ColorType } from "lightweight-charts"
+import type { Indicator } from "@/lib/api"
 
 export const STACK_COLORS = [
   "#6366f1", // indigo-500
@@ -69,16 +70,11 @@ export function baseChartOptions(container: HTMLElement, height: number) {
   return {
     width: container.clientWidth,
     height,
+    ...chartThemeOptions(theme),
     layout: {
-      background: { type: ColorType.Solid, color: theme.bg },
-      textColor: theme.text,
+      ...chartThemeOptions(theme).layout,
       attributionLogo: false,
     },
-    grid: {
-      vertLines: { color: theme.grid },
-      horzLines: { color: theme.grid },
-    },
-    rightPriceScale: { borderColor: theme.border },
     timeScale: { borderColor: theme.border, timeVisible: false },
     crosshair: { mode: 0 as const },
     handleScroll: {
@@ -94,4 +90,19 @@ export function baseChartOptions(container: HTMLElement, height: number) {
       axisDoubleClickReset: { time: true, price: false },
     },
   }
+}
+
+/** Build a Map from date string to numeric indicator values, filtering out nulls/non-numbers. */
+export function buildIndicatorTimeMap(indicators: Indicator[]): Map<string, Record<string, number>> {
+  const map = new Map<string, Record<string, number>>()
+  for (const i of indicators) {
+    const vals: Record<string, number> = {}
+    for (const [field, value] of Object.entries(i.values)) {
+      if (value != null && typeof value === "number") {
+        vals[field] = value
+      }
+    }
+    map.set(i.date, vals)
+  }
+  return map
 }

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -250,6 +250,14 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Check whether an indicator is visible in a visibility map (opt-out model: missing = visible). */
+export function isIndicatorVisible(
+  visibilityMap: Record<string, boolean> | undefined,
+  key: string,
+): boolean {
+  return visibilityMap?.[key] !== false
+}
+
 /** Resolve the first matching threshold color class for a value. */
 export function resolveThresholdColor(
   thresholds: ThresholdColor[] | undefined,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Immutable Set toggle: returns a new Set with the item added or removed. */
+export function toggleSetItem<T>(set: Set<T>, item: T): Set<T> {
+  const next = new Set(set)
+  if (next.has(item)) next.delete(item)
+  else next.add(item)
+  return next
+}

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -11,7 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useSettings, type AppSettings, type GroupViewMode } from "@/lib/settings"
-import { INDICATOR_REGISTRY } from "@/lib/indicator-registry"
+import { INDICATOR_REGISTRY, isIndicatorVisible } from "@/lib/indicator-registry"
 
 function VisibilityToggle({
   id,
@@ -86,7 +86,7 @@ export function SettingsPage() {
               key={`grp-${desc.id}`}
               id={`grp-${desc.id}`}
               label={desc.label}
-              checked={draft.group_indicator_visibility[desc.id] !== false}
+              checked={isIndicatorVisible(draft.group_indicator_visibility, desc.id)}
               onCheckedChange={(v) =>
                 change({
                   group_indicator_visibility: { ...draft.group_indicator_visibility, [desc.id]: v },
@@ -107,7 +107,7 @@ export function SettingsPage() {
               key={`dtl-${desc.id}`}
               id={`dtl-${desc.id}`}
               label={desc.label}
-              checked={draft.detail_indicator_visibility[desc.id] !== false}
+              checked={isIndicatorVisible(draft.detail_indicator_visibility, desc.id)}
               onCheckedChange={(v) =>
                 change({
                   detail_indicator_visibility: { ...draft.detail_indicator_visibility, [desc.id]: v },


### PR DESCRIPTION
## Summary
- Replace inline change-pct formatting in `group-table.tsx` and `asset-card.tsx` with existing `formatChangePct()` from `lib/format.ts`
- Extract `buildIndicatorTimeMap()` utility into `lib/chart-utils.ts`, replacing duplicated Map-building loops in `chart-sync-provider.tsx` and `indicator-cards.tsx`
- Extract `toggleSetItem<T>()` generic utility into `lib/utils.ts`, replacing duplicated Set-toggle pattern in `group-table.tsx` and `holdings-grid.tsx`
- Extract `isIndicatorVisible()` into `lib/indicator-registry.ts`, replacing 7+ scattered `!== false` visibility checks across `price-chart.tsx`, `candlestick-chart.tsx`, `group-table.tsx`, `expanded-asset-chart.tsx`, `asset-card.tsx`, and `settings.tsx`
- Compose `baseChartOptions()` from `chartThemeOptions()` in `lib/chart-utils.ts` instead of duplicating theme properties

## Test plan
- [ ] Verify lint passes (`pnpm lint` — zero errors, one pre-existing warning)
- [ ] Verify build passes (`pnpm build` — TypeScript + Vite)
- [ ] Verify group table renders correctly with change-pct formatting
- [ ] Verify asset cards render correctly with change-pct formatting
- [ ] Verify chart crosshair sync still works (indicator time map)
- [ ] Verify expand/collapse toggles work in group table and holdings grid
- [ ] Verify indicator visibility toggles work in settings page
- [ ] Verify chart themes apply correctly (dark/light mode)

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)