### PR TITLE
Split pseudo-etf-charts.tsx into chart/pseudo-etf/ folder

### DIFF
--- a/frontend/src/components/chart/pseudo-etf/daily-contribution-chart.tsx
+++ b/frontend/src/components/chart/pseudo-etf/daily-contribution-chart.tsx
@@ -1,0 +1,156 @@
+import { useState, useEffect, useRef, useMemo } from "react"
+import {
+  createChart,
+  type IChartApi,
+  HistogramSeries,
+} from "lightweight-charts"
+import { baseChartOptions, STACK_COLORS } from "@/lib/chart-utils"
+import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
+import type { PerformanceBreakdownPoint } from "@/lib/api"
+import { SymbolLegend } from "./symbol-legend"
+
+interface SharedChartProps {
+  data: PerformanceBreakdownPoint[]
+  sortedSymbols: string[]
+  symbolColorMap: Map<string, string>
+}
+
+export function DailyContributionChart({ data, sortedSymbols, symbolColorMap }: SharedChartProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const [hoverData, setHoverData] = useState<{ date: string; deltas: Record<string, number>; total: number } | null>(null)
+  const { startLifecycle } = useChartLifecycle(ref, [chartRef])
+
+  const deltasByTime = useRef(new Map<string, Record<string, number>>())
+
+  useEffect(() => {
+    if (!ref.current || data.length < 2 || !sortedSymbols.length) return
+
+    deltasByTime.current.clear()
+
+    // Compute daily deltas per symbol
+    const dailyData: { date: string; deltas: Record<string, number> }[] = []
+    for (let d = 1; d < data.length; d++) {
+      const deltas: Record<string, number> = {}
+      for (const sym of sortedSymbols) {
+        deltas[sym] = (data[d].breakdown[sym] ?? 0) - (data[d - 1].breakdown[sym] ?? 0)
+      }
+      dailyData.push({ date: data[d].date, deltas })
+      deltasByTime.current.set(data[d].date, deltas)
+    }
+
+    // Compute positive and negative cumulative stacks per day
+    const posCum: number[][] = []
+    const negCum: number[][] = []
+    for (const { deltas } of dailyData) {
+      const pos: number[] = []
+      const neg: number[] = []
+      let posSum = 0
+      let negSum = 0
+      for (const sym of sortedSymbols) {
+        const delta = deltas[sym]
+        if (delta > 0) posSum += delta
+        if (delta < 0) negSum += delta
+        pos.push(posSum)
+        neg.push(negSum)
+      }
+      posCum.push(pos)
+      negCum.push(neg)
+    }
+
+    const chart = createChart(ref.current, baseChartOptions(ref.current, 250))
+
+    // Draw positive stack: outermost first (i = N-1 -> 0)
+    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
+      const sym = sortedSymbols[i]
+      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
+      const series = chart.addSeries(HistogramSeries, {
+        color,
+        priceLineVisible: false,
+        base: 0,
+      })
+      series.setData(
+        dailyData.map((d, dayIdx) => ({
+          time: d.date,
+          value: posCum[dayIdx][i],
+        }))
+      )
+    }
+
+    // Draw negative stack: outermost first (i = N-1 -> 0)
+    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
+      const sym = sortedSymbols[i]
+      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
+      const series = chart.addSeries(HistogramSeries, {
+        color,
+        priceLineVisible: false,
+        base: 0,
+      })
+      series.setData(
+        dailyData.map((d, dayIdx) => ({
+          time: d.date,
+          value: negCum[dayIdx][i],
+        }))
+      )
+    }
+
+    // Crosshair
+    chart.subscribeCrosshairMove((param) => {
+      if (param.time) {
+        const key = String(param.time)
+        const deltas = deltasByTime.current.get(key)
+        if (deltas) {
+          const total = Object.values(deltas).reduce((s, v) => s + v, 0)
+          setHoverData({ date: key, deltas, total })
+        }
+      } else {
+        setHoverData(null)
+      }
+    })
+
+    chart.timeScale().fitContent()
+    chartRef.current = chart
+
+    return startLifecycle([chart])
+  }, [data, sortedSymbols, symbolColorMap, startLifecycle])
+
+  // Default to latest day
+  const latestDeltas = useMemo(() => {
+    if (data.length < 2 || !sortedSymbols.length) return null
+    const last = data[data.length - 1]
+    const prev = data[data.length - 2]
+    const deltas: Record<string, number> = {}
+    for (const sym of sortedSymbols) {
+      deltas[sym] = (last.breakdown[sym] ?? 0) - (prev.breakdown[sym] ?? 0)
+    }
+    const total = Object.values(deltas).reduce((s, v) => s + v, 0)
+    return { date: last.date, deltas, total }
+  }, [data, sortedSymbols])
+  const displayData = hoverData ?? latestDeltas
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold px-1">Daily Contribution</h3>
+      <div ref={ref} className="w-full rounded-md overflow-hidden" />
+      <SymbolLegend
+        sortedSymbols={sortedSymbols}
+        symbolColorMap={symbolColorMap}
+        values={displayData ? sortedSymbols.map((sym) => {
+          const v = displayData.deltas[sym]
+          return v !== undefined ? `${v >= 0 ? "+" : ""}${v.toFixed(2)}` : undefined
+        }) : undefined}
+        valueColors={displayData ? sortedSymbols.map((sym) => {
+          const v = displayData.deltas[sym]
+          return v !== undefined ? (v >= 0 ? "text-emerald-500" : "text-red-500") : undefined
+        }) : undefined}
+        suffix={displayData ? (
+          <span className="text-xs font-medium ml-auto">
+            Net: <span className={displayData.total >= 0 ? "text-emerald-500" : "text-red-500"}>
+              {displayData.total >= 0 ? "+" : ""}{displayData.total.toFixed(2)}
+            </span>
+          </span>
+        ) : undefined}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/chart/pseudo-etf/index.ts
+++ b/frontend/src/components/chart/pseudo-etf/index.ts
@@ -1,0 +1,2 @@
+export { PerformanceOverlayChart } from "./performance-overlay-chart"
+export { DailyContributionChart } from "./daily-contribution-chart"

