### PR TITLE
fix: frontend critical bugs — NaN routes, stale chart, error boundary, SSE leak (#465)

### DIFF
--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,0 +1,44 @@
+import { Component, type ReactNode } from "react"
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center p-6">
+          <div className="max-w-md text-center space-y-4">
+            <h1 className="text-2xl font-bold">Something went wrong</h1>
+            <p className="text-muted-foreground text-sm">
+              {this.state.error?.message ?? "An unexpected error occurred."}
+            </p>
+            <button
+              onClick={() => {
+                this.setState({ hasError: false, error: null })
+                window.location.href = "/"
+              }}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Go Home
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/components/intraday-chart.tsx
+++ b/frontend/src/components/intraday-chart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, memo } from "react"
+import { useEffect, useRef, useState, memo } from "react"
 import { createChart, type IChartApi, ColorType, BaselineSeries, CrosshairMode } from "lightweight-charts"
 import type { IntradayPoint } from "@/lib/types"
 import { useChartTheme } from "@/lib/chart-utils"
@@ -91,6 +91,8 @@ export const IntradayChart = memo(function IntradayChart({
   const prevCloseRef = useRef<number | null>(null)
   const segmentCountRef = useRef(0)
   const firstTimeRef = useRef<number>(0)
+  const chartVersionRef = useRef(0)
+  const [chartVersion, setChartVersion] = useState(0)
   const theme = useChartTheme()
 
   // Create chart once, recreate on theme change
@@ -136,6 +138,9 @@ export const IntradayChart = memo(function IntradayChart({
     prevCloseRef.current = null
     segmentCountRef.current = 0
     firstTimeRef.current = 0
+    // Bump version so the data effect re-runs even if points haven't changed
+    chartVersionRef.current += 1
+    setChartVersion(chartVersionRef.current)
 
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -287,7 +292,7 @@ export const IntradayChart = memo(function IntradayChart({
         })
       }
     }
-  }, [points, previousClose, theme, interactive])
+  }, [points, previousClose, theme, interactive, chartVersion])
 
   return <div ref={containerRef} className="w-full h-full" />
 })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -132,7 +132,6 @@ export const api = {
     delete: (symbol: string, id: number) =>
       request<void>(`/assets/${symbol}/annotations/${id}`, { method: "DELETE" }),
   },
