### PR TITLE
feat: collapse tag filter into compact popover in group view

### DIFF
--- a/frontend/src/components/tag-filter-popover.tsx
+++ b/frontend/src/components/tag-filter-popover.tsx
@@ -1,0 +1,66 @@
+import { Filter, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { TagBadge } from "@/components/tag-badge"
+import type { Tag } from "@/lib/api"
+
+interface TagFilterPopoverProps {
+  tags: Tag[]
+  selectedTags: number[]
+  onToggleTag: (id: number) => void
+  onClear: () => void
+}
+
+export function TagFilterPopover({
+  tags,
+  selectedTags,
+  onToggleTag,
+  onClear,
+}: TagFilterPopoverProps) {
+  const activeCount = selectedTags.length
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="h-7 text-xs gap-1.5">
+          <Filter className="h-3.5 w-3.5" />
+          Tags
+          {activeCount > 0 && (
+            <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-0 text-[10px] font-semibold leading-4 min-w-[18px] text-center">
+              {activeCount}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto max-w-80">
+        <div className="flex items-center justify-between gap-4 mb-2">
+          <span className="text-xs font-medium text-muted-foreground">Filter by tag</span>
+          {activeCount > 0 && (
+            <button
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              onClick={onClear}
+            >
+              <X className="h-3 w-3" />
+              Clear
+            </button>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {tags.map((tag) => (
+            <TagBadge
+              key={tag.id}
+              name={tag.name}
+              color={tag.color}
+              active={activeCount === 0 || selectedTags.includes(tag.id)}
+              onClick={() => onToggleTag(tag.id)}
+            />
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -13,7 +13,7 @@ import { SegmentedControl } from "@/components/ui/segmented-control"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AddSymbolDialog } from "@/components/add-symbol-dialog"
 import { AssetCard } from "@/components/asset-card"
-import { TagBadge } from "@/components/tag-badge"
+import { TagFilterPopover } from "@/components/tag-filter-popover"
 import { useGroup, useGroupSparklines, useGroupIndicators, useRemoveAssetFromGroup, useUpdateGroup, useTags, usePrefetchAssetDetail } from "@/lib/queries"
 import { useQuotes } from "@/lib/quote-stream"
 import { buildSortOptions, getScannableDescriptors } from "@/lib/indicator-registry"
@@ -178,31 +178,17 @@ export function GroupPage({ groupId }: { groupId: number }) {
             value={settings.group_view_mode}
             onChange={setViewMode}
           />
+          {allTags && allTags.length > 0 && (
+            <TagFilterPopover
+              tags={allTags}
+              selectedTags={selectedTags}
+              onToggleTag={toggleTag}
+              onClear={() => setSelectedTags([])}
+            />
+          )}
         </div>
         <AddSymbolDialog groupId={groupId} isDefaultGroup={isDefaultGroup} />
       </div>
-
-      {allTags && allTags.length > 0 && (
-        <div className="flex items-center gap-2 flex-wrap">
-          {allTags.map((tag) => (
-            <TagBadge
-              key={tag.id}
-              name={tag.name}
-              color={tag.color}
-              active={selectedTags.length === 0 || selectedTags.includes(tag.id)}
-              onClick={() => toggleTag(tag.id)}
-            />
-          ))}
-          {selectedTags.length > 0 && (
-            <button
-              className="text-xs text-muted-foreground hover:text-foreground"
-              onClick={() => setSelectedTags([])}
-            >
-              Clear
-            </button>
-          )}
-        </div>
-      )}
 
       {groupLoading && <p className="text-muted-foreground">Loading...</p>}
 


### PR DESCRIPTION
## Summary
- Replaces the always-visible tag filter row with a compact "Tags" popover button in the control bar
- Active filter count shown as a badge on the trigger
- Reclaims vertical space that was wasted by multi-line tag wrapping

Closes #386

## Changes
- New `TagFilterPopover` component with Filter icon, count badge, and popover with tag badges
- `group-page.tsx`: replaced inline tag row with the popover, moved into the control bar alongside other filters

## Test plan
- [ ] Tag popover opens on click, shows all tags
- [ ] Clicking tags toggles filter (same OR logic)
- [ ] Active count badge appears when tags are selected
- [ ] Clear button resets filter
- [ ] No vertical space wasted when popover is closed
- [ ] Lint clean, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)