--- a/frontend/src/components/chart/pseudo-etf/performance-overlay-chart.tsx
+++ b/frontend/src/components/chart/pseudo-etf/performance-overlay-chart.tsx
@@ -1,14 +1,13 @@
 import { useState, useEffect, useRef, useMemo } from "react"
-import { Link } from "react-router-dom"
 import {
   createChart,
   type IChartApi,
   LineSeries,
-  HistogramSeries,
 } from "lightweight-charts"
 import { baseChartOptions, STACK_COLORS } from "@/lib/chart-utils"
 import { useChartLifecycle } from "@/hooks/use-chart-lifecycle"
 import type { PerformanceBreakdownPoint } from "@/lib/api"
+import { SymbolLegend } from "./symbol-legend"
 
 interface SharedChartProps {
   data: PerformanceBreakdownPoint[]
@@ -173,182 +172,6 @@ export function PerformanceOverlayChart({
         values={displayData ? sortedSymbols.map((sym) => displayData.rebased[sym]?.toFixed(2)) : undefined}
         suffix={displayData ? <span className="text-xs font-medium ml-auto">Index: {displayData.total.toFixed(2)}</span> : undefined}
       />
-    </div>
-  )
-}
-
-export function DailyContributionChart({ data, sortedSymbols, symbolColorMap }: SharedChartProps) {
-  const ref = useRef<HTMLDivElement>(null)
-  const chartRef = useRef<IChartApi | null>(null)
-  const [hoverData, setHoverData] = useState<{ date: string; deltas: Record<string, number>; total: number } | null>(null)
-  const { startLifecycle } = useChartLifecycle(ref, [chartRef])
-
-  const deltasByTime = useRef(new Map<string, Record<string, number>>())
-
-  useEffect(() => {
-    if (!ref.current || data.length < 2 || !sortedSymbols.length) return
-
-    deltasByTime.current.clear()
-
-    // Compute daily deltas per symbol
-    const dailyData: { date: string; deltas: Record<string, number> }[] = []
-    for (let d = 1; d < data.length; d++) {
-      const deltas: Record<string, number> = {}
-      for (const sym of sortedSymbols) {
-        deltas[sym] = (data[d].breakdown[sym] ?? 0) - (data[d - 1].breakdown[sym] ?? 0)
-      }
-      dailyData.push({ date: data[d].date, deltas })
-      deltasByTime.current.set(data[d].date, deltas)
-    }
-
-    // Compute positive and negative cumulative stacks per day
-    const posCum: number[][] = []
-    const negCum: number[][] = []
-    for (const { deltas } of dailyData) {
-      const pos: number[] = []
-      const neg: number[] = []
-      let posSum = 0
-      let negSum = 0
-      for (const sym of sortedSymbols) {
-        const delta = deltas[sym]
-        if (delta > 0) posSum += delta
-        if (delta < 0) negSum += delta
-        pos.push(posSum)
-        neg.push(negSum)
-      }
-      posCum.push(pos)
-      negCum.push(neg)
-    }
-
-    const chart = createChart(ref.current, baseChartOptions(ref.current, 250))
-
-    // Draw positive stack: outermost first (i = N-1 -> 0)
-    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
-      const sym = sortedSymbols[i]
-      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
-      const series = chart.addSeries(HistogramSeries, {
-        color,
-        priceLineVisible: false,
-        base: 0,
-      })
-      series.setData(
-        dailyData.map((d, dayIdx) => ({
-          time: d.date,
-          value: posCum[dayIdx][i],
-        }))
-      )
-    }
-
-    // Draw negative stack: outermost first (i = N-1 -> 0)
-    for (let i = sortedSymbols.length - 1; i >= 0; i--) {
-      const sym = sortedSymbols[i]
-      const color = symbolColorMap.get(sym) ?? STACK_COLORS[0]
-      const series = chart.addSeries(HistogramSeries, {
-        color,
-        priceLineVisible: false,
-        base: 0,
-      })
-      series.setData(
-        dailyData.map((d, dayIdx) => ({
-          time: d.date,
-          value: negCum[dayIdx][i],
-        }))
-      )
-    }
-
-    // Crosshair
-    chart.subscribeCrosshairMove((param) => {
-      if (param.time) {
-        const key = String(param.time)
-        const deltas = deltasByTime.current.get(key)
-        if (deltas) {
-          const total = Object.values(deltas).reduce((s, v) => s + v, 0)
-          setHoverData({ date: key, deltas, total })
-        }
-      } else {
-        setHoverData(null)
-      }
-    })
-
-    chart.timeScale().fitContent()
-    chartRef.current = chart
-
-    return startLifecycle([chart])
-  }, [data, sortedSymbols, symbolColorMap, startLifecycle])
-
-  // Default to latest day
-  const latestDeltas = useMemo(() => {
-    if (data.length < 2 || !sortedSymbols.length) return null
-    const last = data[data.length - 1]
-    const prev = data[data.length - 2]
-    const deltas: Record<string, number> = {}
-    for (const sym of sortedSymbols) {
-      deltas[sym] = (last.breakdown[sym] ?? 0) - (prev.breakdown[sym] ?? 0)
-    }
-    const total = Object.values(deltas).reduce((s, v) => s + v, 0)
-    return { date: last.date, deltas, total }
-  }, [data, sortedSymbols])
-  const displayData = hoverData ?? latestDeltas
-
-  return (
-    <div className="space-y-2">
-      <h3 className="text-sm font-semibold px-1">Daily Contribution</h3>
-      <div ref={ref} className="w-full rounded-md overflow-hidden" />
-      <SymbolLegend
-        sortedSymbols={sortedSymbols}
-        symbolColorMap={symbolColorMap}
-        values={displayData ? sortedSymbols.map((sym) => {
-          const v = displayData.deltas[sym]
-          return v !== undefined ? `${v >= 0 ? "+" : ""}${v.toFixed(2)}` : undefined
-        }) : undefined}
-        valueColors={displayData ? sortedSymbols.map((sym) => {
-          const v = displayData.deltas[sym]
-          return v !== undefined ? (v >= 0 ? "text-emerald-500" : "text-red-500") : undefined
-        }) : undefined}
-        suffix={displayData ? (
-          <span className="text-xs font-medium ml-auto">
-            Net: <span className={displayData.total >= 0 ? "text-emerald-500" : "text-red-500"}>
-              {displayData.total >= 0 ? "+" : ""}{displayData.total.toFixed(2)}
-            </span>
-          </span>
-        ) : undefined}
-      />
-    </div>
-  )
-}
-
-function SymbolLegend({
-  sortedSymbols,
-  symbolColorMap,
-  values,
-  valueColors,
-  suffix,
-}: {
-  sortedSymbols: string[]
-  symbolColorMap: Map<string, string>
-  values?: (string | undefined)[]
-  valueColors?: (string | undefined)[]
-  suffix?: React.ReactNode
-}) {
-  return (
-    <div className="flex flex-wrap gap-x-4 gap-y-1 px-1 items-center">
-      {sortedSymbols.map((sym, idx) => (
-        <div key={sym} className="flex items-center gap-1.5 text-xs">
-          <div
-            className="w-3 h-3 rounded-sm flex-shrink-0"
-            style={{ backgroundColor: symbolColorMap.get(sym) }}
-          />
-          <Link to={`/asset/${sym}`} className="hover:underline text-muted-foreground hover:text-foreground">
-            {sym}
-          </Link>
-          {values?.[idx] !== undefined && (
-            <span className={`font-mono ${valueColors?.[idx] ?? "text-muted-foreground"}`}>
-              {values[idx]}
-            </span>
-          )}
-        </div>
-      ))}
-      {suffix}
     </div>
   )
 }

