### PR TITLE
test: add 165 backend tests covering 15 untested modules

### DIFF
--- a/backend/tests/integration/test_annotations.py
+++ b/backend/tests/integration/test_annotations.py
@@ -1,0 +1,108 @@
+"""Integration tests for the annotations router."""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+_MOCK_VALIDATE = {"symbol": "AAPL", "name": "Apple", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+
+
+async def _create_asset(client):
+    with patch("app.services.asset_service.validate_symbol", return_value=_MOCK_VALIDATE):
+        resp = await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
+    assert resp.status_code == 201
+    return resp.json()
+
+
+class TestListAnnotations:
+    async def test_empty_list(self, client):
+        await _create_asset(client)
+        resp = await client.get("/api/assets/AAPL/annotations")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_returns_created_annotations(self, client):
+        await _create_asset(client)
+        await client.post("/api/assets/AAPL/annotations", json={
+            "date": "2025-01-15", "title": "Earnings", "body": "Beat estimates",
+        })
+        resp = await client.get("/api/assets/AAPL/annotations")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "Earnings"
+
+    async def test_404_for_unknown_asset(self, client):
+        resp = await client.get("/api/assets/UNKNOWN/annotations")
+        assert resp.status_code == 404
+
+
+class TestCreateAnnotation:
+    async def test_creates_annotation(self, client):
+        await _create_asset(client)
+        resp = await client.post("/api/assets/AAPL/annotations", json={
+            "date": "2025-01-15", "title": "Earnings", "body": "Q1 beat",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["title"] == "Earnings"
+        assert data["date"] == "2025-01-15"
+        assert data["body"] == "Q1 beat"
+        assert data["color"] == "#3b82f6"  # default
+
+    async def test_custom_color(self, client):
+        await _create_asset(client)
+        resp = await client.post("/api/assets/AAPL/annotations", json={
+            "date": "2025-01-15", "title": "Alert", "color": "#ff0000",
+        })
+        assert resp.status_code == 201
+        assert resp.json()["color"] == "#ff0000"
+
+    async def test_invalid_color_rejected(self, client):
+        await _create_asset(client)
+        resp = await client.post("/api/assets/AAPL/annotations", json={
+            "date": "2025-01-15", "title": "Bad", "color": "red",
+        })
+        assert resp.status_code == 422
+
+    async def test_404_for_unknown_asset(self, client):
+        resp = await client.post("/api/assets/UNKNOWN/annotations", json={
+            "date": "2025-01-15", "title": "Test",
+        })
+        assert resp.status_code == 404
+
+    async def test_body_is_optional(self, client):
+        await _create_asset(client)
+        resp = await client.post("/api/assets/AAPL/annotations", json={
+            "date": "2025-01-15", "title": "No body",
+        })
+        assert resp.status_code == 201
+        assert resp.json()["body"] is None
+
+
+class TestDeleteAnnotation:
+    async def test_deletes_annotation(self, client):
+        await _create_asset(client)
+        create_resp = await client.post("/api/assets/AAPL/annotations", json={
+            "date": "2025-01-15", "title": "To delete",
+        })
+        ann_id = create_resp.json()["id"]
+
+        resp = await client.delete(f"/api/assets/AAPL/annotations/{ann_id}")
+        assert resp.status_code == 204
+
+        # Verify it's gone
+        list_resp = await client.get("/api/assets/AAPL/annotations")
+        assert list_resp.json() == []
+
+    async def test_404_for_nonexistent_annotation(self, client):
+        await _create_asset(client)
+        resp = await client.delete("/api/assets/AAPL/annotations/999")
+        assert resp.status_code == 404
+
+    async def test_404_for_unknown_asset(self, client):
+        resp = await client.delete("/api/assets/UNKNOWN/annotations/1")
+        assert resp.status_code == 404

--- a/backend/tests/integration/test_pseudo_etf_analysis.py
+++ b/backend/tests/integration/test_pseudo_etf_analysis.py
@@ -1,0 +1,127 @@
+"""Integration tests for pseudo-ETF analysis router (performance + constituent indicators)."""
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models import Asset, AssetType, PriceHistory
+from app.models.pseudo_etf import PseudoETF
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def _seed_pseudo_etf(db, name: str = "Tech ETF", n_days: int = 60) -> PseudoETF:
+    """Create a pseudo-ETF with two constituents and price data."""
+    aapl = Asset(symbol="AAPL", name="Apple", type=AssetType.STOCK, currency="USD")
+    msft = Asset(symbol="MSFT", name="Microsoft", type=AssetType.STOCK, currency="USD")
+    db.add_all([aapl, msft])
+    await db.flush()
+
+    etf = PseudoETF(
+        name=name,
+        base_date=date.today() - timedelta(days=n_days),
+        base_value=100.0,
+    )
+    etf.constituents = [aapl, msft]
+    db.add(etf)
+    await db.flush()
+
+    today = date.today()
+    for asset in [aapl, msft]:
+        for i in range(n_days):
+            d = today - timedelta(days=n_days - 1 - i)
+            if d.weekday() >= 5:
+                continue
+            price = 100.0 + i * 0.5
+            db.add(PriceHistory(
+                asset_id=asset.id, date=d,
+                open=price - 0.5, high=price + 1.0,
+                low=price - 1.0, close=price,
+                volume=1_000_000,
+            ))
+    await db.commit()
+    return etf
+
+
+class TestGetPerformance:
+    async def test_returns_performance_data(self, client, db):
+        etf = await _seed_pseudo_etf(db)
+        resp = await client.get(f"/api/pseudo-etfs/{etf.id}/performance")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) > 0
+        assert "date" in data[0]
+        assert "value" in data[0]
+
+    async def test_404_for_nonexistent_etf(self, client):
+        resp = await client.get("/api/pseudo-etfs/999/performance")
+        assert resp.status_code == 404
+
+    async def test_empty_constituents(self, client, db):
+        etf = PseudoETF(
+            name="Empty ETF",
+            base_date=date.today() - timedelta(days=30),
+            base_value=100.0,
+        )
+        db.add(etf)
+        await db.commit()
+
+        resp = await client.get(f"/api/pseudo-etfs/{etf.id}/performance")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_performance_starts_near_base_value(self, client, db):
+        etf = await _seed_pseudo_etf(db)
+        resp = await client.get(f"/api/pseudo-etfs/{etf.id}/performance")
+        data = resp.json()
+        assert data[0]["value"] == pytest.approx(100.0, abs=0.5)
+
+
+class TestGetConstituentIndicators:
+    @patch("app.routers.pseudo_etf_analysis.compute_batch_indicator_snapshots", new_callable=AsyncMock)
+    async def test_returns_indicator_data(self, mock_compute, client, db):
+        etf = await _seed_pseudo_etf(db)
+        mock_compute.return_value = [
+            {"symbol": "AAPL", "currency": "USD", "values": {"rsi": 55.0}},
+            {"symbol": "MSFT", "currency": "USD", "values": {"rsi": 48.0}},
+        ]
+
+        resp = await client.get(f"/api/pseudo-etfs/{etf.id}/constituents/indicators")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        symbols = {d["symbol"] for d in data}
+        assert symbols == {"AAPL", "MSFT"}
+
+    async def test_404_for_nonexistent_etf(self, client):
+        resp = await client.get("/api/pseudo-etfs/999/constituents/indicators")
+        assert resp.status_code == 404
+
+    @patch("app.routers.pseudo_etf_analysis.compute_batch_indicator_snapshots", new_callable=AsyncMock)
+    async def test_empty_constituents(self, mock_compute, client, db):
+        etf = PseudoETF(
+            name="Empty ETF 2",
+            base_date=date.today() - timedelta(days=30),
+            base_value=100.0,
+        )
+        db.add(etf)
+        await db.commit()
+
+        resp = await client.get(f"/api/pseudo-etfs/{etf.id}/constituents/indicators")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @patch("app.routers.pseudo_etf_analysis.compute_batch_indicator_snapshots", new_callable=AsyncMock)
+    async def test_includes_weight_and_name(self, mock_compute, client, db):
+        etf = await _seed_pseudo_etf(db)
+        mock_compute.return_value = [
+            {"symbol": "AAPL", "currency": "USD", "values": {"rsi": 55.0}},
+            {"symbol": "MSFT", "currency": "USD", "values": {"rsi": 48.0}},
+        ]
+
+        resp = await client.get(f"/api/pseudo-etfs/{etf.id}/constituents/indicators")
+        data = resp.json()
+        for item in data:
+            assert "name" in item
+            assert "weight_pct" in item

--- a/backend/tests/integration/test_search.py
+++ b/backend/tests/integration/test_search.py
@@ -1,0 +1,95 @@
+"""Integration tests for the search router."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.symbol_directory import SymbolDirectory
+from tests.conftest import TestSession
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def _seed_symbols(db):
+    """Seed some symbols into the symbol_directory for local search."""
+    symbols = [
+        SymbolDirectory(symbol="AAPL", name="Apple Inc.", exchange="NASDAQ", type="stock"),
+        SymbolDirectory(symbol="AMZN", name="Amazon.com Inc.", exchange="NASDAQ", type="stock"),
+        SymbolDirectory(symbol="AMD", name="Advanced Micro Devices", exchange="NASDAQ", type="stock"),
+        SymbolDirectory(symbol="ABBV", name="AbbVie Inc.", exchange="NYSE", type="stock"),
+        SymbolDirectory(symbol="ABT", name="Abbott Laboratories", exchange="NYSE", type="stock"),
+        SymbolDirectory(symbol="ABNB", name="Airbnb Inc.", exchange="NASDAQ", type="stock"),
+        SymbolDirectory(symbol="ADBE", name="Adobe Inc.", exchange="NASDAQ", type="stock"),
+        SymbolDirectory(symbol="AVGO", name="Broadcom Inc.", exchange="NASDAQ", type="stock"),
+    ]
+    db.add_all(symbols)
+    await db.commit()
+
+
+class TestSearchSymbols:
+    async def test_search_requires_query(self, client):
+        resp = await client.get("/api/search")
+        assert resp.status_code == 422
+
+    async def test_empty_query_rejected(self, client):
+        resp = await client.get("/api/search", params={"q": ""})
+        assert resp.status_code == 422
+
+    async def test_local_source(self, client, db):
+        await _seed_symbols(db)
+        resp = await client.get("/api/search", params={"q": "aapl", "source": "local"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+        assert data[0]["symbol"] == "AAPL"
+
+    async def test_local_search_partial_match(self, client, db):
+        await _seed_symbols(db)
+        resp = await client.get("/api/search", params={"q": "apple", "source": "local"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(d["symbol"] == "AAPL" for d in data)
+
+    @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
+    async def test_yahoo_source(self, mock_yahoo, client, db):
+        mock_yahoo.return_value = {"quotes": [
+            {"symbol": "TSLA", "shortname": "Tesla Inc.", "exchDisp": "NASDAQ", "quoteType": "EQUITY"},
+        ]}
+        resp = await client.get("/api/search", params={"q": "tesla", "source": "yahoo"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+        assert data[0]["symbol"] == "TSLA"
+        assert data[0]["type"] == "stock"
+
+    @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
+    async def test_all_source_uses_local_first(self, mock_yahoo, client, db):
+        await _seed_symbols(db)
+        # With 8 local results for "a", should not call Yahoo
+        resp = await client.get("/api/search", params={"q": "a", "source": "all"})
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+
+    @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
+    async def test_all_source_falls_back_to_yahoo(self, mock_yahoo, client, db):
+        """With fewer than 8 local results, should query Yahoo."""
+        mock_yahoo.return_value = {"quotes": [
+            {"symbol": "XYZQ", "shortname": "XYZ Corp", "exchDisp": "NYSE", "quoteType": "EQUITY"},
+        ]}
+        resp = await client.get("/api/search", params={"q": "xyzq", "source": "all"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(d["symbol"] == "XYZQ" for d in data)
+
+    @patch("app.services.search_service.yahoo_search", new_callable=AsyncMock)
+    async def test_yahoo_filters_non_equity_etf(self, mock_yahoo, client):
+        mock_yahoo.return_value = {"quotes": [
+            {"symbol": "BTCUSD", "shortname": "Bitcoin", "exchDisp": "CCC", "quoteType": "CRYPTOCURRENCY"},
+            {"symbol": "AAPL", "shortname": "Apple", "exchDisp": "NASDAQ", "quoteType": "EQUITY"},
+        ]}
+        resp = await client.get("/api/search", params={"q": "btc", "source": "yahoo"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # CRYPTOCURRENCY should be filtered out
+        symbols = [d["symbol"] for d in data]
+        assert "BTCUSD" not in symbols

--- a/backend/tests/integration/test_symbol_sources.py
+++ b/backend/tests/integration/test_symbol_sources.py
@@ -1,0 +1,133 @@
+"""Integration tests for the symbol sources router."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.symbol_source import SymbolSource
+from app.models.symbol_directory import SymbolDirectory
+from tests.conftest import TestSession
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def _create_source(client, name: str = "Test Source", provider_type: str = "euronext") -> dict:
+    resp = await client.post("/api/symbol-sources", json={
+        "name": name,
+        "provider_type": provider_type,
+        "config": {"markets": ["amsterdam"]},
+    })
+    assert resp.status_code == 201
+    return resp.json()
+
+
+class TestListSources:
+    async def test_empty_list(self, client):
+        resp = await client.get("/api/symbol-sources")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_returns_created_sources(self, client):
+        await _create_source(client, name="Euronext")
+        resp = await client.get("/api/symbol-sources")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Euronext"
+        assert data[0]["provider_type"] == "euronext"
+
+
+class TestListProviders:
+    async def test_returns_available_providers(self, client):
+        resp = await client.get("/api/symbol-sources/providers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "euronext" in data
+        assert "xetra" in data
+        assert "key" in data["euronext"]
+        assert "markets" in data["euronext"]
+
+
+class TestCreateSource:
+    async def test_creates_source(self, client):
+        data = await _create_source(client)
+        assert data["name"] == "Test Source"
+        assert data["provider_type"] == "euronext"
+        assert data["enabled"] is True
+        assert data["symbol_count"] == 0
+
+    async def test_invalid_provider_type(self, client):
+        resp = await client.post("/api/symbol-sources", json={
+            "name": "Bad", "provider_type": "nonexistent", "config": {},
+        })
+        assert resp.status_code == 400
+        assert "Unknown provider" in resp.json()["detail"]
+
+
+class TestUpdateSource:
+    async def test_update_name(self, client):
+        source = await _create_source(client)
+        resp = await client.patch(f"/api/symbol-sources/{source['id']}", json={"name": "Renamed"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Renamed"
+
+    async def test_disable_source(self, client):
+        source = await _create_source(client)
+        resp = await client.patch(f"/api/symbol-sources/{source['id']}", json={"enabled": False})
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is False
+
+    async def test_update_config(self, client):
+        source = await _create_source(client)
+        new_config = {"markets": ["amsterdam", "brussels"]}
+        resp = await client.patch(f"/api/symbol-sources/{source['id']}", json={"config": new_config})
+        assert resp.status_code == 200
+        assert resp.json()["config"] == new_config
+
+    async def test_404_for_nonexistent(self, client):
+        resp = await client.patch("/api/symbol-sources/999", json={"name": "X"})
+        assert resp.status_code == 404
+
+
+class TestTriggerSync:
+    async def test_trigger_sync(self, client):
+        source = await _create_source(client)
+        resp = await client.post(f"/api/symbol-sources/{source['id']}/sync")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source_id"] == source["id"]
+        assert data["message"] == "Sync started in background"
+
+    async def test_404_for_nonexistent(self, client):
+        resp = await client.post("/api/symbol-sources/999/sync")
+        assert resp.status_code == 404
+
+
+class TestDeleteSource:
+    async def test_deletes_source(self, client):
+        source = await _create_source(client)
+        resp = await client.delete(f"/api/symbol-sources/{source['id']}")
+        assert resp.status_code == 204
+
+        # Verify it's gone
+        list_resp = await client.get("/api/symbol-sources")
+        assert list_resp.json() == []
+
+    async def test_404_for_nonexistent(self, client):
+        resp = await client.delete("/api/symbol-sources/999")
+        assert resp.status_code == 404
+
+    async def test_nullifies_symbol_directory_refs(self, client, db):
+        """Deleting a source should set source_id to NULL on related symbols."""
+        source = await _create_source(client)
+        source_id = source["id"]
+
+        # Seed a symbol directory entry linked to this source
+        sym = SymbolDirectory(symbol="TEST.XX", name="Test Corp", source_id=source_id)
+        db.add(sym)
+        await db.commit()
+
+        await client.delete(f"/api/symbol-sources/{source_id}")
+
+        await db.refresh(sym)
+        assert sym.source_id is None

--- a/backend/tests/services/test_compute_group.py
+++ b/backend/tests/services/test_compute_group.py
@@ -1,0 +1,178 @@
+"""Tests for batch indicator computation and sparkline data (group.py)."""
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.compute.group import (
+    _indicator_cache,
+    compute_and_cache_indicators,
+    get_batch_sparklines,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _make_asset_row(id: int, symbol: str):
+    """Create a mock asset row with .id and .symbol attributes."""
+    row = MagicMock()
+    row.id = id
+    row.symbol = symbol
+    return row
+
+
+def _make_price(asset_id: int, d: date, close: float):
+    """Create a mock PriceHistory object."""
+    p = MagicMock()
+    p.asset_id = asset_id
+    p.date = d
+    p.close = close
+    p.open = close - 0.5
+    p.high = close + 1.0
+    p.low = close - 1.0
+    p.volume = 1_000_000
+    return p
+
+
+class TestGetBatchSparklines:
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_returns_sparklines_for_group(self, mock_asset_repo_cls, mock_price_repo_cls, db):
+        rows = [_make_asset_row(1, "AAPL"), _make_asset_row(2, "MSFT")]
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=rows)
+
+        d1, d2 = date.today() - timedelta(days=2), date.today() - timedelta(days=1)
+        prices = [
+            _make_price(1, d1, 150.0), _make_price(1, d2, 152.0),
+            _make_price(2, d1, 400.0), _make_price(2, d2, 405.0),
+        ]
+        mock_price_repo_cls.return_value.list_by_assets_since = AsyncMock(return_value=prices)
+
+        result = await get_batch_sparklines(db, period="3mo", group_id=1)
+
+        assert "AAPL" in result
+        assert "MSFT" in result
+        assert len(result["AAPL"]) == 2
+        assert result["AAPL"][0]["close"] == 150.0
+
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    @patch("app.services.compute.group.GroupRepository")
+    async def test_uses_default_group_when_no_id(self, mock_group_repo_cls, mock_asset_repo_cls, mock_price_repo_cls, db):
+        default_group = MagicMock()
+        default_group.id = 1
+        mock_group_repo_cls.return_value.get_default = AsyncMock(return_value=default_group)
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=[])
+
+        result = await get_batch_sparklines(db, period="3mo", group_id=None)
+        assert result == {}
+
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_empty_assets_returns_empty(self, mock_asset_repo_cls, mock_price_repo_cls, db):
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=[])
+
+        result = await get_batch_sparklines(db, period="3mo", group_id=1)
+        assert result == {}
+
+
+class TestComputeAndCacheIndicators:
+    @patch("app.services.compute.group.batch_fetch_fundamentals", new_callable=AsyncMock)
+    @patch("app.services.compute.group.build_indicator_snapshot")
+    @patch("app.services.compute.group.compute_indicators")
+    @patch("app.services.compute.group.prices_to_df")
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_computes_snapshots(
+        self, mock_asset_repo_cls, mock_price_repo_cls, mock_prices_to_df,
+        mock_compute_ind, mock_build_snap, mock_fetch_fund, db,
+    ):
+        _indicator_cache._data.clear()
+
+        rows = [_make_asset_row(1, "AAPL")]
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=rows)
+
+        today = date.today()
+        prices = [_make_price(1, today - timedelta(days=i), 150.0 + i) for i in range(30)]
+        mock_price_repo_cls.return_value.list_by_assets_since = AsyncMock(return_value=prices)
+        mock_price_repo_cls.return_value.get_latest_date = AsyncMock(return_value=today)
+
+        mock_prices_to_df.return_value = MagicMock()
+        mock_compute_ind.return_value = MagicMock()
+        mock_build_snap.return_value = {"values": {"rsi": 55.0}}
+        mock_fetch_fund.return_value = {"AAPL": {"forward_pe": 28.5}}
+
+        result = await compute_and_cache_indicators(db, group_id=1)
+
+        assert "AAPL" in result
+        assert result["AAPL"]["values"]["rsi"] == 55.0
+        assert result["AAPL"]["values"]["forward_pe"] == 28.5
+
+        _indicator_cache._data.clear()
+
+    @patch("app.services.compute.group.batch_fetch_fundamentals", new_callable=AsyncMock)
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_skips_assets_with_too_few_prices(
+        self, mock_asset_repo_cls, mock_price_repo_cls, mock_fetch_fund, db,
+    ):
+        _indicator_cache._data.clear()
+
+        rows = [_make_asset_row(1, "NEW")]
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=rows)
+
+        # Only 10 prices — less than 26 needed for MACD
+        prices = [_make_price(1, date.today() - timedelta(days=i), 50.0) for i in range(10)]
+        mock_price_repo_cls.return_value.list_by_assets_since = AsyncMock(return_value=prices)
+        mock_price_repo_cls.return_value.get_latest_date = AsyncMock(return_value=date.today())
+        mock_fetch_fund.return_value = {}
+
+        result = await compute_and_cache_indicators(db, group_id=1)
+
+        assert result["NEW"] == {"values": {}}
+
+        _indicator_cache._data.clear()
+
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_empty_assets_returns_empty(self, mock_asset_repo_cls, mock_price_repo_cls, db):
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=[])
+
+        result = await compute_and_cache_indicators(db, group_id=1)
+        assert result == {}
+
+    @patch("app.services.compute.group.batch_fetch_fundamentals", new_callable=AsyncMock)
+    @patch("app.services.compute.group.build_indicator_snapshot")
+    @patch("app.services.compute.group.compute_indicators")
+    @patch("app.services.compute.group.prices_to_df")
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_cache_hit_skips_computation(
+        self, mock_asset_repo_cls, mock_price_repo_cls, mock_prices_to_df,
+        mock_compute_ind, mock_build_snap, mock_fetch_fund, db,
+    ):
+        _indicator_cache._data.clear()
+
+        rows = [_make_asset_row(1, "AAPL")]
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=rows)
+
+        today = date.today()
+        prices = [_make_price(1, today - timedelta(days=i), 150.0 + i) for i in range(30)]
+        mock_price_repo_cls.return_value.list_by_assets_since = AsyncMock(return_value=prices)
+        mock_price_repo_cls.return_value.get_latest_date = AsyncMock(return_value=today)
+
+        mock_prices_to_df.return_value = MagicMock()
+        mock_compute_ind.return_value = MagicMock()
+        mock_build_snap.return_value = {"values": {"rsi": 55.0}}
+        mock_fetch_fund.return_value = {}
+
+        # First call populates cache
+        await compute_and_cache_indicators(db, group_id=1)
+        call_count_1 = mock_compute_ind.call_count
+
+        # Second call should use cache
+        await compute_and_cache_indicators(db, group_id=1)
+        assert mock_compute_ind.call_count == call_count_1  # No additional calls
+
+        _indicator_cache._data.clear()

