### PR TITLE
feat: compact number formatting (K/M/B suffixes)

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -8,10 +8,11 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { DeferredSparkline } from "@/components/sparkline"
 import { TagBadge } from "@/components/tag-badge"
 import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary } from "@/lib/api"
-import { formatPrice, changeColor, formatChangePct } from "@/lib/format"
+import { formatPrice, formatCompactPrice, changeColor, formatChangePct } from "@/lib/format"
 import { getCardDescriptors, isIndicatorVisible, type IndicatorDescriptor } from "@/lib/indicator-registry"
 import { IndicatorValue } from "@/components/indicator-value"
 import { usePriceFlash } from "@/lib/use-price-flash"
+import { useSettings } from "@/lib/settings"
 
 const CARD_DESCRIPTORS = getCardDescriptors()
 
@@ -65,6 +66,7 @@ export function AssetCard({
   showSparkline,
   indicatorVisibility,
 }: AssetCardProps) {
+  const { settings } = useSettings()
   const enabledCards = CARD_DESCRIPTORS.filter(
     (d) => isIndicatorVisible(indicatorVisibility, d.id),
   )
@@ -87,8 +89,14 @@ export function AssetCard({
                   {type}
                 </Badge>
                 {lastPrice != null ? (
-                  <span ref={priceRef} className="ml-auto text-base font-semibold tabular-nums rounded px-1 -mx-1">
-                    {formatPrice(lastPrice, currency)}
+                  <span
+                    ref={priceRef}
+                    className="ml-auto text-base font-semibold tabular-nums rounded px-1 -mx-1"
+                    title={settings.compact_numbers ? formatPrice(lastPrice, currency) : undefined}
+                  >
+                    {settings.compact_numbers
+                      ? formatCompactPrice(lastPrice, currency)
+                      : formatPrice(lastPrice, currency)}
                   </span>
                 ) : (
                   <Skeleton className="ml-auto h-5 w-16 rounded" />

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -9,7 +9,7 @@ import { TagBadge } from "@/components/tag-badge"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { ExpandedAssetChart } from "@/components/expanded-asset-chart"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
-import { formatPrice, changeColor, formatChangePct } from "@/lib/format"
+import { formatPrice, formatCompactPrice, changeColor, formatChangePct } from "@/lib/format"
 import {
   getNumericValue,
   extractMacdValues,
@@ -150,8 +150,14 @@ export function TableRow({
           {isColumnVisible(columnSettings, "price") && (
             <td className={`${py} px-3 text-right tabular-nums`}>
               {displayPrice != null ? (
-                <span ref={priceRef} className={`font-medium rounded px-1 -mx-1 ${staleClass}`}>
-                  {formatPrice(displayPrice, asset.currency)}
+                <span
+                  ref={priceRef}
+                  className={`font-medium rounded px-1 -mx-1 ${staleClass}`}
+                  title={settings.compact_numbers ? formatPrice(displayPrice, asset.currency) : undefined}
+                >
+                  {settings.compact_numbers
+                    ? formatCompactPrice(displayPrice, asset.currency)
+                    : formatPrice(displayPrice, asset.currency)}
                 </span>
               ) : (
                 <Skeleton className="h-4 w-14 ml-auto rounded" />

--- a/frontend/src/components/holdings-grid/holding-row.tsx
+++ b/frontend/src/components/holdings-grid/holding-row.tsx
@@ -2,7 +2,8 @@ import { Link } from "react-router-dom"
 import { ChevronRight, ChevronDown, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ExpandedAssetChart } from "@/components/expanded-asset-chart"
-import { formatPrice, formatChangePct } from "@/lib/format"
+import { formatPrice, formatCompactPrice, formatChangePct } from "@/lib/format"
+import { useSettings } from "@/lib/settings"
 import { HoldingSummaryCell } from "./holding-summary-cell"
 import { SUMMARY_DESCRIPTORS } from "./types"
 import type { HoldingsGridRow, IndicatorData } from "./types"
@@ -26,6 +27,7 @@ export function HoldingRow({
   linkTarget?: "_blank"
   totalColSpan: number
 }) {
+  const { settings } = useSettings()
   const chg = formatChangePct(indicator?.change_pct ?? null)
 
   return (
@@ -66,8 +68,15 @@ export function HoldingRow({
           </td>
         ) : (
           <>
-            <td className="py-1 px-2 text-right text-xs">
-              {indicator?.close != null ? formatPrice(indicator.close, indicator.currency, 0) : "\u2014"}
+            <td
+              className="py-1 px-2 text-right text-xs"
+              title={settings.compact_numbers && indicator?.close != null ? formatPrice(indicator.close, indicator.currency, 0) : undefined}
+            >
+              {indicator?.close != null
+                ? settings.compact_numbers
+                  ? formatCompactPrice(indicator.close, indicator.currency)
+                  : formatPrice(indicator.close, indicator.currency, 0)
+                : "\u2014"}
             </td>
             <td className={`py-1 px-2 text-right text-xs ${chg.className}`}>
               {chg.text ?? "\u2014"}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -7,15 +7,44 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   ILA: "\u20aa",
   ZAR: "R",
   JPY: "\u00a5",
+  KRW: "\u20a9",
   CHF: "CHF\u00a0",
+}
+
+const ZERO_DECIMAL_CURRENCIES = new Set(["KRW", "JPY", "IDR", "HUF", "VND", "CLP", "TWD"])
+
+export function currencyDecimals(currency: string): number {
+  return ZERO_DECIMAL_CURRENCIES.has(currency.toUpperCase()) ? 0 : 2
 }
 
 export function currencySymbol(currency: string): string {
   return CURRENCY_SYMBOLS[currency.toUpperCase()] ?? `${currency}\u00a0`
 }
 
-export function formatPrice(value: number, currency: string, decimals = 2): string {
-  return `${currencySymbol(currency)}${value.toFixed(decimals)}`
+export function formatPrice(value: number, currency: string, decimals?: number): string {
+  return `${currencySymbol(currency)}${value.toFixed(decimals ?? currencyDecimals(currency))}`
+}
+
+export function formatCompactPrice(value: number, currency: string): string {
+  const abs = Math.abs(value)
+  const sym = currencySymbol(currency)
+  let scaled: string
+  if (abs >= 1e9) {
+    scaled = (value / 1e9).toFixed(1)
+    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
+    return `${sym}${scaled}B`
+  }
+  if (abs >= 1e6) {
+    scaled = (value / 1e6).toFixed(1)
+    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
+    return `${sym}${scaled}M`
+  }
+  if (abs >= 1e3) {
+    scaled = (value / 1e3).toFixed(1)
+    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
+    return `${sym}${scaled}K`
+  }
+  return formatPrice(value, currency)
 }
 
 export function changeColor(pct: number | null | undefined): string {

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -23,6 +23,7 @@ export interface AppSettings {
   chart_type: "candle" | "line"
   theme: "dark" | "light" | "system"
   compact_mode: boolean
+  compact_numbers: boolean
   show_asset_type_badge: boolean
   decimal_places: number
   sync_pseudo_etf_crosshairs: boolean
@@ -49,6 +50,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   chart_type: "candle",
   theme: "system",
   compact_mode: false,
+  compact_numbers: false,
   show_asset_type_badge: true,
   decimal_places: 2,
   sync_pseudo_etf_crosshairs: false,

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -3,10 +3,11 @@ import { ArrowLeft, ExternalLink, RefreshCw, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { PeriodSelector } from "@/components/period-selector"
 import { MarketStatusDot } from "@/components/market-status-dot"
-import { buildYahooFinanceUrl, formatPrice, formatChangePct } from "@/lib/format"
+import { buildYahooFinanceUrl, formatPrice, formatCompactPrice, formatChangePct } from "@/lib/format"
 import { useQuotes } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useRefreshPrices, useCreateAsset } from "@/lib/queries"
+import { useSettings } from "@/lib/settings"
 
 export function Header({
   symbol,
@@ -23,6 +24,7 @@ export function Header({
   setPeriod: (p: string) => void
   isTracked: boolean
 }) {
+  const { settings } = useSettings()
   const refresh = useRefreshPrices(symbol)
   const createAsset = useCreateAsset()
   const quotes = useQuotes()
@@ -47,8 +49,14 @@ export function Header({
           {name && <p className="text-sm text-muted-foreground">{name}</p>}
         </div>
         {price != null && (
-          <span ref={priceRef} className="text-xl font-semibold tabular-nums rounded px-1">
-            {formatPrice(price, currency)}
+          <span
+            ref={priceRef}
+            className="text-xl font-semibold tabular-nums rounded px-1"
+            title={settings.compact_numbers ? formatPrice(price, currency) : undefined}
+          >
+            {settings.compact_numbers
+              ? formatCompactPrice(price, currency)
+              : formatPrice(price, currency)}
           </span>
         )}
         {changePct != null && (() => {

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -167,6 +167,12 @@ export function SettingsPage() {
             onCheckedChange={(v) => change({ compact_mode: v })}
           />
           <VisibilityToggle
+            id="compact-numbers"
+            label="Compact Numbers"
+            checked={draft.compact_numbers}
+            onCheckedChange={(v) => change({ compact_numbers: v })}
+          />
+          <VisibilityToggle
             id="asset-type-badge"
             label="Asset Type Badge"
             checked={draft.show_asset_type_badge}


### PR DESCRIPTION
## Summary
- Add `formatCompactPrice()` with K/M/B suffixes and `currencyDecimals()` for zero-decimal currency auto-detection (KRW, JPY, IDR, HUF, VND, CLP, TWD)
- Add `compact_numbers` user setting with toggle in Display settings card
- Apply compact formatting to group table, asset cards, asset detail header, and holdings grid — with full-value tooltip on hover

## Test plan
- [ ] `pnpm lint` and `pnpm build` pass (verified)
- [ ] Settings page → "Compact Numbers" toggle appears in Display section
- [ ] Toggle ON → group table prices show K/M/B suffixes for large values (e.g. ₩70K)
- [ ] Hover over compact price → tooltip shows full value (e.g. ₩70000)
- [ ] Toggle OFF → KRW/JPY prices show without .00 (e.g. ₩70000 not ₩70000.00)
- [ ] USD/EUR prices still show 2 decimals when compact is off (e.g. $123.45)
- [ ] Asset detail header + asset cards + holdings grid follow same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)