### PR TITLE
feat: add volume and avg volume columns to group table

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -116,6 +116,11 @@ def adx(df: pd.DataFrame, period: int = 14) -> dict[str, pd.Series]:
     return {"adx": adx_series, "plus_di": plus_di, "minus_di": minus_di}
 
 
+def volume_stats(df: pd.DataFrame, period: int = 20) -> dict[str, pd.Series]:
+    """Volume and average volume (SMA of volume)."""
+    return {"volume": df["volume"], "avg_volume": df["volume"].rolling(window=period).mean()}
+
+
 def bb_position(close: float, upper: float, middle: float, lower: float) -> str:
     """Classify where price sits relative to Bollinger Bands."""
     if close > upper:
@@ -250,6 +255,15 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
         decimals=2,
         warmup_periods=28,
         snapshot_derived=_adx_snapshot_derived,
+        uses_ohlc=True,
+    ),
+    "volume": IndicatorDef(
+        func=volume_stats,
+        params={"period": 20},
+        output_fields=["volume", "avg_volume"],
+        result_mapping={"volume": "volume", "avg_volume": "avg_volume"},
+        decimals=0,
+        warmup_periods=20,
         uses_ohlc=True,
     ),
 }

--- a/frontend/src/components/group-table/shared.ts
+++ b/frontend/src/components/group-table/shared.ts
@@ -19,7 +19,9 @@ export function isColumnVisible(columnSettings: Record<string, boolean>, key: st
 const RESPONSIVE_HIDE_BREAKPOINTS: Record<string, number> = {
   adx: 1280,
   atr_pct: 1280,
+  avg_volume: 1280,
   atr: 1024,
+  volume: 1024,
   macd: 768,
   rsi: 640,
 }

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -9,7 +9,7 @@ import { TagBadge } from "@/components/tag-badge"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { ExpandedAssetChart } from "@/components/expanded-asset-chart"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
-import { formatPrice, formatCompactPrice, changeColor, formatChangePct } from "@/lib/format"
+import { formatPrice, formatCompactPrice, formatCompactNumber, changeColor, formatChangePct } from "@/lib/format"
 import {
   getNumericValue,
   extractMacdValues,
@@ -209,10 +209,20 @@ export function TableRow({
               ? resolveAdxColor(val, indicator.values)
               : resolveThresholdColor(series?.thresholdColors, val)
             const decimals = desc?.decimals ?? (val != null && Math.abs(val) >= 100 ? 0 : 2)
+            const formatted = val != null
+              ? desc?.compactFormat
+                ? formatCompactNumber(val)
+                : `${val.toFixed(decimals)}${desc?.suffix ?? ""}`
+              : null
             return (
               <td key={field} className={`${py} px-3 text-right text-sm tabular-nums`}>
-                {val != null ? (
-                  <span className={colorClass}>{val.toFixed(decimals)}{desc?.suffix ?? ""}</span>
+                {formatted != null ? (
+                  <span
+                    className={colorClass}
+                    title={desc?.compactFormat && val != null ? val.toLocaleString() : undefined}
+                  >
+                    {formatted}
+                  </span>
                 ) : (
                   <span className="text-muted-foreground">&mdash;</span>
                 )}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -47,6 +47,27 @@ export function formatCompactPrice(value: number, currency: string): string {
   return formatPrice(value, currency)
 }
 
+export function formatCompactNumber(value: number): string {
+  const abs = Math.abs(value)
+  let scaled: string
+  if (abs >= 1e9) {
+    scaled = (value / 1e9).toFixed(1)
+    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
+    return `${scaled}B`
+  }
+  if (abs >= 1e6) {
+    scaled = (value / 1e6).toFixed(1)
+    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
+    return `${scaled}M`
+  }
+  if (abs >= 1e3) {
+    scaled = (value / 1e3).toFixed(1)
+    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
+    return `${scaled}K`
+  }
+  return value.toFixed(0)
+}
+
 export function changeColor(pct: number | null | undefined): string {
   if (pct == null) return "text-muted-foreground"
   return pct >= 0 ? "text-emerald-500" : "text-red-500"

--- a/frontend/src/lib/indicator-descriptors.ts
+++ b/frontend/src/lib/indicator-descriptors.ts
@@ -188,4 +188,18 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
       colorMap: { strong: "text-emerald-500", weak: "text-yellow-500", absent: "text-zinc-400" },
     },
   },
+  {
+    id: "volume",
+    label: "Volume",
+    shortLabel: "Vol",
+    placement: "card",
+    fields: ["volume", "avg_volume"],
+    sortableFields: ["volume", "avg_volume"],
+    series: [
+      { field: "volume", label: "Vol", color: "#64748b" },
+      { field: "avg_volume", label: "Avg Vol", color: "#94a3b8" },
+    ],
+    decimals: 0,
+    compactFormat: true,
+  },
 ]

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -73,6 +73,8 @@ export interface IndicatorDescriptor {
   priceDenominated?: boolean
   /** Suffix appended after the formatted value (e.g. "%" for ATR%). */
   suffix?: string
+  /** When true, table values use formatCompactNumber (K/M/B) instead of toFixed. */
+  compactFormat?: boolean
 }
 
 /** Narrowed descriptor where holdingSummary is guaranteed present. */


### PR DESCRIPTION
## Summary
- Register volume as a backend indicator (volume + 20-day SMA avg_volume) — no migration needed, `PriceHistory.volume` already exists
- Add `formatCompactNumber()` for K/M/B formatting without currency symbol, with full number on hover via `title` attribute
- Add `compactFormat` flag to `IndicatorDescriptor` and wire it into the generic table column renderer
- Responsive breakpoints: volume auto-hides below 1024px, avg_volume below 1280px

## Test plan
- [x] `pytest` — 339 passed
- [x] `pnpm lint` — clean
- [x] `pnpm build` — successful
- [ ] CI passes
- [ ] Manual: group table shows Vol and Avg Vol columns with compact formatting (e.g. 50M, 1.2B), sortable, hover shows full number

🤖 Generated with [Claude Code](https://claude.com/claude-code)