### PR TITLE
feat: improve expand-all button visibility and performance

### DIFF
--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -91,13 +91,12 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
                 />
               )
             })}
-            <th className="w-8 text-right pr-1">
+            <th className="w-28 text-right pr-1">
               <div className="flex items-center justify-end gap-0.5">
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 w-6 p-0"
-                  aria-label={allExpanded ? "Collapse all rows" : "Expand all rows"}
+                  className="h-6 gap-1 px-1.5 text-xs text-muted-foreground"
                   onClick={toggleExpandAll}
                 >
                   {allExpanded ? (
@@ -105,6 +104,7 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
                   ) : (
                     <ChevronsUpDown className="h-3.5 w-3.5" />
                   )}
+                  {allExpanded ? "Collapse" : "Expand"}
                 </Button>
                 <ColumnVisibilityMenu
                   columnSettings={columnSettings}

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { ChevronRight, ChevronDown } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -18,6 +19,37 @@ import {
 } from "@/lib/indicator-registry"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { isColumnVisible } from "./shared"
+
+function LazyExpandedChart({ symbol, currency }: { symbol: string; currency: string }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: "200px" },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref}>
+      {visible ? (
+        <ExpandedAssetChart symbol={symbol} currency={currency} compact />
+      ) : (
+        <Skeleton className="h-[200px] lg:h-[300px] w-full rounded-md" />
+      )}
+    </div>
+  )
+}
 
 export function TableRow({
   groupId,
@@ -188,7 +220,7 @@ export function TableRow({
         <tr>
           <td colSpan={totalColSpan} className="bg-muted/20 p-4 border-b border-border">
             <div className="max-w-[calc(100vw-4rem)]">
-              <ExpandedAssetChart symbol={asset.symbol} currency={asset.currency} compact />
+              <LazyExpandedChart symbol={asset.symbol} currency={asset.currency} />
             </div>
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- Add text label ("Expand"/"Collapse") to the expand-all button in group table header — previously a tiny unlabeled icon
- Lazy-load expanded charts via `IntersectionObserver` so expanding all rows doesn't freeze the UI (charts mount only when scrolled into view)

Closes #385

## Test plan
- [ ] Expand-all button now shows "Expand" / "Collapse" text and is clearly visible
- [ ] Clicking "Expand" on a group with 10+ assets — no UI freeze, charts load progressively as scrolled
- [ ] Individual row expand still works as before
- [ ] Lint clean, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)