### PR TITLE
fix: add group picker dropdown to Add Symbol dialog (#451)

### DIFF
--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -189,7 +189,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
             />
           )}
         </div>
-        <AddSymbolDialog groupId={groupId} isDefaultGroup={isDefaultGroup} />
+        <AddSymbolDialog groupId={groupId} />
       </div>
 
       {groupLoading && <p className="text-muted-foreground">Loading...</p>}


### PR DESCRIPTION
## Summary
- Added a group picker dropdown to the Add Symbol dialog, defaulting to the current group
- Selecting an already-tracked ticker now populates the symbol field instead of navigating away
- Removed the `isDefaultGroup` prop dependency — the dialog now uses `useGroups()` to list non-default groups
- Global search bar behavior unchanged

## Test plan
- [ ] Open Add Symbol dialog → verify group dropdown shows all non-default groups
- [ ] Select an already-tracked ticker → verify it populates the symbol field (no navigation)
- [ ] Change target group → add symbol → verify it's added to the selected group
- [ ] Global search bar still navigates to asset page on selection
- [ ] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)