### PR TITLE
feat: highlight sidebar group when context menu is open (#398)

### DIFF
--- a/frontend/src/components/groups-section.tsx
+++ b/frontend/src/components/groups-section.tsx
@@ -108,7 +108,7 @@ function SortableGroupItem({
     <SidebarMenuItem ref={setNodeRef} style={style}>
       <ContextMenu>
         <ContextMenuTrigger asChild>
-          <div className="flex items-center w-full">
+          <div className="flex items-center w-full rounded-md data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground">
             {showDragHandle && <DragHandle {...attributes} {...listeners} />}
             <SidebarMenuButton
               asChild


### PR DESCRIPTION
## Summary
- Adds visual highlight to sidebar group item when its right-click context menu is open
- Uses Radix `data-[state=open]` attribute to apply `bg-sidebar-accent` styling on the `ContextMenuTrigger` wrapper
- Consistent with existing hover/active styles used by `SidebarMenuButton`

Closes #398

## Test plan
- [ ] Right-click group in sidebar → row highlights with accent background
- [ ] Close context menu → highlight disappears
- [ ] Highlight style is consistent with existing hover styling
- [ ] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)