### PR TITLE
Fix stale volume data in stats panel and group table

### DIFF
--- a/backend/app/schemas/quote.py
+++ b/backend/app/schemas/quote.py
@@ -7,5 +7,7 @@ class QuoteResponse(BaseModel):
     previous_close: float | None = Field(default=None, description="Previous session close price")
     change: float | None = Field(default=None, description="Absolute price change from previous close")
     change_percent: float | None = Field(default=None, description="Percentage change from previous close")
+    volume: int | None = Field(default=None, description="Current session trading volume")
+    avg_volume: int | None = Field(default=None, description="10-day average daily volume")
     currency: str = Field(default="USD", description="ISO 4217 currency code")
     market_state: str | None = Field(default=None, description="Market state: REGULAR, PRE, POST, PREPRE, POSTPOST, or CLOSED")

--- a/backend/app/services/yahoo/quotes.py
+++ b/backend/app/services/yahoo/quotes.py
@@ -43,6 +43,8 @@ def _parse_price_data(
         prev_close = _sanitize(info.get("regularMarketPreviousClose"))
         change = _sanitize(info.get("regularMarketChange"))
         change_pct = _sanitize(info.get("regularMarketChangePercent"))
+        volume = info.get("regularMarketVolume")
+        avg_volume = info.get("averageDailyVolume10Day")
 
         if price is None and info.get("regularMarketPrice") is not None:
             nan_fields.append(f"{sym}.price")
@@ -58,6 +60,8 @@ def _parse_price_data(
             "previous_close": round(float(prev_close) / divisor, 4) if prev_close is not None else None,
             "change": round(float(change) / divisor, 4) if change is not None else None,
             "change_percent": round(float(change_pct) * 100, 2) if change_pct is not None else None,
+            "volume": int(volume) if volume is not None else None,
+            "avg_volume": int(avg_volume) if avg_volume is not None else None,
             "currency": currency,
             "market_state": info.get("marketState"),
         })

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -176,6 +176,17 @@ export function TableRow({
             </td>
           )}
           {visibleIndicatorFields.map((field) => {
+            // Override stale DB volume with live SSE quote values
+            if ((field === "volume" || field === "avg_volume") && quote?.[field] != null) {
+              const val = quote[field]!
+              const desc = getDescriptorByField(field)
+              const formatted = desc?.compactFormat ? formatCompactNumber(val) : val.toLocaleString()
+              return (
+                <td key={field} className={`${py} px-3 text-right text-sm tabular-nums`}>
+                  <span title={val.toLocaleString()}>{formatted}</span>
+                </td>
+              )
+            }
             if (field === "macd") {
               const macdVals = extractMacdValues(indicator?.values)
               const m = macdVals?.macd

--- a/frontend/src/components/stats-panel.tsx
+++ b/frontend/src/components/stats-panel.tsx
@@ -10,19 +10,24 @@ import {
   type IndicatorCategory,
   type Placement,
 } from "@/lib/indicator-registry"
-import type { Indicator } from "@/lib/api"
+import type { Indicator, Quote } from "@/lib/api"
 
 interface StatsPanelProps {
   indicators: Indicator[]
   indicatorVisibility: Record<string, Placement[]>
   currency?: string
+  quote?: Quote
 }
 
-export function StatsPanel({ indicators, indicatorVisibility, currency }: StatsPanelProps) {
+export function StatsPanel({ indicators, indicatorVisibility, currency, quote }: StatsPanelProps) {
   const latestValues = useMemo(() => {
     if (!indicators.length) return undefined
-    return indicators[indicators.length - 1].values
-  }, [indicators])
+    const values = { ...indicators[indicators.length - 1].values }
+    // Override stale DB volume with live SSE quote values
+    if (quote?.volume != null) values.volume = quote.volume
+    if (quote?.avg_volume != null) values.avg_volume = quote.avg_volume
+    return values
+  }, [indicators, quote])
 
   const grouped = useMemo(() => {
     const visible = INDICATOR_REGISTRY.filter((d) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -244,6 +244,8 @@ export interface Quote {
   previous_close: number | null
   change: number | null
   change_percent: number | null
+  volume: number | null
+  avg_volume: number | null
   currency: string
   market_state: string | null
 }

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -13,6 +13,7 @@ import {
   useUpdateThesis,
 } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
+import { useQuotes } from "@/lib/quote-stream"
 import { StatsPanel } from "@/components/stats-panel"
 import { Header } from "./header"
 import { ChartSection } from "./chart-section"
@@ -26,6 +27,8 @@ export function AssetDetailPage() {
   const { data: assets } = useAssets()
   const asset = assets?.find((a) => a.symbol === symbol?.toUpperCase())
   const { data: detail } = useAssetDetail(symbol ?? "", period, { enabled: !!symbol })
+  const quotes = useQuotes()
+  const quote = symbol ? quotes[symbol.toUpperCase()] : undefined
   const isTracked = !!asset
   const isEtf = asset?.type === "etf"
 
@@ -46,6 +49,7 @@ export function AssetDetailPage() {
           indicators={detail.indicators}
           indicatorVisibility={settings.indicator_visibility}
           currency={asset?.currency}
+          quote={quote}
         />
       )}
       {isEtf && <HoldingsSection symbol={symbol} />}


### PR DESCRIPTION
## Summary
- Added `volume` and `avg_volume` fields to the SSE quote stream (from Yahoo's `regularMarketVolume` and `averageDailyVolume10Day`)
- Stats panel on asset detail page now overlays live volume from SSE quotes over stale indicator-computed values
- Group table volume/avg_volume columns prefer live SSE data over cached DB indicators

Fixes #431

## Root Cause
Indicator snapshots are computed from DB-stored daily prices (synced via 23:00 cron). During trading hours, the latest row in the DB is yesterday's complete candle, so volume showed yesterday's value. The SSE quote stream already provided live prices but didn't include volume data.

## Test plan
- [ ] Verify backend tests pass (no schema changes break existing tests)
- [ ] Verify frontend build + lint pass
- [ ] During market hours, compare volume on detail page stats panel with Yahoo Finance
- [ ] Verify group table volume column shows live values

🤖 Generated with [Claude Code](https://claude.com/claude-code)