--- a/backend/tests/services/test_compute_portfolio.py
+++ b/backend/tests/services/test_compute_portfolio.py
@@ -1,0 +1,160 @@
+"""Tests for portfolio index computation and performer ranking."""
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models import AssetType
+from app.services.compute.portfolio import (
+    _MIN_ENTRY_PRICE,
+    compute_performers,
+    compute_portfolio_index,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestComputePortfolioIndex:
+    @patch("app.services.compute.portfolio.calculate_performance", new_callable=AsyncMock)
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_returns_index_data(self, mock_asset_repo_cls, mock_calc_perf, db):
+        mock_asset_repo_cls.return_value.list_in_any_group_ids = AsyncMock(return_value=[1, 2])
+        mock_calc_perf.return_value = [
+            {"date": "2025-01-01", "value": 1000.0},
+            {"date": "2025-06-01", "value": 1100.0},
+        ]
+
+        result = await compute_portfolio_index(db, period="1y")
+
+        assert result["dates"] == ["2025-01-01", "2025-06-01"]
+        assert result["values"] == [1000.0, 1100.0]
+        assert result["current"] == 1100.0
+        assert result["change"] == 100.0
+        assert result["change_pct"] == 10.0
+
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_no_assets_returns_empty(self, mock_asset_repo_cls, db):
+        mock_asset_repo_cls.return_value.list_in_any_group_ids = AsyncMock(return_value=[])
+
+        result = await compute_portfolio_index(db, period="1y")
+        assert result["dates"] == []
+        assert result["current"] == 0
+
+    @patch("app.services.compute.portfolio.calculate_performance", new_callable=AsyncMock)
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_no_points_returns_empty(self, mock_asset_repo_cls, mock_calc_perf, db):
+        mock_asset_repo_cls.return_value.list_in_any_group_ids = AsyncMock(return_value=[1])
+        mock_calc_perf.return_value = []
+
+        result = await compute_portfolio_index(db, period="1y")
+        assert result["current"] == 0
+
+    @patch("app.services.compute.portfolio.calculate_performance", new_callable=AsyncMock)
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_passes_dynamic_entry_and_min_price(self, mock_asset_repo_cls, mock_calc_perf, db):
+        mock_asset_repo_cls.return_value.list_in_any_group_ids = AsyncMock(return_value=[1])
+        mock_calc_perf.return_value = [{"date": "2025-01-01", "value": 1000.0}]
+
+        await compute_portfolio_index(db, period="1y")
+
+        call_kwargs = mock_calc_perf.call_args
+        assert call_kwargs.kwargs.get("dynamic_entry") is True or call_kwargs[1].get("dynamic_entry") is True
+
+    @patch("app.services.compute.portfolio.calculate_performance", new_callable=AsyncMock)
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_negative_change(self, mock_asset_repo_cls, mock_calc_perf, db):
+        mock_asset_repo_cls.return_value.list_in_any_group_ids = AsyncMock(return_value=[1])
+        mock_calc_perf.return_value = [
+            {"date": "2025-01-01", "value": 1000.0},
+            {"date": "2025-06-01", "value": 900.0},
+        ]
+
+        result = await compute_portfolio_index(db, period="1y")
+        assert result["change"] == -100.0
+        assert result["change_pct"] == -10.0
+
+
+def _make_asset(id: int, symbol: str, name: str, type_val: AssetType = AssetType.STOCK):
+    asset = MagicMock()
+    asset.id = id
+    asset.symbol = symbol
+    asset.name = name
+    asset.type = type_val
+    return asset
+
+
+class TestComputePerformers:
+    @patch("app.services.compute.portfolio.PriceRepository")
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_returns_ranked_performers(self, mock_asset_repo_cls, mock_price_repo_cls, db):
+        assets = [
+            _make_asset(1, "AAPL", "Apple"),
+            _make_asset(2, "MSFT", "Microsoft"),
+        ]
+        mock_asset_repo_cls.return_value.list_in_any_group = AsyncMock(return_value=assets)
+
+        today = date.today()
+        start = today - timedelta(days=365)
+        mock_price_repo_cls.return_value.get_first_dates = AsyncMock(
+            return_value={1: start, 2: start}
+        )
+        mock_price_repo_cls.return_value.get_last_dates = AsyncMock(
+            return_value={1: today, 2: today}
+        )
+        mock_price_repo_cls.return_value.get_prices_at_dates = AsyncMock(
+            return_value={
+                (1, start): 100.0, (1, today): 150.0,
+                (2, start): 200.0, (2, today): 280.0,
+            }
+        )
+
+        result = await compute_performers(db, period="1y")
+
+        assert len(result) == 2
+        # MSFT (40%) should rank above AAPL (50%) — wait, AAPL is 50% and MSFT is 40%
+        assert result[0]["symbol"] == "AAPL"
+        assert result[0]["change_pct"] == 50.0
+        assert result[1]["symbol"] == "MSFT"
+        assert result[1]["change_pct"] == 40.0
+
+    @patch("app.services.compute.portfolio.PriceRepository")
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_no_assets_returns_empty(self, mock_asset_repo_cls, mock_price_repo_cls, db):
+        mock_asset_repo_cls.return_value.list_in_any_group = AsyncMock(return_value=[])
+        result = await compute_performers(db, period="1y")
+        assert result == []
+
+    @patch("app.services.compute.portfolio.PriceRepository")
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_skips_asset_with_same_first_last_date(self, mock_asset_repo_cls, mock_price_repo_cls, db):
+        assets = [_make_asset(1, "NEW", "New Stock")]
+        mock_asset_repo_cls.return_value.list_in_any_group = AsyncMock(return_value=assets)
+
+        today = date.today()
+        mock_price_repo_cls.return_value.get_first_dates = AsyncMock(return_value={1: today})
+        mock_price_repo_cls.return_value.get_last_dates = AsyncMock(return_value={1: today})
+        mock_price_repo_cls.return_value.get_prices_at_dates = AsyncMock(return_value={(1, today): 100.0})
+
+        result = await compute_performers(db, period="1y")
+        assert result == []
+
+    @patch("app.services.compute.portfolio.PriceRepository")
+    @patch("app.services.compute.portfolio.AssetRepository")
+    async def test_skips_asset_with_zero_first_close(self, mock_asset_repo_cls, mock_price_repo_cls, db):
+        assets = [_make_asset(1, "AAPL", "Apple")]
+        mock_asset_repo_cls.return_value.list_in_any_group = AsyncMock(return_value=assets)
+
+        today = date.today()
+        start = today - timedelta(days=365)
+        mock_price_repo_cls.return_value.get_first_dates = AsyncMock(return_value={1: start})
+        mock_price_repo_cls.return_value.get_last_dates = AsyncMock(return_value={1: today})
+        mock_price_repo_cls.return_value.get_prices_at_dates = AsyncMock(
+            return_value={(1, start): 0, (1, today): 50.0}
+        )
+
+        result = await compute_performers(db, period="1y")
+        assert result == []
+
+    def test_min_entry_price_is_10(self):
+        assert _MIN_ENTRY_PRICE == 10.0

--- a/backend/tests/services/test_compute_utils.py
+++ b/backend/tests/services/test_compute_utils.py
@@ -1,0 +1,71 @@
+"""Tests for shared compute utility functions."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from app.services.compute.utils import prices_to_df
+
+
+def _make_price(d: date, open_: float, high: float, low: float, close: float, volume: int):
+    """Create a mock PriceHistory object."""
+    p = MagicMock()
+    p.date = d
+    p.open = open_
+    p.high = high
+    p.low = low
+    p.close = close
+    p.volume = volume
+    return p
+
+
+class TestPricesToDf:
+    def test_converts_to_dataframe(self):
+        prices = [
+            _make_price(date(2025, 1, 2), 100.0, 105.0, 99.0, 102.0, 1_000_000),
+            _make_price(date(2025, 1, 3), 102.0, 106.0, 101.0, 104.0, 1_200_000),
+        ]
+        df = prices_to_df(prices)
+
+        assert isinstance(df, pd.DataFrame)
+        assert df.index.name == "date"
+        assert list(df.columns) == ["open", "high", "low", "close", "volume"]
+        assert len(df) == 2
+
+    def test_values_correct(self):
+        prices = [_make_price(date(2025, 1, 2), 100.0, 105.0, 99.0, 102.0, 1_000_000)]
+        df = prices_to_df(prices)
+
+        assert df.iloc[0]["open"] == 100.0
+        assert df.iloc[0]["high"] == 105.0
+        assert df.iloc[0]["low"] == 99.0
+        assert df.iloc[0]["close"] == 102.0
+        assert df.iloc[0]["volume"] == 1_000_000
+
+    def test_date_as_index(self):
+        prices = [
+            _make_price(date(2025, 1, 2), 100.0, 105.0, 99.0, 102.0, 1_000_000),
+            _make_price(date(2025, 1, 3), 102.0, 106.0, 101.0, 104.0, 1_200_000),
+        ]
+        df = prices_to_df(prices)
+
+        assert df.index[0] == date(2025, 1, 2)
+        assert df.index[1] == date(2025, 1, 3)
+
+    def test_empty_prices(self):
+        """Empty input raises KeyError due to missing 'date' column in set_index."""
+        with pytest.raises(KeyError):
+            prices_to_df([])
+
+    def test_preserves_order(self):
+        prices = [
+            _make_price(date(2025, 1, 5), 110.0, 115.0, 109.0, 112.0, 800_000),
+            _make_price(date(2025, 1, 2), 100.0, 105.0, 99.0, 102.0, 1_000_000),
+        ]
+        df = prices_to_df(prices)
+
+        # Order should match input, not be sorted by date
+        assert df.index[0] == date(2025, 1, 5)
+        assert df.index[1] == date(2025, 1, 2)

--- a/backend/tests/services/test_entity_lookups.py
+++ b/backend/tests/services/test_entity_lookups.py
@@ -1,0 +1,89 @@
+"""Tests for entity lookup helpers (find_asset, get_asset, get_group, get_pseudo_etf)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.entity_lookups import find_asset, get_asset, get_group, get_pseudo_etf
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestFindAsset:
+    @patch("app.services.entity_lookups.AssetRepository")
+    async def test_returns_asset_when_found(self, mock_repo_cls, db):
+        asset = MagicMock()
+        asset.symbol = "AAPL"
+        mock_repo_cls.return_value.find_by_symbol = AsyncMock(return_value=asset)
+
+        result = await find_asset("AAPL", db)
+        assert result.symbol == "AAPL"
+
+    @patch("app.services.entity_lookups.AssetRepository")
+    async def test_returns_none_when_not_found(self, mock_repo_cls, db):
+        mock_repo_cls.return_value.find_by_symbol = AsyncMock(return_value=None)
+
+        result = await find_asset("UNKNOWN", db)
+        assert result is None
+
+
+class TestGetAsset:
+    @patch("app.services.entity_lookups.AssetRepository")
+    async def test_returns_asset_when_found(self, mock_repo_cls, db):
+        asset = MagicMock()
+        asset.symbol = "AAPL"
+        mock_repo_cls.return_value.find_by_symbol = AsyncMock(return_value=asset)
+
+        result = await get_asset("AAPL", db)
+        assert result.symbol == "AAPL"
+
+    @patch("app.services.entity_lookups.AssetRepository")
+    async def test_raises_404_when_not_found(self, mock_repo_cls, db):
+        mock_repo_cls.return_value.find_by_symbol = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_asset("UNKNOWN", db)
+        assert exc_info.value.status_code == 404
+        assert "UNKNOWN" in str(exc_info.value.detail)
+
+
+class TestGetPseudoEtf:
+    @patch("app.services.entity_lookups.PseudoEtfRepository")
+    async def test_returns_etf_when_found(self, mock_repo_cls, db):
+        etf = MagicMock()
+        etf.id = 1
+        mock_repo_cls.return_value.get_by_id = AsyncMock(return_value=etf)
+
+        result = await get_pseudo_etf(1, db)
+        assert result.id == 1
+
+    @patch("app.services.entity_lookups.PseudoEtfRepository")
+    async def test_raises_404_when_not_found(self, mock_repo_cls, db):
+        mock_repo_cls.return_value.get_by_id = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_pseudo_etf(999, db)
+        assert exc_info.value.status_code == 404
+        assert "Pseudo-ETF" in str(exc_info.value.detail)
+
+
+class TestGetGroup:
+    @patch("app.services.entity_lookups.GroupRepository")
+    async def test_returns_group_when_found(self, mock_repo_cls, db):
+        group = MagicMock()
+        group.id = 1
+        group.name = "Tech"
+        mock_repo_cls.return_value.get_by_id = AsyncMock(return_value=group)
+
+        result = await get_group(1, db)
+        assert result.name == "Tech"
+
+    @patch("app.services.entity_lookups.GroupRepository")
+    async def test_raises_404_when_not_found(self, mock_repo_cls, db):
+        mock_repo_cls.return_value.get_by_id = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_group(999, db)
+        assert exc_info.value.status_code == 404
+        assert "Group" in str(exc_info.value.detail)

--- a/backend/tests/services/test_symbol_sync_service.py
+++ b/backend/tests/services/test_symbol_sync_service.py
@@ -1,0 +1,156 @@
+"""Tests for symbol sync service (provider execution and symbol_directory upserts)."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from app.models.symbol_source import SymbolSource
+from app.services.symbol_providers.base import SymbolEntry
+from app.services.symbol_sync_service import (
+    nullify_source_symbols,
+    sync_all_enabled,
+    sync_source,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _make_source(id: int = 1, name: str = "Test", provider_type: str = "euronext") -> SymbolSource:
+    """Create a SymbolSource model instance."""
+    source = SymbolSource(
+        id=id, name=name, provider_type=provider_type,
+        enabled=True, config={}, symbol_count=0,
+    )
+    return source
+
+
+class TestSyncSource:
+    async def test_raises_on_missing_source(self, db):
+        with pytest.raises(ValueError, match="Symbol source 999 not found"):
+            await sync_source(999, db)
+
+    @patch("app.services.symbol_sync_service.get_provider")
+    async def test_returns_zero_when_provider_returns_empty(self, mock_get_provider, db):
+        source = _make_source()
+        db.add(source)
+        await db.commit()
+
+        provider = MagicMock()
+        provider.fetch_symbols = AsyncMock(return_value=[])
+        mock_get_provider.return_value = provider
+
+        count = await sync_source(source.id, db)
+        assert count == 0
+
+    @patch("app.services.symbol_sync_service.get_provider")
+    async def test_syncs_symbols_and_updates_stats(self, mock_get_provider, db):
+        source = _make_source()
+        db.add(source)
+        await db.commit()
+
+        entries = [
+            SymbolEntry(symbol="AAPL", name="Apple", exchange="NASDAQ", currency="USD", type="stock"),
+            SymbolEntry(symbol="MSFT", name="Microsoft", exchange="NASDAQ", currency="USD", type="stock"),
+        ]
+        provider = MagicMock()
+        provider.fetch_symbols = AsyncMock(return_value=entries)
+        mock_get_provider.return_value = provider
+
+        # Mock db.execute to avoid PG-specific ON CONFLICT syntax
+        original_execute = db.execute
+        async def _mock_execute(stmt, *args, **kwargs):
+            from sqlalchemy.dialects.postgresql import Insert
+            if isinstance(stmt, Insert):
+                return MagicMock()
+            return await original_execute(stmt, *args, **kwargs)
+
+        with patch.object(db, "execute", side_effect=_mock_execute):
+            count = await sync_source(source.id, db)
+
+        assert count == 2
+
+    @patch("app.services.symbol_sync_service.get_provider")
+    async def test_updates_last_synced_at(self, mock_get_provider, db):
+        source = _make_source()
+        db.add(source)
+        await db.commit()
+
+        entries = [SymbolEntry(symbol="AAPL", name="Apple", exchange="NASDAQ", currency="USD", type="stock")]
+        provider = MagicMock()
+        provider.fetch_symbols = AsyncMock(return_value=entries)
+        mock_get_provider.return_value = provider
+
+        original_execute = db.execute
+        async def _mock_execute(stmt, *args, **kwargs):
+            from sqlalchemy.dialects.postgresql import Insert
+            if isinstance(stmt, Insert):
+                return MagicMock()
+            return await original_execute(stmt, *args, **kwargs)
+
+        with patch.object(db, "execute", side_effect=_mock_execute):
+            await sync_source(source.id, db)
+
+        await db.refresh(source)
+        assert source.last_synced_at is not None
+        assert source.symbol_count == 1
+
+
+class TestSyncAllEnabled:
+    @patch("app.services.symbol_sync_service.sync_source", new_callable=AsyncMock)
+    async def test_syncs_all_enabled_sources(self, mock_sync_source, db):
+        s1 = _make_source(id=None, name="Source1")
+        s2 = _make_source(id=None, name="Source2")
+        db.add_all([s1, s2])
+        await db.commit()
+
+        mock_sync_source.side_effect = lambda sid, session: 10
+
+        counts = await sync_all_enabled(db)
+        assert len(counts) == 2
+        assert all(v == 10 for v in counts.values())
+
+    @patch("app.services.symbol_sync_service.sync_source", new_callable=AsyncMock)
+    async def test_disabled_sources_skipped(self, mock_sync_source, db):
+        s1 = _make_source(id=None, name="Enabled")
+        s2 = _make_source(id=None, name="Disabled")
+        s2.enabled = False
+        db.add_all([s1, s2])
+        await db.commit()
+
+        mock_sync_source.return_value = 5
+
+        counts = await sync_all_enabled(db)
+        assert len(counts) == 1
+
+    @patch("app.services.symbol_sync_service.sync_source", new_callable=AsyncMock)
+    async def test_failed_source_returns_zero(self, mock_sync_source, db):
+        source = _make_source(id=None, name="Failing")
+        db.add(source)
+        await db.commit()
+
+        mock_sync_source.side_effect = Exception("Provider error")
+
+        counts = await sync_all_enabled(db)
+        assert list(counts.values()) == [0]
+
+
+class TestNullifySourceSymbols:
+    async def test_nullifies_source_id(self, db):
+        """Test that nullify works at the SQL level (uses SQLite for test)."""
+        # Create a SymbolSource first since we need a valid FK
+        source = _make_source(id=None)
+        db.add(source)
+        await db.commit()
+
+        from app.models.symbol_directory import SymbolDirectory
+        sym = SymbolDirectory(symbol="AAPL", name="Apple", source_id=source.id)
+        db.add(sym)
+        await db.commit()
+
+        await nullify_source_symbols(source.id, db)
+        await db.commit()
+
+        await db.refresh(sym)
+        assert sym.source_id is None

--- a/backend/tests/services/test_yahoo_fundamentals.py
+++ b/backend/tests/services/test_yahoo_fundamentals.py
@@ -1,0 +1,163 @@
+"""Tests for Yahoo Finance fundamental metrics fetching."""
+
+import math
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.yahoo.fundamentals import (
+    FUNDAMENTAL_FIELDS,
+    _batch_fetch_fundamentals_sync,
+    _safe_float,
+    batch_fetch_fundamentals,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestSafeFloat:
+    def test_none_returns_none(self):
+        assert _safe_float(None) is None
+
+    def test_nan_returns_none(self):
+        assert _safe_float(float("nan")) is None
+
+    def test_inf_returns_none(self):
+        assert _safe_float(float("inf")) is None
+
+    def test_neg_inf_returns_none(self):
+        assert _safe_float(float("-inf")) is None
+
+    def test_valid_float(self):
+        assert _safe_float(15.678, multiplier=1, decimals=2) == 15.68
+
+    def test_multiplier_applied(self):
+        assert _safe_float(0.15, multiplier=100, decimals=1) == 15.0
+
+    def test_string_number_converted(self):
+        assert _safe_float("42.5", multiplier=1, decimals=1) == 42.5
+
+    def test_invalid_string_returns_none(self):
+        assert _safe_float("not_a_number") is None
+
+    def test_zero_value(self):
+        assert _safe_float(0.0) == 0.0
+
+    def test_negative_value(self):
+        assert _safe_float(-5.5, multiplier=1, decimals=1) == -5.5
+
+
+class TestFundamentalFields:
+    def test_expected_fields_exist(self):
+        expected = {"forward_pe", "peg_ratio", "roe", "ev_ebitda", "revenue_growth"}
+        assert set(FUNDAMENTAL_FIELDS.keys()) == expected
+
+    def test_roe_has_100x_multiplier(self):
+        _, _, _, multiplier = FUNDAMENTAL_FIELDS["roe"]
+        assert multiplier == 100
+
+    def test_revenue_growth_has_100x_multiplier(self):
+        _, _, _, multiplier = FUNDAMENTAL_FIELDS["revenue_growth"]
+        assert multiplier == 100
+
+    def test_forward_pe_has_1x_multiplier(self):
+        _, _, _, multiplier = FUNDAMENTAL_FIELDS["forward_pe"]
+        assert multiplier == 1
+
+
+class TestBatchFetchFundamentalsSync:
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    def test_empty_symbols(self, mock_ticker_cls):
+        assert _batch_fetch_fundamentals_sync([]) == {}
+
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    def test_returns_all_fields(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.key_stats = {
+            "AAPL": {"forwardPE": 28.5, "pegRatio": 2.1, "enterpriseToEbitda": 22.3}
+        }
+        ticker.financial_data = {
+            "AAPL": {"returnOnEquity": 0.157, "revenueGrowth": 0.089}
+        }
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_fundamentals_sync(["AAPL"])
+
+        assert "AAPL" in result
+        data = result["AAPL"]
+        assert data["forward_pe"] == 28.5
+        assert data["peg_ratio"] == 2.1
+        assert data["roe"] == 15.7
+        assert data["ev_ebitda"] == 22.3
+        assert data["revenue_growth"] == 8.9
+
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    def test_missing_fields_are_none(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.key_stats = {"AAPL": {"forwardPE": 28.5}}
+        ticker.financial_data = {"AAPL": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_fundamentals_sync(["AAPL"])
+        data = result["AAPL"]
+        assert data["forward_pe"] == 28.5
+        assert data["roe"] is None
+        assert data["revenue_growth"] is None
+
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    def test_string_error_for_symbol(self, mock_ticker_cls):
+        """Yahoo returns string errors for symbols with no data."""
+        ticker = MagicMock()
+        ticker.key_stats = {"AAPL": "No fundamentals data found"}
+        ticker.financial_data = {"AAPL": "No fundamentals data found"}
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_fundamentals_sync(["AAPL"])
+        data = result["AAPL"]
+        assert all(v is None for v in data.values())
+
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    def test_nan_values_filtered(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.key_stats = {"AAPL": {"forwardPE": float("nan"), "pegRatio": float("inf")}}
+        ticker.financial_data = {"AAPL": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_fundamentals_sync(["AAPL"])
+        assert result["AAPL"]["forward_pe"] is None
+        assert result["AAPL"]["peg_ratio"] is None
+
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    def test_multiple_symbols(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.key_stats = {
+            "AAPL": {"forwardPE": 28.5, "pegRatio": 2.1, "enterpriseToEbitda": 22.3},
+            "MSFT": {"forwardPE": 32.0, "pegRatio": 1.8, "enterpriseToEbitda": 25.0},
+        }
+        ticker.financial_data = {
+            "AAPL": {"returnOnEquity": 0.15, "revenueGrowth": 0.08},
+            "MSFT": {"returnOnEquity": 0.38, "revenueGrowth": 0.15},
+        }
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_fundamentals_sync(["AAPL", "MSFT"])
+        assert len(result) == 2
+        assert result["MSFT"]["roe"] == 38.0
+        assert result["MSFT"]["revenue_growth"] == 15.0
+
+
+class TestBatchFetchFundamentalsAsync:
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    async def test_async_wrapper(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.key_stats = {"AAPL": {"forwardPE": 28.5}}
+        ticker.financial_data = {"AAPL": {"returnOnEquity": 0.15}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await batch_fetch_fundamentals(["AAPL"])
+        assert result["AAPL"]["forward_pe"] == 28.5
+
+    @patch("app.services.yahoo.fundamentals.Ticker")
+    async def test_empty_returns_empty(self, mock_ticker_cls):
+        result = await batch_fetch_fundamentals([])
+        assert result == {}

--- a/backend/tests/services/test_yahoo_history.py
+++ b/backend/tests/services/test_yahoo_history.py
@@ -1,0 +1,265 @@
+"""Tests for Yahoo Finance OHLCV history fetching."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from app.services.yahoo.history import (
+    PERIOD_MAP,
+    _batch_fetch_history_sync,
+    fetch_history,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _make_ohlcv_df(n: int = 5, base: float = 100.0) -> pd.DataFrame:
+    """Create a simple OHLCV DataFrame like Yahoo returns."""
+    dates = pd.bdate_range(end=date.today(), periods=n)
+    return pd.DataFrame(
+        {
+            "open": [base + i for i in range(n)],
+            "high": [base + i + 1 for i in range(n)],
+            "low": [base + i - 1 for i in range(n)],
+            "close": [base + i + 0.5 for i in range(n)],
+            "volume": [1_000_000] * n,
+        },
+        index=dates,
+    )
+
+
+def _make_multi_index_df(symbols: list[str], n: int = 5, base: float = 100.0) -> pd.DataFrame:
+    """Create a MultiIndex OHLCV DataFrame (multi-symbol batch result)."""
+    frames = []
+    dates = pd.bdate_range(end=date.today(), periods=n)
+    for sym in symbols:
+        df = pd.DataFrame(
+            {
+                "open": [base + i for i in range(n)],
+                "high": [base + i + 1 for i in range(n)],
+                "low": [base + i - 1 for i in range(n)],
+                "close": [base + i + 0.5 for i in range(n)],
+                "volume": [1_000_000] * n,
+            },
+            index=pd.MultiIndex.from_tuples(
+                [(sym, d) for d in dates], names=["symbol", "date"]
+            ),
+        )
+        frames.append(df)
+    return pd.concat(frames)
+
+
+class TestFetchHistory:
+    """Tests for the single-symbol fetch_history function."""
+
+    @patch("app.services.yahoo.history.Ticker")
+    async def test_returns_dataframe_with_period(self, mock_ticker_cls):
+        df = _make_ohlcv_df()
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await fetch_history("AAPL", period="3mo")
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == ["open", "high", "low", "close", "volume"]
+        ticker.history.assert_called_once_with(period="3mo", interval="1d")
+
+    @patch("app.services.yahoo.history.Ticker")
+    async def test_uses_start_end_when_provided(self, mock_ticker_cls):
+        df = _make_ohlcv_df()
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        mock_ticker_cls.return_value = ticker
+
+        s, e = date(2025, 1, 1), date(2025, 3, 1)
+        await fetch_history("AAPL", start=s, end=e)
+
+        ticker.history.assert_called_once_with(
+            start="2025-01-01", end="2025-03-01", interval="1d"
+        )
+
+    @patch("app.services.yahoo.history.Ticker")
+    async def test_raises_on_empty_dataframe(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.history.return_value = pd.DataFrame()
+        mock_ticker_cls.return_value = ticker
+
+        with pytest.raises(ValueError, match="No data found"):
+            await fetch_history("INVALID")
+
+    @patch("app.services.yahoo.history.Ticker")
+    async def test_raises_on_dict_response(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.history.return_value = {"INVALID": "No data found"}
+        mock_ticker_cls.return_value = ticker
+
+        with pytest.raises(ValueError, match="No data found"):
+            await fetch_history("INVALID")
+
+    @patch("app.services.yahoo.history.Ticker")
+    async def test_handles_multi_index(self, mock_ticker_cls):
+        """Yahoo sometimes returns MultiIndex even for single symbols."""
+        dates = pd.bdate_range(end=date.today(), periods=3)
+        df = pd.DataFrame(
+            {
+                "open": [100, 101, 102],
+                "high": [101, 102, 103],
+                "low": [99, 100, 101],
+                "close": [100.5, 101.5, 102.5],
+                "volume": [1_000_000, 1_000_000, 1_000_000],
+            },
+            index=pd.MultiIndex.from_tuples(
+                [("AAPL", d) for d in dates], names=["symbol", "date"]
+            ),
+        )
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await fetch_history("AAPL")
+        assert result.index.name == "date"
+
+    @patch("app.services.yahoo.history.Ticker")
+    async def test_applies_currency_divisor(self, mock_ticker_cls):
+        """GBp prices should be divided by 100."""
+        df = pd.DataFrame(
+            {
+                "open": [15000.0],
+                "high": [15100.0],
+                "low": [14900.0],
+                "close": [15050.0],
+                "volume": [500_000],
+            },
+            index=pd.DatetimeIndex([date.today()]),
+        )
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"HSBA.L": {"currency": "GBp"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await fetch_history("HSBA.L")
+        assert result["close"].iloc[0] == 150.50
+
+    @patch("app.services.yahoo.history.Ticker")
+    async def test_normalizes_period_alias(self, mock_ticker_cls):
+        """'1w' should map to '5d'."""
+        df = _make_ohlcv_df()
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        mock_ticker_cls.return_value = ticker
+
+        await fetch_history("AAPL", period="1w")
+        ticker.history.assert_called_once_with(period="5d", interval="1d")
+
+
+class TestPeriodMap:
+    def test_contains_expected_keys(self):
+        expected = {"1d", "5d", "1w", "1mo", "3mo", "6mo", "1y", "2y", "5y", "ytd", "max"}
+        assert set(PERIOD_MAP.keys()) == expected
+
+    def test_1w_maps_to_5d(self):
+        assert PERIOD_MAP["1w"] == "5d"
+
+
+class TestBatchFetchHistorySync:
+    @patch("app.services.yahoo.history.Ticker")
+    def test_empty_symbols_returns_empty(self, mock_ticker_cls):
+        assert _batch_fetch_history_sync([]) == {}
+
+    @patch("app.services.yahoo.history.Ticker")
+    def test_empty_history_returns_empty(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.history.return_value = pd.DataFrame()
+        ticker.price = {}
+        mock_ticker_cls.return_value = ticker
+
+        assert _batch_fetch_history_sync(["AAPL"]) == {}
+
+    @patch("app.services.yahoo.history.Ticker")
+    def test_dict_history_returns_empty(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.history.return_value = {"error": "no data"}
+        ticker.price = {}
+        mock_ticker_cls.return_value = ticker
+
+        assert _batch_fetch_history_sync(["AAPL"]) == {}
+
+    @patch("app.services.yahoo.history.Ticker")
+    def test_returns_dataframes_per_symbol(self, mock_ticker_cls):
+        df = _make_multi_index_df(["AAPL", "MSFT"], n=5)
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {
+            "AAPL": {"currency": "USD"},
+            "MSFT": {"currency": "USD"},
+        }
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_history_sync(["AAPL", "MSFT"])
+        assert "AAPL" in result
+        assert "MSFT" in result
+        assert len(result["AAPL"]) == 5
+
+    @patch("app.services.yahoo.history.Ticker")
+    def test_skips_symbol_with_too_few_rows(self, mock_ticker_cls):
+        """Symbols with < 2 rows are skipped."""
+        dates = pd.bdate_range(end=date.today(), periods=1)
+        df = pd.DataFrame(
+            {"open": [100], "high": [101], "low": [99], "close": [100.5], "volume": [1_000_000]},
+            index=pd.MultiIndex.from_tuples([("AAPL", dates[0])], names=["symbol", "date"]),
+        )
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_history_sync(["AAPL"])
+        assert result == {}
+
+    @patch("app.services.yahoo.history.Ticker")
+    def test_skips_missing_symbol_keyerror(self, mock_ticker_cls):
+        """Gracefully skip symbols that raise KeyError on .loc."""
+        dates = pd.bdate_range(end=date.today(), periods=3)
+        df = pd.DataFrame(
+            {"open": [100, 101, 102], "high": [101, 102, 103], "low": [99, 100, 101],
+             "close": [100.5, 101.5, 102.5], "volume": [1_000_000] * 3},
+            index=pd.MultiIndex.from_tuples(
+                [("AAPL", d) for d in dates], names=["symbol", "date"]
+            ),
+        )
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_history_sync(["AAPL", "MISSING"])
+        assert "AAPL" in result
+        assert "MISSING" not in result
+
+    @patch("app.services.yahoo.history.Ticker")
+    def test_applies_currency_normalization(self, mock_ticker_cls):
+        """GBp prices in batch should be divided by 100."""
+        dates = pd.bdate_range(end=date.today(), periods=3)
+        df = pd.DataFrame(
+            {"open": [15000, 15100, 15200], "high": [15100, 15200, 15300],
+             "low": [14900, 15000, 15100], "close": [15050, 15150, 15250],
+             "volume": [500_000] * 3},
+            index=pd.MultiIndex.from_tuples(
+                [("HSBA.L", d) for d in dates], names=["symbol", "date"]
+            ),
+        )
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"HSBA.L": {"currency": "GBp"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = _batch_fetch_history_sync(["HSBA.L"])
+        assert "HSBA.L" in result
+        assert result["HSBA.L"]["close"].iloc[0] == 150.50

--- a/backend/tests/services/test_yahoo_holdings.py
+++ b/backend/tests/services/test_yahoo_holdings.py
@@ -1,0 +1,161 @@
+"""Tests for Yahoo Finance ETF holdings fetching."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.yahoo.holdings import (
+    _fetch_etf_holdings_uncached,
+    _holdings_cache,
+    fetch_etf_holdings,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+_MOCK_FUND_INFO = {
+    "holdings": [
+        {"symbol": "AAPL", "holdingName": "Apple Inc.", "holdingPercent": 0.072},
+        {"symbol": "MSFT", "holdingName": "Microsoft Corp.", "holdingPercent": 0.065},
+        {"symbol": "AMZN", "holdingName": "Amazon.com Inc.", "holdingPercent": 0.035},
+    ],
+    "sectorWeightings": [
+        {"technology": 0.29},
+        {"healthcare": 0.14},
+        {"financial_services": 0.13},
+        {"consumer_cyclical": 0.10},
+        {"industrials": 0.09},
+    ],
+}
+
+
+class TestFetchEtfHoldingsUncached:
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_returns_holdings_and_sectors(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"SPY": _MOCK_FUND_INFO}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("SPY")
+
+        assert result is not None
+        assert len(result["top_holdings"]) == 3
+        assert result["top_holdings"][0]["symbol"] == "AAPL"
+        assert result["top_holdings"][0]["percent"] == 7.2
+        assert result["top_holdings"][1]["name"] == "Microsoft Corp."
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_sector_names_are_mapped(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"SPY": _MOCK_FUND_INFO}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("SPY")
+        sector_names = [s["sector"] for s in result["sector_weightings"]]
+
+        assert "Technology" in sector_names
+        assert "Healthcare" in sector_names
+        assert "Financial Services" in sector_names
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_sectors_sorted_descending(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"SPY": _MOCK_FUND_INFO}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("SPY")
+        pcts = [s["percent"] for s in result["sector_weightings"]]
+        assert pcts == sorted(pcts, reverse=True)
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_zero_weight_sectors_excluded(self, mock_ticker_cls):
+        info = {"holdings": [], "sectorWeightings": [{"energy": 0.0}, {"technology": 0.15}]}
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"SPY": info}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("SPY")
+        assert len(result["sector_weightings"]) == 1
+        assert result["sector_weightings"][0]["sector"] == "Technology"
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_total_percent_calculated(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"SPY": _MOCK_FUND_INFO}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("SPY")
+        expected = round(7.2 + 6.5 + 3.5, 2)
+        assert result["total_percent"] == expected
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_returns_none_for_non_etf(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"AAPL": None}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("AAPL")
+        assert result is None
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_returns_none_for_string_error(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"AAPL": "No fundamentals data found"}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("AAPL")
+        assert result is None
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_handles_unknown_sector_key(self, mock_ticker_cls):
+        info = {"holdings": [], "sectorWeightings": [{"unknown_sector": 0.05}]}
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"XYZ": info}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("XYZ")
+        assert result["sector_weightings"][0]["sector"] == "unknown_sector"
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    def test_handles_empty_holdings_list(self, mock_ticker_cls):
+        info = {"holdings": [], "sectorWeightings": []}
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"SPY": info}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_etf_holdings_uncached("SPY")
+        assert result["top_holdings"] == []
+        assert result["total_percent"] == 0.0
+
+
+class TestFetchEtfHoldingsCaching:
+    @patch("app.services.yahoo.holdings.Ticker")
+    async def test_caches_result(self, mock_ticker_cls):
+        _holdings_cache._data.clear()
+
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"SPY": _MOCK_FUND_INFO}
+        mock_ticker_cls.return_value = ticker
+
+        result1 = await fetch_etf_holdings("SPY")
+        result2 = await fetch_etf_holdings("SPY")
+
+        # Only one Ticker instantiation due to cache hit
+        assert mock_ticker_cls.call_count == 1
+        assert result1 == result2
+
+        _holdings_cache._data.clear()
+
+    @patch("app.services.yahoo.holdings.Ticker")
+    async def test_uppercase_cache_key(self, mock_ticker_cls):
+        _holdings_cache._data.clear()
+
+        ticker = MagicMock()
+        ticker.fund_holding_info = {"spy": _MOCK_FUND_INFO}
+        mock_ticker_cls.return_value = ticker
+
+        await fetch_etf_holdings("spy")
+        # Cache key should be uppercase
+        assert _holdings_cache.get_value("SPY") is not None
+
+        _holdings_cache._data.clear()

--- a/backend/tests/services/test_yahoo_quotes.py
+++ b/backend/tests/services/test_yahoo_quotes.py
@@ -1,0 +1,222 @@
+"""Tests for Yahoo Finance real-time quote fetching."""
+
+import math
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.yahoo.quotes import (
+    _has_invalid_crumb,
+    _parse_price_data,
+    _sanitize,
+    batch_fetch_currencies,
+    batch_fetch_quotes,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestSanitize:
+    def test_none_returns_none(self):
+        assert _sanitize(None) is None
+
+    def test_nan_returns_none(self):
+        assert _sanitize(float("nan")) is None
+
+    def test_inf_returns_none(self):
+        assert _sanitize(float("inf")) is None
+
+    def test_neg_inf_returns_none(self):
+        assert _sanitize(float("-inf")) is None
+
+    def test_valid_float_passthrough(self):
+        assert _sanitize(42.5) == 42.5
+
+    def test_zero_passthrough(self):
+        assert _sanitize(0.0) == 0.0
+
+
+class TestParsePriceData:
+    def test_basic_quote(self):
+        ticker = MagicMock()
+        price_data = {
+            "AAPL": {
+                "currency": "USD",
+                "regularMarketPrice": 185.50,
+                "regularMarketPreviousClose": 184.00,
+                "regularMarketChange": 1.50,
+                "regularMarketChangePercent": 0.0082,
+                "regularMarketVolume": 50_000_000,
+                "averageDailyVolume10Day": 55_000_000,
+                "marketState": "REGULAR",
+            }
+        }
+
+        results = _parse_price_data(ticker, ["AAPL"], price_data)
+
+        assert len(results) == 1
+        q = results[0]
+        assert q["symbol"] == "AAPL"
+        assert q["price"] == 185.50
+        assert q["previous_close"] == 184.0
+        assert q["change"] == 1.50
+        assert q["change_percent"] == 0.82
+        assert q["volume"] == 50_000_000
+        assert q["avg_volume"] == 55_000_000
+        assert q["currency"] == "USD"
+        assert q["market_state"] == "REGULAR"
+
+    def test_non_dict_info_returns_symbol_only(self):
+        ticker = MagicMock()
+        price_data = {"AAPL": "No data found"}
+
+        results = _parse_price_data(ticker, ["AAPL"], price_data)
+
+        assert len(results) == 1
+        assert results[0] == {"symbol": "AAPL"}
+
+    def test_nan_values_sanitized(self):
+        ticker = MagicMock()
+        price_data = {
+            "AAPL": {
+                "currency": "USD",
+                "regularMarketPrice": float("nan"),
+                "regularMarketPreviousClose": None,
+                "regularMarketChange": float("inf"),
+                "regularMarketChangePercent": float("nan"),
+                "regularMarketVolume": None,
+                "averageDailyVolume10Day": None,
+                "marketState": "REGULAR",
+            }
+        }
+
+        results = _parse_price_data(ticker, ["AAPL"], price_data)
+        q = results[0]
+        assert q["price"] is None
+        assert q["change"] is None
+        assert q["change_percent"] is None
+
+    def test_missing_symbol_in_price_data(self):
+        ticker = MagicMock()
+        results = _parse_price_data(ticker, ["AAPL"], {})
+
+        assert len(results) == 1
+        q = results[0]
+        assert q["symbol"] == "AAPL"
+        assert q["price"] is None
+        assert q["currency"] == "USD"
+
+    def test_currency_normalization_gbp(self):
+        ticker = MagicMock()
+        price_data = {
+            "HSBA.L": {
+                "currency": "GBp",
+                "regularMarketPrice": 6500.0,
+                "regularMarketPreviousClose": 6400.0,
+                "regularMarketChange": 100.0,
+                "regularMarketChangePercent": 0.015625,
+                "regularMarketVolume": 10_000_000,
+                "averageDailyVolume10Day": None,
+                "marketState": "REGULAR",
+            }
+        }
+
+        results = _parse_price_data(ticker, ["HSBA.L"], price_data)
+        q = results[0]
+        assert q["currency"] == "GBP"
+        assert q["price"] == 65.0
+        assert q["previous_close"] == 64.0
+        assert q["change"] == 1.0
+
+    def test_multiple_symbols(self):
+        ticker = MagicMock()
+        price_data = {
+            "AAPL": {
+                "currency": "USD", "regularMarketPrice": 185.0,
+                "regularMarketPreviousClose": 184.0, "regularMarketChange": 1.0,
+                "regularMarketChangePercent": 0.005, "regularMarketVolume": 50_000_000,
+                "averageDailyVolume10Day": None, "marketState": "REGULAR",
+            },
+            "MSFT": {
+                "currency": "USD", "regularMarketPrice": 420.0,
+                "regularMarketPreviousClose": 418.0, "regularMarketChange": 2.0,
+                "regularMarketChangePercent": 0.005, "regularMarketVolume": 30_000_000,
+                "averageDailyVolume10Day": None, "marketState": "REGULAR",
+            },
+        }
+
+        results = _parse_price_data(ticker, ["AAPL", "MSFT"], price_data)
+        assert len(results) == 2
+        assert results[0]["symbol"] == "AAPL"
+        assert results[1]["symbol"] == "MSFT"
+
+
+class TestHasInvalidCrumb:
+    def test_all_invalid(self):
+        assert _has_invalid_crumb({"AAPL": "Invalid Crumb", "MSFT": "Invalid Crumb"}) is True
+
+    def test_none_invalid(self):
+        assert _has_invalid_crumb({"AAPL": {"price": 185}, "MSFT": {"price": 420}}) is False
+
+    def test_partial_invalid(self):
+        assert _has_invalid_crumb({"AAPL": "Invalid Crumb", "MSFT": {"price": 420}}) is False
+
+    def test_empty_dict(self):
+        assert _has_invalid_crumb({}) is False
+
+
+class TestBatchFetchQuotes:
+    @patch("app.services.yahoo.quotes.Ticker")
+    async def test_empty_symbols(self, mock_ticker_cls):
+        result = await batch_fetch_quotes([])
+        assert result == []
+        mock_ticker_cls.assert_not_called()
+
+    @patch("app.services.yahoo.quotes.Ticker")
+    async def test_retries_on_invalid_crumb(self, mock_ticker_cls):
+        bad = {"AAPL": "Invalid Crumb"}
+        good = {"AAPL": {
+            "currency": "USD", "regularMarketPrice": 185.0,
+            "regularMarketPreviousClose": 184.0, "regularMarketChange": 1.0,
+            "regularMarketChangePercent": 0.005, "regularMarketVolume": 50_000_000,
+            "averageDailyVolume10Day": None, "marketState": "REGULAR",
+        }}
+
+        ticker1 = MagicMock()
+        ticker1.price = bad
+        ticker2 = MagicMock()
+        ticker2.price = good
+        mock_ticker_cls.side_effect = [ticker1, ticker2]
+
+        result = await batch_fetch_quotes(["AAPL"])
+        assert len(result) == 1
+        assert result[0]["price"] == 185.0
+        assert mock_ticker_cls.call_count == 2
+
+
+class TestBatchFetchCurrencies:
+    @patch("app.services.yahoo.quotes.Ticker")
+    def test_empty_symbols(self, mock_ticker_cls):
+        assert batch_fetch_currencies([]) == {}
+
+    @patch("app.services.yahoo.quotes.Ticker")
+    def test_returns_currency_map(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.price = {
+            "AAPL": {"currency": "USD"},
+            "HSBA.L": {"currency": "GBp"},
+        }
+        mock_ticker_cls.return_value = ticker
+
+        result = batch_fetch_currencies(["AAPL", "HSBA.L"])
+        assert result["AAPL"] == "USD"
+        assert result["HSBA.L"] == "GBP"
+
+    @patch("app.services.yahoo.quotes.Ticker")
+    def test_non_dict_price_data(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.price = "error"
+        mock_ticker_cls.return_value = ticker
+
+        result = batch_fetch_currencies(["AAPL"])
+        assert result["AAPL"] == "USD"

--- a/backend/tests/services/test_yahoo_search.py
+++ b/backend/tests/services/test_yahoo_search.py
@@ -1,0 +1,35 @@
+"""Tests for Yahoo Finance symbol search."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services.yahoo.search import search
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestSearch:
+    @patch("app.services.yahoo.search._yq_search")
+    async def test_delegates_to_yahooquery(self, mock_search):
+        mock_search.return_value = {"quotes": [{"symbol": "AAPL"}]}
+
+        result = await search("AAPL")
+
+        mock_search.assert_called_once_with("AAPL")
+        assert result == {"quotes": [{"symbol": "AAPL"}]}
+
+    @patch("app.services.yahoo.search._yq_search")
+    async def test_passes_kwargs(self, mock_search):
+        mock_search.return_value = {"quotes": []}
+
+        await search("AAPL", first_quote=False)
+
+        mock_search.assert_called_once_with("AAPL", first_quote=False)
+
+    @patch("app.services.yahoo.search._yq_search")
+    async def test_returns_empty_on_no_results(self, mock_search):
+        mock_search.return_value = {"quotes": []}
+
+        result = await search("XYZXYZ")
+        assert result["quotes"] == []

--- a/backend/tests/services/test_yahoo_validation.py
+++ b/backend/tests/services/test_yahoo_validation.py
@@ -1,0 +1,160 @@
+"""Tests for Yahoo Finance symbol validation and type detection."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.yahoo.validation import validate_symbol
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestValidateSymbol:
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_valid_us_stock(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"AAPL": {"shortName": "Apple Inc.", "quoteType": "EQUITY"}}
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        ticker.summary_detail = {"AAPL": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("AAPL")
+
+        assert result is not None
+        assert result["symbol"] == "AAPL"
+        assert result["name"] == "Apple Inc."
+        assert result["type"] == "EQUITY"
+        assert result["currency"] == "USD"
+        assert result["currency_code"] == "USD"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_returns_none_for_invalid_symbol(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"INVALID": None}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("INVALID")
+        assert result is None
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_returns_none_for_string_error(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"INVALID": "Quote not found for ticker symbol: INVALID"}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("INVALID")
+        assert result is None
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_etf_type(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"SPY": {"shortName": "SPDR S&P 500", "quoteType": "ETF"}}
+        ticker.price = {"SPY": {"currency": "USD"}}
+        ticker.summary_detail = {"SPY": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("SPY")
+        assert result["type"] == "ETF"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_currency_from_price_info(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"VWCE.DE": {"shortName": "Vanguard FTSE", "quoteType": "ETF"}}
+        ticker.price = {"VWCE.DE": {"currency": "EUR"}}
+        ticker.summary_detail = {"VWCE.DE": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("VWCE.DE")
+        assert result["currency"] == "EUR"
+        assert result["currency_code"] == "EUR"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_currency_fallback_to_summary_detail(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"AAPL": {"shortName": "Apple", "quoteType": "EQUITY"}}
+        ticker.price = {"AAPL": {}}  # No currency in price
+        ticker.summary_detail = {"AAPL": {"currency": "USD"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("AAPL")
+        assert result["currency"] == "USD"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_currency_fallback_to_suffix(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"006260.KS": {"shortName": "LS Corp", "quoteType": "EQUITY"}}
+        ticker.price = {"006260.KS": {}}
+        ticker.summary_detail = {"006260.KS": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("006260.KS")
+        assert result["currency"] == "KRW"
+        assert result["currency_code"] == "KRW"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_currency_fallback_to_usd(self, mock_ticker_cls):
+        """US stocks with no currency info anywhere default to USD."""
+        ticker = MagicMock()
+        ticker.quote_type = {"AAPL": {"shortName": "Apple", "quoteType": "EQUITY"}}
+        ticker.price = {"AAPL": {}}
+        ticker.summary_detail = {"AAPL": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("AAPL")
+        assert result["currency_code"] == "USD"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_name_fallback_to_longname(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"AAPL": {"longName": "Apple Inc.", "quoteType": "EQUITY"}}
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        ticker.summary_detail = {"AAPL": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("AAPL")
+        assert result["name"] == "Apple Inc."
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_name_fallback_to_symbol(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"AAPL": {"quoteType": "EQUITY"}}
+        ticker.price = {"AAPL": {"currency": "USD"}}
+        ticker.summary_detail = {"AAPL": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("AAPL")
+        assert result["name"] == "AAPL"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_gbp_subunit_normalization(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"HSBA.L": {"shortName": "HSBC Holdings", "quoteType": "EQUITY"}}
+        ticker.price = {"HSBA.L": {"currency": "GBp"}}
+        ticker.summary_detail = {"HSBA.L": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("HSBA.L")
+        assert result["currency"] == "GBP"
+        assert result["currency_code"] == "GBp"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_non_dict_price_info_uses_suffix(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"7203.T": {"shortName": "Toyota", "quoteType": "EQUITY"}}
+        ticker.price = {"7203.T": "No data found"}
+        ticker.summary_detail = {"7203.T": "No data found"}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("7203.T")
+        assert result["currency"] == "JPY"
+
+    @patch("app.services.yahoo.validation.Ticker")
+    async def test_symbol_uppercased(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.quote_type = {"aapl": {"shortName": "Apple", "quoteType": "EQUITY"}}
+        ticker.price = {"aapl": {"currency": "USD"}}
+        ticker.summary_detail = {"aapl": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await validate_symbol("aapl")
+        assert result["symbol"] == "AAPL"


### PR DESCRIPTION
## Summary
- Adds dedicated test coverage for 15 previously untested backend modules
- **165 new tests** across 15 new test files, bringing total from 377 → 542
- Zero regressions in existing tests

## Test Groups

**Group 1 — Yahoo submodule** (86 tests): `history`, `holdings`, `quotes`, `search`, `validation`, `fundamentals`
**Group 2 — Compute submodule** (22 tests): `group`, `portfolio`, `utils`
**Group 3 — Service unit tests** (18 tests): `entity_lookups`, `symbol_sync_service`
**Group 4 — Router integration tests** (39 tests): `annotations`, `search`, `symbol_sources`, `pseudo_etf_analysis`

Closes #444, closes #445, closes #446, closes #447

## Test plan
- [x] All 542 tests pass (`docker compose exec backend pytest`)
- [x] No regressions in existing test suite
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)