-  search: (q: string) => request<SymbolSearchResult[]>(`/search?q=${encodeURIComponent(q)}`),
   searchLocal: (q: string) => request<SymbolSearchResult[]>(`/search?q=${encodeURIComponent(q)}&source=local`),
   searchYahoo: (q: string) => request<SymbolSearchResult[]>(`/search?q=${encodeURIComponent(q)}&source=yahoo`),
   settings: {

--- a/frontend/src/lib/quote-stream.tsx
+++ b/frontend/src/lib/quote-stream.tsx
@@ -25,9 +25,13 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
   const esRef = useRef<EventSource | null>(null)
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const backoffMs = useRef(1_000)
+  const mountedRef = useRef(true)
 
   useEffect(() => {
+    mountedRef.current = true
+
     function connect() {
+      if (!mountedRef.current) return
       const es = new EventSource("/api/quotes/stream")
       esRef.current = es
 
@@ -108,6 +112,7 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
     connect()
 
     return () => {
+      mountedRef.current = false
       esRef.current?.close()
       esRef.current = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 import "./index.css"
 import App from "./App.tsx"
+import { ErrorBoundary } from "./components/error-boundary.tsx"
 import { QuoteStreamProvider } from "./lib/quote-stream.tsx"
 import { SettingsProvider } from "./lib/settings.tsx"
 
@@ -16,14 +17,16 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <SettingsProvider>
-        <QuoteStreamProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
-        </QuoteStreamProvider>
-      </SettingsProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <SettingsProvider>
+          <QuoteStreamProvider>
+            <BrowserRouter>
+              <App />
+            </BrowserRouter>
+          </QuoteStreamProvider>
+        </SettingsProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>
 )

--- a/frontend/src/pages/group-detail.tsx
+++ b/frontend/src/pages/group-detail.tsx
@@ -1,9 +1,11 @@
-import { useParams } from "react-router-dom"
+import { useParams, Navigate } from "react-router-dom"
 import { GroupPage } from "@/pages/group-page"
 
 export function GroupDetailPage() {
   const { id } = useParams<{ id: string }>()
   const groupId = Number(id)
+
+  if (!id || isNaN(groupId)) return <Navigate to="/" replace />
 
   return <GroupPage groupId={groupId} />
 }

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -182,7 +182,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
               { value: "scanner", label: <ScanLine className="h-3.5 w-3.5" /> },
               { value: "live", label: <Activity className="h-3.5 w-3.5" /> },
             ]}
-            value={settings.group_view_mode}
+            value={viewMode}
             onChange={setViewMode}
           />
           {allTags && allTags.length > 0 && (

--- a/frontend/src/pages/portfolio/performers-section.tsx
+++ b/frontend/src/pages/portfolio/performers-section.tsx
@@ -27,22 +27,26 @@ export function PerformersSection({
   if (!performers?.length) return null
 
   const top5 = performers.slice(0, 5)
-  const bottom5 = [...performers].reverse().slice(0, 5)
+  const bottom5 = performers.length > 5
+    ? [...performers].reverse().slice(0, 5)
+    : []
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div className={`grid grid-cols-1 ${bottom5.length > 0 ? "lg:grid-cols-2" : ""} gap-6`}>
       <PerformersList
         title="Top Performers"
         icon={<TrendingUp className="h-4 w-4 text-emerald-500" />}
         assets={top5}
         period={period}
       />
-      <PerformersList
-        title="Bottom Performers"
-        icon={<TrendingDown className="h-4 w-4 text-red-500" />}
-        assets={bottom5}
-        period={period}
-      />
+      {bottom5.length > 0 && (
+        <PerformersList
+          title="Bottom Performers"
+          icon={<TrendingDown className="h-4 w-4 text-red-500" />}
+          assets={bottom5}
+          period={period}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/pseudo-etf-detail.tsx
+++ b/frontend/src/pages/pseudo-etf-detail.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react"
-import { useParams, Link } from "react-router-dom"
+import { useParams, Link, Navigate } from "react-router-dom"
 import { ArrowLeft, UserPlus, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -31,6 +31,7 @@ import {
 export function PseudoEtfDetailPage() {
   const { id } = useParams<{ id: string }>()
   const etfId = Number(id)
+  const validId = !!id && !isNaN(etfId)
   const { data: etf } = usePseudoEtf(etfId)
   const { data: performance, isLoading } = usePseudoEtfPerformance(etfId)
 
@@ -55,6 +56,7 @@ export function PseudoEtfDetailPage() {
     return map
   }, [sortedSymbols])
 
+  if (!validId) return <Navigate to="/pseudo-etfs" replace />
   if (!etf) return null
 
   return (


### PR DESCRIPTION
## Summary
- Guard against `NaN` groupId/etfId from invalid URL params — redirect instead of propagating NaN into queries
- Fix intraday chart showing empty data after theme/interactive toggle by adding a version counter dependency
- Add app-level `ErrorBoundary` wrapping the entire provider tree to prevent white-screen crashes
- Fix `EventSource` memory leak by checking a mounted ref before reconnecting after unmount
- Fix `SegmentedControl` value using `settings.group_view_mode` instead of deferred `viewMode` — tab now matches rendered content during transitions
- Fix performers section showing duplicate assets in both top/bottom when fewer than 6 performers
- Remove dead `api.search` function (only `searchLocal`/`searchYahoo` are used)

Closes #465

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` passes
- [ ] Navigate to `/groups/abc` — redirects to `/` instead of crashing
- [ ] Navigate to `/pseudo-etf/abc` — redirects to `/pseudo-etfs`
- [ ] Toggle theme in live intraday view — chart re-renders with data
- [ ] Portfolio page with < 6 assets — only "Top Performers" shown, no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)