### PR TITLE
chore: code quality cleanup (#467)

### DIFF
--- a/backend/app/models/symbol_directory.py
+++ b/backend/app/models/symbol_directory.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Optional
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
@@ -16,6 +17,6 @@ class SymbolDirectory(Base):
     exchange: Mapped[str] = mapped_column(String(100), default="")
     type: Mapped[str] = mapped_column(String(10), default="stock")
     last_seen: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
-    source_id: Mapped[Optional[int]] = mapped_column(
+    source_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("symbol_sources.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/models/symbol_source.py
+++ b/backend/app/models/symbol_source.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Optional
 
 from sqlalchemy import Boolean, DateTime, Integer, JSON, String, func
 from sqlalchemy.orm import Mapped, mapped_column
@@ -15,6 +16,6 @@ class SymbolSource(Base):
     provider_type: Mapped[str] = mapped_column(String(50))
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     config: Mapped[dict] = mapped_column(JSON, default=dict)
-    last_synced_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    last_synced_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     symbol_count: Mapped[int] = mapped_column(Integer, default=0)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/app/routers/symbol_sources.py
+++ b/backend/app/routers/symbol_sources.py
@@ -1,6 +1,10 @@
+import logging
+
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from app.database import async_session, get_db
 from app.models.symbol_source import SymbolSource
@@ -90,8 +94,7 @@ async def trigger_sync(
             try:
                 await sync_source(sid, session)
             except Exception:
-                import logging
-                logging.getLogger(__name__).exception("Background sync failed for source %d", sid)
+                logger.exception("Background sync failed for source %d", sid)
 
     background_tasks.add_task(_run_sync, source_id)
 

--- a/backend/app/schemas/_validators.py
+++ b/backend/app/schemas/_validators.py
@@ -1,0 +1,12 @@
+"""Shared Pydantic field validators."""
+
+import re
+
+HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+def validate_hex_color(v: str) -> str:
+    """Validate that a string is a valid 6-digit hex colour code."""
+    if not HEX_COLOR_RE.match(v):
+        raise ValueError("color must be a valid hex code (e.g. '#3b82f6')")
+    return v

--- a/backend/app/schemas/annotation.py
+++ b/backend/app/schemas/annotation.py
@@ -1,9 +1,8 @@
 import datetime
-import re
 
 from pydantic import BaseModel, Field, field_validator
 
-_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+from app.schemas._validators import validate_hex_color
 
 
 class AnnotationCreate(BaseModel):
@@ -14,10 +13,8 @@ class AnnotationCreate(BaseModel):
 
     @field_validator("color")
     @classmethod
-    def validate_hex_color(cls, v: str) -> str:
-        if not _HEX_COLOR_RE.match(v):
-            raise ValueError("color must be a valid hex code (e.g. '#3b82f6')")
-        return v
+    def _validate_hex_color(cls, v: str) -> str:
+        return validate_hex_color(v)
 
 
 class AnnotationResponse(BaseModel):

--- a/backend/app/schemas/symbol_source.py
+++ b/backend/app/schemas/symbol_source.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -11,9 +13,9 @@ class SymbolSourceCreate(BaseModel):
 
 
 class SymbolSourceUpdate(BaseModel):
-    enabled: Optional[bool] = None
-    config: Optional[dict[str, Any]] = None
-    name: Optional[str] = None
+    enabled: bool | None = None
+    config: dict[str, Any] | None = None
+    name: str | None = None
 
 
 class SymbolSourceResponse(BaseModel):
@@ -22,7 +24,7 @@ class SymbolSourceResponse(BaseModel):
     provider_type: str
     enabled: bool
     config: dict[str, Any]
-    last_synced_at: Optional[datetime] = None
+    last_synced_at: datetime | None = None
     symbol_count: int
     created_at: datetime
 

--- a/backend/app/schemas/tag.py
+++ b/backend/app/schemas/tag.py
@@ -1,11 +1,9 @@
 import datetime
-import re
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.schemas._validators import validate_hex_color
 from app.schemas.asset import AssetResponse
-
-_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 
 class TagCreate(BaseModel):
@@ -14,10 +12,8 @@ class TagCreate(BaseModel):
 
     @field_validator("color")
     @classmethod
-    def validate_hex_color(cls, v: str) -> str:
-        if not _HEX_COLOR_RE.match(v):
-            raise ValueError("color must be a valid hex code (e.g. '#3b82f6')")
-        return v
+    def _validate_hex_color(cls, v: str) -> str:
+        return validate_hex_color(v)
 
 
 class TagUpdate(BaseModel):
@@ -26,9 +22,9 @@ class TagUpdate(BaseModel):
 
     @field_validator("color")
     @classmethod
-    def validate_hex_color(cls, v: str | None) -> str | None:
-        if v is not None and not _HEX_COLOR_RE.match(v):
-            raise ValueError("color must be a valid hex code (e.g. '#3b82f6')")
+    def _validate_hex_color(cls, v: str | None) -> str | None:
+        if v is not None:
+            return validate_hex_color(v)
         return v
 
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -6,10 +6,13 @@ import asyncio
 import threading
 import time
 from functools import wraps
-from typing import Hashable, TypeVar
+from typing import Awaitable, Callable, ParamSpec, TypeVar
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
-def async_threadable(fn):
+def async_threadable(fn: Callable[_P, _R]) -> Callable[_P, Awaitable[_R]]:
     """Decorator that wraps a sync function to run in a thread via asyncio.to_thread.
 
     The decorated function becomes async. Callers simply ``await func(...)``
@@ -17,13 +20,10 @@ def async_threadable(fn):
     """
 
     @wraps(fn)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         return await asyncio.to_thread(fn, *args, **kwargs)
 
-    return wrapper
-
-K = TypeVar("K", bound=Hashable)
-V = TypeVar("V")
+    return wrapper  # type: ignore[return-value]
 
 
 class TTLCache:

--- a/frontend/src/components/add-symbol-dialog.tsx
+++ b/frontend/src/components/add-symbol-dialog.tsx
@@ -36,6 +36,7 @@ export function AddSymbolDialog({ groupId }: { groupId?: number }) {
   const closeDialog = () => {
     setSymbol("")
     setTargetGroupId(groupId)
+    createAsset.reset()
     setDialogOpen(false)
   }
 

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -38,6 +38,7 @@ export function Header({
   const quote = quotes[symbol.toUpperCase()]
   const price = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
+  const changeFmt = changePct != null ? formatChangePct(changePct) : null
   const [priceRef, pctRef] = usePriceFlash(price)
 
   return (
@@ -66,17 +67,14 @@ export function Header({
               : formatPrice(price, currency, undefined, settings.thousands_separator)}
           </span>
         )}
-        {changePct != null && (() => {
-          const chg = formatChangePct(changePct)
-          return (
-            <span
-              ref={pctRef}
-              className={`text-sm font-medium tabular-nums rounded px-1 ${chg.className}`}
-            >
-              {chg.text}
-            </span>
-          )
-        })()}
+        {changeFmt && (
+          <span
+            ref={pctRef}
+            className={`text-sm font-medium tabular-nums rounded px-1 ${changeFmt.className}`}
+          >
+            {changeFmt.text}
+          </span>
+        )}
         <a
           href={buildYahooFinanceUrl(symbol)}
           target="_blank"


### PR DESCRIPTION
## Summary
- Remove unused `TypeVar K/V` and `Hashable` import from `utils.py`
- Add `ParamSpec`/`TypeVar` generics to `async_threadable` so decorated functions preserve return types
- Extract duplicated hex color regex + validator from `annotation.py` and `tag.py` into shared `schemas/_validators.py`
- Modernize `Optional[T]` → `T | None` (PEP 604) in `symbol_directory`, `symbol_source` models and schemas
- Derive `_DELTA_FIELDS` dynamically from `INDICATOR_REGISTRY` output fields instead of hardcoding — eliminates maintenance trap when adding new indicators with deltas
- Move inner `import logging` to module level in `routers/symbol_sources.py`
- Add `createAsset.reset()` to `closeDialog()` in AddSymbolDialog — prevents stale error message showing on dialog reopen
- Extract IIFE pattern in asset detail header to a precomputed variable

## Test plan
- [x] All 542 backend tests pass
- [x] Frontend lint clean
- [x] Frontend build succeeds
- [x] Hex color validation behavior unchanged (same regex, same error messages)
- [x] Indicator delta computation unchanged (verified via existing indicator tests)

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)