### PR TITLE
refactor: deduplicate annotation/thesis wrapper components

### DIFF
--- a/frontend/src/components/connected-annotations.tsx
+++ b/frontend/src/components/connected-annotations.tsx
@@ -1,0 +1,24 @@
+import { AnnotationsList } from "@/components/annotations-list"
+import type { Annotation, AnnotationCreate } from "@/lib/api"
+import type { UseMutationResult } from "@tanstack/react-query"
+
+interface ConnectedAnnotationsProps {
+  annotations: Annotation[] | undefined
+  createMutation: UseMutationResult<Annotation, Error, AnnotationCreate>
+  deleteMutation: UseMutationResult<void, Error, number>
+}
+
+export function ConnectedAnnotations({
+  annotations,
+  createMutation,
+  deleteMutation,
+}: ConnectedAnnotationsProps) {
+  return (
+    <AnnotationsList
+      annotations={annotations}
+      onCreate={(data) => createMutation.mutate(data)}
+      onDelete={(id) => deleteMutation.mutate(id)}
+      isCreating={createMutation.isPending}
+    />
+  )
+}

--- a/frontend/src/components/connected-thesis.tsx
+++ b/frontend/src/components/connected-thesis.tsx
@@ -1,0 +1,18 @@
+import { ThesisEditor } from "@/components/thesis-editor"
+import type { Thesis } from "@/lib/api"
+import type { UseMutationResult } from "@tanstack/react-query"
+
+interface ConnectedThesisProps {
+  thesis: Thesis | undefined
+  updateMutation: UseMutationResult<Thesis, Error, string>
+}
+
+export function ConnectedThesis({ thesis, updateMutation }: ConnectedThesisProps) {
+  return (
+    <ThesisEditor
+      thesis={thesis}
+      onSave={(content) => updateMutation.mutate(content)}
+      isSaving={updateMutation.isPending}
+    />
+  )
+}

--- a/frontend/src/pages/asset-detail.tsx
+++ b/frontend/src/pages/asset-detail.tsx
@@ -6,8 +6,8 @@ import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { PriceChart } from "@/components/price-chart"
 import { ChartSkeleton } from "@/components/chart-skeleton"
-import { ThesisEditor } from "@/components/thesis-editor"
-import { AnnotationsList } from "@/components/annotations-list"
+import { ConnectedThesis } from "@/components/connected-thesis"
+import { ConnectedAnnotations } from "@/components/connected-annotations"
 import { TagInput } from "@/components/tag-input"
 import { PeriodSelector } from "@/components/period-selector"
 import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
@@ -292,28 +292,21 @@ function TopHoldingsCard({
 
 function AssetAnnotations({ symbol }: { symbol: string }) {
   const { data: annotations } = useAnnotations(symbol)
-  const createAnnotation = useCreateAnnotation(symbol)
-  const deleteAnnotation = useDeleteAnnotation(symbol)
-
   return (
-    <AnnotationsList
+    <ConnectedAnnotations
       annotations={annotations}
-      onCreate={(data) => createAnnotation.mutate(data)}
-      onDelete={(id) => deleteAnnotation.mutate(id)}
-      isCreating={createAnnotation.isPending}
+      createMutation={useCreateAnnotation(symbol)}
+      deleteMutation={useDeleteAnnotation(symbol)}
     />
   )
 }
 
 function AssetThesis({ symbol }: { symbol: string }) {
   const { data: thesis } = useThesis(symbol)
-  const updateThesis = useUpdateThesis(symbol)
-
   return (
-    <ThesisEditor
+    <ConnectedThesis
       thesis={thesis}
-      onSave={(content) => updateThesis.mutate(content)}
-      isSaving={updateThesis.isPending}
+      updateMutation={useUpdateThesis(symbol)}
     />
   )
 }

--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -3,8 +3,8 @@ import { useParams, Link } from "react-router-dom"
 import { ArrowLeft, UserPlus, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { ThesisEditor } from "@/components/thesis-editor"
-import { AnnotationsList } from "@/components/annotations-list"
+import { ConnectedThesis } from "@/components/connected-thesis"
+import { ConnectedAnnotations } from "@/components/connected-annotations"
 import { HoldingsGrid, type HoldingsGridRow } from "@/components/holdings-grid"
 import { AddConstituentPicker } from "@/components/add-constituent-picker"
 import { CrosshairTimeSyncProvider } from "@/components/chart/crosshair-time-sync"
@@ -107,28 +107,21 @@ export function PseudoEtfDetailPage() {
 
 function EtfAnnotations({ etfId }: { etfId: number }) {
   const { data: annotations } = usePseudoEtfAnnotations(etfId)
-  const createAnnotation = useCreatePseudoEtfAnnotation(etfId)
-  const deleteAnnotation = useDeletePseudoEtfAnnotation(etfId)
-
   return (
-    <AnnotationsList
+    <ConnectedAnnotations
       annotations={annotations}
-      onCreate={(data) => createAnnotation.mutate(data)}
-      onDelete={(id) => deleteAnnotation.mutate(id)}
-      isCreating={createAnnotation.isPending}
+      createMutation={useCreatePseudoEtfAnnotation(etfId)}
+      deleteMutation={useDeletePseudoEtfAnnotation(etfId)}
     />
   )
 }
 
 function EtfThesis({ etfId }: { etfId: number }) {
   const { data: thesis } = usePseudoEtfThesis(etfId)
-  const updateThesis = useUpdatePseudoEtfThesis(etfId)
-
   return (
-    <ThesisEditor
+    <ConnectedThesis
       thesis={thesis}
-      onSave={(content) => updateThesis.mutate(content)}
-      isSaving={updateThesis.isPending}
+      updateMutation={useUpdatePseudoEtfThesis(etfId)}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Extracted the repeated hook-to-prop wiring from `AssetAnnotations`/`EtfAnnotations` and `AssetThesis`/`EtfThesis` into two shared components: `ConnectedAnnotations` and `ConnectedThesis`
- Each page's thin wrapper now calls its domain-specific hooks and passes the mutation results to the shared component, which handles the uniform prop mapping to `AnnotationsList` / `ThesisEditor`
- The pattern centralizes the `.mutate()` and `.isPending` wiring in one place instead of duplicating it across both detail pages

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify annotations CRUD works on asset detail page
- [ ] Verify annotations CRUD works on pseudo-ETF detail page
- [ ] Verify thesis edit/save works on asset detail page
- [ ] Verify thesis edit/save works on pseudo-ETF detail page

Closes #362

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>