### PR TITLE
fix: backend critical bug fixes (#464)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -84,10 +84,12 @@ async def scheduled_intraday_sync():
             symbols = [sym for _, sym in pairs]
             asset_map = {sym: aid for aid, sym in pairs}
 
-            # Sample across the list to detect mixed-timezone market activity
-            sample_size = min(10, len(symbols))
-            step = max(1, len(symbols) // sample_size)
-            sample = symbols[::step][:sample_size]
+            # Sample across the list to detect market activity.
+            # Use a shuffled sample to avoid always picking the same symbols,
+            # which could miss active markets in different timezones.
+            import random
+            sample_size = min(15, len(symbols))
+            sample = random.sample(symbols, sample_size)
             quotes = await batch_fetch_quotes(sample)
             market_states = {q.get("market_state") for q in quotes if q.get("market_state")}
             active_states = {"REGULAR", "PRE", "POST", "PREPRE", "POSTPOST"}

--- a/backend/app/services/intraday.py
+++ b/backend/app/services/intraday.py
@@ -147,7 +147,8 @@ def _fetch_intraday_sync(symbols: list[str]) -> dict[str, list[dict]]:
 
             if bars:
                 result[sym] = bars
-        except (KeyError, TypeError):
+        except (KeyError, TypeError) as exc:
+            logger.warning("Failed to parse intraday data for %s: %s", sym, exc)
             continue
 
     return result

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -176,6 +176,8 @@ async def _compute_or_cached_indicators(
 
     if asset:
         prices = await _ensure_prices(db, asset, period)
+        if not prices:
+            return [], None
         last_date = prices[-1].date
 
         cache_key = f"{symbol}:{period}:{last_date}"

--- a/backend/tests/integration/test_quotes.py
+++ b/backend/tests/integration/test_quotes.py
@@ -6,6 +6,7 @@ import json
 import pytest
 from unittest.mock import patch
 
+from app.services.quote_service import _reset_asset_list_cache
 from tests.conftest import TestSession
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
@@ -95,6 +96,7 @@ async def test_get_quotes_uppercase_normalization(client):
 
 async def test_stream_quotes_no_tracked(client):
     """SSE stream emits empty payload when no assets are tracked."""
+    _reset_asset_list_cache()
     with (
         patch("app.services.quote_service.async_session", TestSession),
         patch("app.services.quote_service.asyncio.sleep", side_effect=asyncio.CancelledError()),
@@ -112,6 +114,7 @@ async def test_stream_quotes_emits_event(client):
     """SSE stream emits quote data for tracked assets."""
     await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
 
+    _reset_asset_list_cache()
     with (
         patch("app.services.quote_service.async_session", TestSession),
         patch("app.services.quote_service.batch_fetch_quotes", return_value=[_MOCK_QUOTES[0]]),
@@ -129,6 +132,7 @@ async def test_stream_quotes_emits_event(client):
 
 async def test_stream_quotes_cache_headers(client):
     """SSE stream sets correct cache-control and buffering headers."""
+    _reset_asset_list_cache()
     with (
         patch("app.services.quote_service.async_session", TestSession),
         patch("app.services.quote_service.asyncio.sleep", side_effect=asyncio.CancelledError()),
@@ -144,6 +148,7 @@ async def test_stream_quotes_multiple_symbols(client):
     await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
     await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft", "type": "stock"})
 
+    _reset_asset_list_cache()
     with (
         patch("app.services.quote_service.async_session", TestSession),
         patch("app.services.quote_service.batch_fetch_quotes", return_value=_MOCK_QUOTES),


### PR DESCRIPTION
## Summary
- Add zero-price division guards in pseudo-ETF calculations (`_calc_static` + `_calc_dynamic`) to prevent `inf` values from delisted/zero-price assets
- Add empty-prices `IndexError` guard in `_compute_or_cached_indicators` before accessing `prices[-1]`
- Cache SSE asset list with 30s TTL to avoid opening a DB session every SSE iteration (was ~every 15s during market hours)
- Log intraday parse failures with `logger.warning` instead of silently swallowing `KeyError`/`TypeError`
- Use `random.sample()` for unbiased market-state sampling across timezones (was deterministic stepping that could miss active non-US markets)
- Add `_reset_asset_list_cache()` test helper to prevent cross-test cache pollution

## Test plan
- [x] All 541 backend tests pass (1 flaky curl_cffi network error unrelated to changes)
- [x] SSE quote stream tests (8/8) pass with cache reset hooks
- [x] Zero-division edge cases covered by existing pseudo-ETF tests

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)