--- a/frontend/src/components/chart/pseudo-etf/symbol-legend.tsx
+++ b/frontend/src/components/chart/pseudo-etf/symbol-legend.tsx
@@ -1,0 +1,37 @@
+import { Link } from "react-router-dom"
+
+export function SymbolLegend({
+  sortedSymbols,
+  symbolColorMap,
+  values,
+  valueColors,
+  suffix,
+}: {
+  sortedSymbols: string[]
+  symbolColorMap: Map<string, string>
+  values?: (string | undefined)[]
+  valueColors?: (string | undefined)[]
+  suffix?: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 px-1 items-center">
+      {sortedSymbols.map((sym, idx) => (
+        <div key={sym} className="flex items-center gap-1.5 text-xs">
+          <div
+            className="w-3 h-3 rounded-sm flex-shrink-0"
+            style={{ backgroundColor: symbolColorMap.get(sym) }}
+          />
+          <Link to={`/asset/${sym}`} className="hover:underline text-muted-foreground hover:text-foreground">
+            {sym}
+          </Link>
+          {values?.[idx] !== undefined && (
+            <span className={`font-mono ${valueColors?.[idx] ?? "text-muted-foreground"}`}>
+              {values[idx]}
+            </span>
+          )}
+        </div>
+      ))}
+      {suffix}
+    </div>
+  )
+}

--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -11,7 +11,7 @@ import { CrosshairTimeSyncProvider } from "@/components/chart/crosshair-time-syn
 import {
   PerformanceOverlayChart,
   DailyContributionChart,
-} from "@/components/chart/pseudo-etf-charts"
+} from "@/components/chart/pseudo-etf"
 import { STACK_COLORS } from "@/lib/chart-utils"
 import { formatChangePct } from "@/lib/format"
 import { useSettings } from "@/lib/settings"


### PR DESCRIPTION
## Summary
- Split 354-line `pseudo-etf-charts.tsx` into 3 focused files in `chart/pseudo-etf/` folder
- `PerformanceOverlayChart` (155 lines), `DailyContributionChart` (138 lines), and `SymbolLegend` (34 lines)
- Updated import in `pseudo-etf-detail.tsx`
- No behavioral changes

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [ ] Pseudo-ETF detail page charts render correctly

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)