### PR TITLE
feat: show disconnection indicator in live day view (#457)

### DIFF
--- a/frontend/src/components/live-day-view.tsx
+++ b/frontend/src/components/live-day-view.tsx
@@ -113,6 +113,11 @@ const LiveCard = memo(function LiveCard({
             points={points}
             previousClose={previousClose ?? null}
           />
+        ) : quoteStatus === "disconnected" ? (
+          <div className="h-full flex flex-col items-center justify-center gap-1.5 text-muted-foreground">
+            <div className="h-2 w-2 rounded-full bg-destructive/70" />
+            <span className="text-xs">Disconnected</span>
+          </div>
         ) : quoteStatus !== "connected" ? (
           <div className="h-full w-full animate-pulse bg-muted/40" />
         ) : (


### PR DESCRIPTION
## Summary
- When SSE stream is in `"disconnected"` state, live day view cards now show a red dot with "Disconnected" label instead of a silent skeleton pulse
- `"connecting"` / `"reconnecting"` states still show the skeleton pulse (data is on the way)
- `"connected"` with no data shows "No intraday data" as before

## Test plan
- [x] Frontend lint clean
- [x] Frontend build succeeds
- [x] Visual: disconnected state shows red dot + label; connecting shows pulse; connected shows chart

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)