### PR TITLE
feat: add ATR% indicator (#399)

### DIFF
--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -142,7 +142,8 @@ def _df_to_indicator_rows(indicators: pd.DataFrame, start: date) -> list[Indicat
         values: dict[str, float | None] = {}
         for defn in INDICATOR_REGISTRY.values():
             for col in defn.output_fields:
-                values[col] = safe_round(row[col], defn.decimals)
+                decimals = defn.field_decimals.get(col, defn.decimals)
+                values[col] = safe_round(row[col], decimals)
         rows.append(IndicatorResponse(
             date=dt,
             close=round(row["close"], 4),

--- a/frontend/src/components/chart/chart-legends.tsx
+++ b/frontend/src/components/chart/chart-legends.tsx
@@ -31,7 +31,7 @@ function OverlayEntry({ descriptor, v }: { descriptor: IndicatorDescriptor; v: L
       <span>
         <span className="inline-block w-2 h-0.5 mr-1 align-middle" style={{ backgroundColor: color }} />
         {s.label}{" "}
-        <span style={{ color }}>{val?.toFixed(descriptor.decimals)}</span>
+        <span style={{ color }}>{val?.toFixed(descriptor.decimals)}{descriptor.suffix ?? ""}</span>
       </span>
     )
   }
@@ -44,7 +44,7 @@ function OverlayEntry({ descriptor, v }: { descriptor: IndicatorDescriptor; v: L
       {descriptor.series.map((s, i) => (
         <Fragment key={s.field}>
           {i > 0 && " / "}
-          <span>{v.indicators[s.field]?.toFixed(descriptor.decimals)}</span>
+          <span>{v.indicators[s.field]?.toFixed(descriptor.decimals)}{descriptor.suffix ?? ""}</span>
         </Fragment>
       ))}
     </span>
@@ -100,7 +100,7 @@ export function SubChartLegend({ descriptorId, values, latest }: {
         if (thresholdClass) {
           return (
             <span key={s.field} className={thresholdClass}>
-              {s.label} {val.toFixed(desc.decimals)}
+              {s.label} {val.toFixed(desc.decimals)}{desc.suffix ?? ""}
             </span>
           )
         }
@@ -109,7 +109,7 @@ export function SubChartLegend({ descriptorId, values, latest }: {
           <span key={s.field}>
             <span className="inline-block w-2 h-0.5 mr-1 align-middle" style={{ backgroundColor: color }} />
             {s.label}{" "}
-            <span style={{ color }}>{val.toFixed(desc.decimals)}</span>
+            <span style={{ color }}>{val.toFixed(desc.decimals)}{desc.suffix ?? ""}</span>
           </span>
         )
       })}

--- a/frontend/src/components/chart/indicator-cards.tsx
+++ b/frontend/src/components/chart/indicator-cards.tsx
@@ -23,6 +23,7 @@ const CARD_HELP: Record<string, string> = {
   rsi: "Momentum oscillator — below 30 is oversold, above 70 is overbought",
   macd: "Momentum crossover — positive histogram is bullish, negative is bearish",
   atr: "Average daily high-to-low range — higher means more volatile",
+  atr_pct: "ATR as % of price — comparable across different price levels",
   adx: "Trend strength & direction — green is bullish, red is bearish",
 }
 

--- a/frontend/src/components/group-table/shared.ts
+++ b/frontend/src/components/group-table/shared.ts
@@ -18,6 +18,7 @@ export function isColumnVisible(columnSettings: Record<string, boolean>, key: st
 /** Minimum viewport width (px) for a column to be auto-shown. */
 const RESPONSIVE_HIDE_BREAKPOINTS: Record<string, number> = {
   adx: 1280,
+  atr_pct: 1280,
   atr: 1024,
   macd: 768,
   rsi: 640,

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -14,6 +14,7 @@ import {
   getNumericValue,
   extractMacdValues,
   getSeriesByField,
+  getDescriptorByField,
   resolveThresholdColor,
   resolveAdxColor,
 } from "@/lib/indicator-registry"
@@ -197,14 +198,15 @@ export function TableRow({
             }
             const val = getNumericValue(indicator?.values, field)
             const series = getSeriesByField(field)
+            const desc = getDescriptorByField(field)
             const colorClass = field === "adx" && val != null && indicator?.values
               ? resolveAdxColor(val, indicator.values)
               : resolveThresholdColor(series?.thresholdColors, val)
-            const decimals = val != null && Math.abs(val) >= 100 ? 0 : 2
+            const decimals = desc?.decimals ?? (val != null && Math.abs(val) >= 100 ? 0 : 2)
             return (
               <td key={field} className={`${py} px-3 text-right text-sm tabular-nums`}>
                 {val != null ? (
-                  <span className={colorClass}>{val.toFixed(decimals)}</span>
+                  <span className={colorClass}>{val.toFixed(decimals)}{desc?.suffix ?? ""}</span>
                 ) : (
                   <span className="text-muted-foreground">&mdash;</span>
                 )}

--- a/frontend/src/components/holdings-grid/holding-row.tsx
+++ b/frontend/src/components/holdings-grid/holding-row.tsx
@@ -82,6 +82,7 @@ export function HoldingRow({
                     colorMap={hs.colorMap}
                     values={indicator?.values}
                     close={indicator?.close ?? null}
+                    suffix={desc.suffix}
                   />
                 </td>
               )

--- a/frontend/src/components/holdings-grid/holding-summary-cell.tsx
+++ b/frontend/src/components/holdings-grid/holding-summary-cell.tsx
@@ -7,16 +7,18 @@ export function HoldingSummaryCell({
   colorMap,
   values,
   close,
+  suffix,
 }: {
   format: "numeric" | "compare_close" | "string_map"
   field: string
   colorMap?: Record<string, string>
   values?: Record<string, number | string | null>
   close: number | null
+  suffix?: string
 }) {
   if (format === "numeric") {
     const val = getNumericValue(values, field)
-    return <IndicatorCell value={val != null ? val.toFixed(0) : null} />
+    return <IndicatorCell value={val != null ? `${val.toFixed(0)}${suffix ?? ""}` : null} />
   }
 
   if (format === "compare_close") {

--- a/frontend/src/components/indicator-value.tsx
+++ b/frontend/src/components/indicator-value.tsx
@@ -57,7 +57,7 @@ export function IndicatorValue({
         className={`${sizeClass} font-semibold tabular-nums ${colorClass || "text-foreground"}`}
       >
         {currency && descriptor.priceDenominated ? currencySymbol(currency) : ""}
-        {mainVal.toFixed(descriptor.decimals)}
+        {mainVal.toFixed(descriptor.decimals)}{descriptor.suffix ?? ""}
       </span>
 
       {/* ADX: show +DI / -DI below the main value */}

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -72,6 +72,8 @@ export interface IndicatorDescriptor {
   snapField?: string
   /** When true, the indicator's values are denominated in the asset's currency (e.g. ATR). */
   priceDenominated?: boolean
+  /** Suffix appended after the formatted value (e.g. "%" for ATR%). */
+  suffix?: string
 }
 
 /** Narrowed descriptor where holdingSummary is guaranteed present. */
@@ -207,6 +209,25 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
     decimals: 2,
     holdingSummary: { label: "ATR", field: "atr", format: "numeric" },
     priceDenominated: true,
+  },
+  {
+    id: "atr_pct",
+    label: "ATR%",
+    shortLabel: "ATR%",
+    placement: "card",
+    fields: ["atr_pct"],
+    sortableFields: ["atr_pct"],
+    series: [
+      {
+        field: "atr_pct",
+        label: "ATR%",
+        color: "#f97316",
+        lineWidth: 2,
+      },
+    ],
+    decimals: 2,
+    suffix: "%",
+    holdingSummary: { label: "ATR%", field: "atr_pct", format: "numeric" },
   },
   {
     id: "adx",
@@ -354,6 +375,10 @@ export function extractMacdValues(values?: Record<string, number | string | null
     macd_signal: getNumericValue(values, "macd_signal"),
     macd_hist: getNumericValue(values, "macd_hist"),
   } : undefined
+}
+
+export function getDescriptorByField(field: string): IndicatorDescriptor | undefined {
+  return INDICATOR_REGISTRY.find((d) => d.fields.includes(field))
 }
 
 export function getSeriesByField(field: string): SeriesDescriptor | undefined {


### PR DESCRIPTION
## Summary
- Add ATR% (ATR / close × 100) indicator for comparing volatility across assets at different price levels
- Computed per-bar with full time series (modal chart works), not just snapshot-derived
- New `post_compute` callback and `field_decimals` on backend `IndicatorDef` for derived per-bar columns with mixed precision
- New `suffix` prop on frontend `IndicatorDescriptor` for appending "%" after values

## Changes
- **Backend**: `_atr_post_compute` + `_atr_snapshot_derived`, extended `IndicatorDef` dataclass, updated both serialization paths for per-field decimals
- **Frontend**: ATR% descriptor (card placement, sortable, `%` suffix), suffix support in indicator-value, table-row, chart-legends, holding-summary-cell
- **Tests**: 5 new tests (snapshot presence, calculation, division-by-zero guard, NaN guard, per-bar column)

## Test plan
- [x] All 24 backend tests pass
- [x] Frontend lint clean
- [x] Frontend TypeScript build succeeds
- [ ] Manual: group table ATR% column with % suffix
- [ ] Manual: asset detail ATR% card → click opens time-series modal chart
- [ ] Manual: holdings grid ATR% summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)