### PR TITLE
feat: add indicator scanner view to group detail page

### DIFF
--- a/frontend/src/components/chart/crosshair-time-sync.tsx
+++ b/frontend/src/components/chart/crosshair-time-sync.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef, useCallback, type ReactNode } from "react"
+import { createContext, useContext, useRef, useCallback, useMemo, type ReactNode } from "react"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,10 +63,12 @@ export function CrosshairTimeSyncProvider({ enabled, children }: CrosshairTimeSy
     }
   }, [])
 
+  const value = useMemo(() => ({ subscribe, broadcast }), [subscribe, broadcast])
+
   if (!enabled) return <>{children}</>
 
   return (
-    <CrosshairTimeSyncContext.Provider value={{ subscribe, broadcast }}>
+    <CrosshairTimeSyncContext.Provider value={value}>
       {children}
     </CrosshairTimeSyncContext.Provider>
   )

--- a/frontend/src/components/scanner-view.tsx
+++ b/frontend/src/components/scanner-view.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { X } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ChartSyncProvider } from "@/components/chart/chart-sync-provider"
+import { SubChart } from "@/components/chart/sub-chart"
+import { useAssetDetail } from "@/lib/queries"
+import type { Asset } from "@/lib/api"
+
+interface ScannerViewProps {
+  assets: Asset[]
+  descriptorId: string
+  period: string
+}
+
+export function ScannerView({ assets, descriptorId, period }: ScannerViewProps) {
+  const [hiddenSymbols, setHiddenSymbols] = useState<Set<string>>(new Set())
+
+  const visibleAssets = assets.filter((a) => !hiddenSymbols.has(a.symbol))
+  const hiddenAssets = assets.filter((a) => hiddenSymbols.has(a.symbol))
+
+  const toggleHide = (symbol: string) => {
+    setHiddenSymbols((prev) => {
+      const next = new Set(prev)
+      if (next.has(symbol)) next.delete(symbol)
+      else next.add(symbol)
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Symbol filter chips */}
+      {hiddenAssets.length > 0 && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="text-xs text-muted-foreground">Hidden:</span>
+          {hiddenAssets.map((a) => (
+            <button
+              key={a.symbol}
+              onClick={() => toggleHide(a.symbol)}
+              className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
+            >
+              +{a.symbol}
+            </button>
+          ))}
+          {hiddenAssets.length > 1 && (
+            <button
+              onClick={() => setHiddenSymbols(new Set())}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Show all
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Scanner rows */}
+      <div className="space-y-3">
+        {visibleAssets.map((asset) => (
+          <ScannerRow
+            key={asset.symbol}
+            symbol={asset.symbol}
+            name={asset.name}
+            descriptorId={descriptorId}
+            period={period}
+            onHide={() => toggleHide(asset.symbol)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface ScannerRowProps {
+  symbol: string
+  name: string
+  descriptorId: string
+  period: string
+  onHide: () => void
+}
+
+function ScannerRow({ symbol, name, descriptorId, period, onHide }: ScannerRowProps) {
+  const { data: detail, isLoading } = useAssetDetail(symbol, period)
+  const prices = detail?.prices
+  const indicators = detail?.indicators
+
+  if (isLoading || !prices?.length) {
+    return (
+      <div className="rounded-md border border-border p-3">
+        <div className="flex items-center gap-2 mb-2">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+        <Skeleton className="h-[120px] w-full rounded-md" />
+      </div>
+    )
+  }
+
+  return (
+    <ChartSyncProvider prices={prices} indicators={indicators ?? []}>
+      <div className="rounded-md border border-border p-3">
+        <div className="flex items-center gap-2 mb-1">
+          <Link
+            to={`/asset/${symbol}`}
+            className="text-sm font-semibold hover:underline"
+          >
+            {symbol}
+          </Link>
+          <span className="text-xs text-muted-foreground truncate">{name}</span>
+          <button
+            onClick={onHide}
+            className="ml-auto text-muted-foreground hover:text-foreground transition-colors"
+            title={`Hide ${symbol}`}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <SubChart descriptorId={descriptorId} showLegend roundedClass="rounded-md" />
+      </div>
+    </ChartSyncProvider>
+  )
+}

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -321,6 +321,10 @@ export function getDescriptorById(id: string): IndicatorDescriptor | undefined {
   return INDICATOR_REGISTRY.find((d) => d.id === id)
 }
 
+export function getScannableDescriptors(): IndicatorDescriptor[] {
+  return INDICATOR_REGISTRY.filter((d) => d.placement !== "overlay")
+}
+
 export function getHoldingSummaryDescriptors(): IndicatorDescriptorWithSummary[] {
   return INDICATOR_REGISTRY.filter(
     (d): d is IndicatorDescriptorWithSummary => d.holdingSummary != null,

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -6,7 +6,7 @@ export type AssetTypeFilter = "all" | "stock" | "etf"
 export type GroupSortBy = string
 export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"
-export type GroupViewMode = "card" | "table"
+export type GroupViewMode = "card" | "table" | "scanner"
 
 export interface AppSettings {
   group_indicator_visibility: Record<string, boolean>


### PR DESCRIPTION
## Summary
- Add scanner view mode to group detail page that stacks indicator sub-charts (RSI, MACD, ATR, ADX) vertically with crosshair sync across all group members
- Scanner-specific controls: indicator selector + full period selector, replacing sparkline/sort controls
- Symbol filter chips to hide/show individual assets in the scanner
- Fix: memoize `CrosshairTimeSyncProvider` context value to prevent chart destruction cascades on parent re-renders (affected scanner view most due to many simultaneous charts)

Closes #375

## Test plan
- [ ] Switch to scanner view, verify all group member charts render with selected indicator
- [ ] Switch between RSI/MACD/ATR/ADX, verify charts update
- [ ] Hover one chart, verify crosshair syncs to all other charts
- [ ] Change period selector, verify charts refetch with new period
- [ ] Hide/show symbols via filter chips
- [ ] Toggle dark/light theme, verify charts re-theme
- [ ] Type filter (stocks/ETFs) still filters scanner results
- [ ] Table and card views still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)