### PR TITLE
fix: Add Symbol dialog UI fixes (#456, #458, #459)

### DIFF
--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -112,7 +112,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
             <>
               {/* Indicator selector */}
               <Select value={scannerIndicator} onValueChange={setScannerIndicator}>
-                <SelectTrigger size="sm" className="text-xs h-7">
+                <SelectTrigger className="text-xs h-7">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>


### PR DESCRIPTION
## Summary
- Remove redundant `size="sm"` on `SelectTrigger` where `h-7` already sets height (group-page scanner dropdown + add-symbol dialog group picker)
- Resolve `targetGroupId` through `selectableGroups` so when opened from the default group, the dropdown falls back to the first non-default group instead of showing a "Select group" placeholder
- Use `resolveTargetGroup()` for Select value display and in `handleAdd` guard clause to prevent stale/mismatched state
- Add `createAsset.reset()` in `closeDialog()` to clear stale error messages on reopen

## Test plan
- [x] Frontend lint clean
- [x] Frontend build succeeds (TypeScript + Vite)
- [x] Manual: open Add Symbol from default group → dropdown shows first non-default group (not placeholder)
- [x] Manual: open Add Symbol from non-default group → dropdown shows that group
- [x] Manual: add symbol → dialog closes, reopen → no stale error shown

Closes #456
Closes #458
Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)