### PR TITLE
Add move/copy asset to another group via context menu

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -1,14 +1,9 @@
 import { Link } from "react-router-dom"
-import { Trash2 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu"
+import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu"
+import { AssetContextMenuContent } from "@/components/asset-context-menu"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { DeferredSparkline } from "@/components/sparkline"
 import { TagBadge } from "@/components/tag-badge"
@@ -21,6 +16,8 @@ import { usePriceFlash } from "@/lib/use-price-flash"
 const CARD_DESCRIPTORS = getCardDescriptors()
 
 export interface AssetCardProps {
+  groupId: number
+  assetId: number
   symbol: string
   name: string
   type: AssetType
@@ -53,6 +50,8 @@ function MiniIndicatorCard({
 }
 
 export function AssetCard({
+  groupId,
+  assetId,
   symbol,
   name,
   type,
@@ -131,12 +130,12 @@ export function AssetCard({
           </Link>
         </Card>
       </ContextMenuTrigger>
-      <ContextMenuContent>
-        <ContextMenuItem variant="destructive" onClick={onDelete}>
-          <Trash2 />
-          Remove from group
-        </ContextMenuItem>
-      </ContextMenuContent>
+      <AssetContextMenuContent
+        groupId={groupId}
+        assetId={assetId}
+        symbol={symbol}
+        onRemove={onDelete}
+      />
     </ContextMenu>
   )
 }

--- a/frontend/src/components/asset-context-menu.tsx
+++ b/frontend/src/components/asset-context-menu.tsx
@@ -1,0 +1,101 @@
+import { ArrowRightLeft, Copy, Trash2 } from "lucide-react"
+import { resolveIcon } from "@/lib/icon-utils"
+import {
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+} from "@/components/ui/context-menu"
+import { useGroups, useAddAssetsToGroup, useRemoveAssetFromGroup } from "@/lib/queries"
+
+interface AssetContextMenuContentProps {
+  groupId: number
+  assetId: number
+  symbol: string
+  onRemove: () => void
+}
+
+export function AssetContextMenuContent({
+  groupId,
+  assetId,
+  symbol,
+  onRemove,
+}: AssetContextMenuContentProps) {
+  const { data: groups } = useGroups()
+  const addToGroup = useAddAssetsToGroup()
+  const removeFromGroup = useRemoveAssetFromGroup()
+
+  const otherGroups = groups?.filter((g) => g.id !== groupId) ?? []
+
+  const handleMove = (targetGroupId: number) => {
+    removeFromGroup.mutate({ groupId, assetId })
+    addToGroup.mutate({ groupId: targetGroupId, assetIds: [assetId] })
+  }
+
+  const handleCopy = (targetGroupId: number) => {
+    addToGroup.mutate({ groupId: targetGroupId, assetIds: [assetId] })
+  }
+
+  const isInGroup = (group: { assets: { id: number }[] }) =>
+    group.assets.some((a) => a.id === assetId)
+
+  return (
+    <ContextMenuContent>
+      {otherGroups.length > 0 && (
+        <>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <ArrowRightLeft className="h-4 w-4" />
+              Move to group
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              {otherGroups.map((g) => {
+                const Icon = resolveIcon(g.icon)
+                return (
+                  <ContextMenuItem key={g.id} onClick={() => handleMove(g.id)}>
+                    <Icon className="h-4 w-4" />
+                    {g.name}
+                  </ContextMenuItem>
+                )
+              })}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <Copy className="h-4 w-4" />
+              Copy to group
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              {otherGroups.map((g) => {
+                const alreadyIn = isInGroup(g)
+                const Icon = resolveIcon(g.icon)
+                return (
+                  <ContextMenuItem
+                    key={g.id}
+                    disabled={alreadyIn}
+                    onClick={() => handleCopy(g.id)}
+                  >
+                    <Icon className="h-4 w-4" />
+                    {g.name}
+                    {alreadyIn && (
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {symbol} already in group
+                      </span>
+                    )}
+                  </ContextMenuItem>
+                )
+              })}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          <ContextMenuSeparator />
+        </>
+      )}
+      <ContextMenuItem variant="destructive" onClick={onRemove}>
+        <Trash2 className="h-4 w-4" />
+        Remove from group
+      </ContextMenuItem>
+    </ContextMenuContent>
+  )
+}

--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -13,6 +13,7 @@ import { SORTABLE_FIELDS, BASE_COLUMN_DEFS, isColumnVisible } from "./shared"
 
 
 interface GroupTableProps {
+  groupId: number
   assets: Asset[]
   quotes: Record<string, Quote>
   indicators?: Record<string, IndicatorSummary>
@@ -24,7 +25,7 @@ interface GroupTableProps {
   onSort?: (key: GroupSortBy) => void
 }
 
-export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort }: GroupTableProps) {
+export function GroupTable({ groupId, assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort }: GroupTableProps) {
   const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(new Set())
   const { settings, updateSettings } = useSettings()
   const columnSettings = settings.group_table_columns
@@ -117,6 +118,7 @@ export function GroupTable({ assets, quotes, indicators, onDelete, compactMode, 
           {assets.map((asset) => (
             <TableRow
               key={asset.id}
+              groupId={groupId}
               asset={asset}
               quote={quotes[asset.symbol]}
               indicator={indicators?.[asset.symbol]}

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -1,13 +1,9 @@
 import { Link } from "react-router-dom"
-import { ChevronRight, ChevronDown, Trash2 } from "lucide-react"
+import { ChevronRight, ChevronDown } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu"
+import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu"
+import { AssetContextMenuContent } from "@/components/asset-context-menu"
 import { TagBadge } from "@/components/tag-badge"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { ExpandedAssetChart } from "@/components/expanded-asset-chart"
@@ -24,6 +20,7 @@ import { usePriceFlash } from "@/lib/use-price-flash"
 import { isColumnVisible } from "./shared"
 
 export function TableRow({
+  groupId,
   asset,
   quote,
   indicator,
@@ -36,6 +33,7 @@ export function TableRow({
   visibleIndicatorFields,
   totalColSpan,
 }: {
+  groupId: number
   asset: Asset
   quote?: Quote
   indicator?: IndicatorSummary
@@ -180,12 +178,12 @@ export function TableRow({
           <td className={`${py} pr-2`} />
         </tr>
       </ContextMenuTrigger>
-      <ContextMenuContent>
-        <ContextMenuItem variant="destructive" onClick={onDelete}>
-          <Trash2 />
-          Remove from group
-        </ContextMenuItem>
-      </ContextMenuContent>
+      <AssetContextMenuContent
+        groupId={groupId}
+        assetId={asset.id}
+        symbol={asset.symbol}
+        onRemove={onDelete}
+      />
       {expanded && (
         <tr>
           <td colSpan={totalColSpan} className="bg-muted/20 p-4 border-b border-border">

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -211,6 +211,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
       ) : viewMode === "table" && assets && assets.length > 0 ? (
         <CrosshairTimeSyncProvider enabled={true}>
           <GroupTable
+            groupId={groupId}
             assets={assets}
             quotes={quotes}
             indicators={batchIndicators}
@@ -231,6 +232,8 @@ export function GroupPage({ groupId }: { groupId: number }) {
           {assets?.map((asset) => (
             <AssetCard
               key={asset.id}
+              groupId={groupId}
+              assetId={asset.id}
               symbol={asset.symbol}
               name={asset.name}
               type={asset.type}


### PR DESCRIPTION
## Summary
- Add "Move to group" and "Copy to group" submenus to the asset right-click context menu
- Move: removes asset from current group, adds to target group
- Copy: adds asset to target group (disabled if already present)
- Group icons shown in submenus for easy identification
- Extract shared `AssetContextMenuContent` component used by both asset cards and table rows

Closes #391

## Test plan
- [ ] Right-click asset card → "Move to group" submenu lists other groups
- [ ] Right-click table row → "Copy to group" submenu lists other groups
- [ ] Move removes asset from current group and adds to target
- [ ] Copy adds asset to target group, source unchanged
- [ ] "Copy" submenu disables groups the asset is already in
- [ ] "Remove from group" still works
- [ ] No regression on card click / row expansion behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)