### PR TITLE
perf: add route-based code splitting with React.lazy

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,24 +1,82 @@
+import { lazy, Suspense } from "react"
 import { Routes, Route } from "react-router-dom"
 import { Layout } from "@/components/layout"
-import { PortfolioPage } from "@/pages/portfolio"
-import { GroupDetailPage } from "@/pages/group-detail"
-import { AssetDetailPage } from "@/pages/asset-detail"
-import { PseudoEtfsPage } from "@/pages/pseudo-etfs"
-import { PseudoEtfDetailPage } from "@/pages/pseudo-etf-detail"
-import { SettingsPage } from "@/pages/settings"
 import { WatchlistRedirect } from "@/pages/watchlist-redirect"
+
+const PortfolioPage = lazy(() =>
+  import("@/pages/portfolio").then((m) => ({ default: m.PortfolioPage })),
+)
+const GroupDetailPage = lazy(() =>
+  import("@/pages/group-detail").then((m) => ({ default: m.GroupDetailPage })),
+)
+const AssetDetailPage = lazy(() =>
+  import("@/pages/asset-detail").then((m) => ({ default: m.AssetDetailPage })),
+)
+const PseudoEtfsPage = lazy(() =>
+  import("@/pages/pseudo-etfs").then((m) => ({ default: m.PseudoEtfsPage })),
+)
+const PseudoEtfDetailPage = lazy(() =>
+  import("@/pages/pseudo-etf-detail").then((m) => ({
+    default: m.PseudoEtfDetailPage,
+  })),
+)
+const SettingsPage = lazy(() =>
+  import("@/pages/settings").then((m) => ({ default: m.SettingsPage })),
+)
 
 export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route index element={<PortfolioPage />} />
+        <Route
+          index
+          element={
+            <Suspense>
+              <PortfolioPage />
+            </Suspense>
+          }
+        />
         <Route path="/watchlist" element={<WatchlistRedirect />} />
-        <Route path="/groups/:id" element={<GroupDetailPage />} />
-        <Route path="/asset/:symbol" element={<AssetDetailPage />} />
-        <Route path="/pseudo-etfs" element={<PseudoEtfsPage />} />
-        <Route path="/pseudo-etf/:id" element={<PseudoEtfDetailPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route
+          path="/groups/:id"
+          element={
+            <Suspense>
+              <GroupDetailPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/asset/:symbol"
+          element={
+            <Suspense>
+              <AssetDetailPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/pseudo-etfs"
+          element={
+            <Suspense>
+              <PseudoEtfsPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/pseudo-etf/:id"
+          element={
+            <Suspense>
+              <PseudoEtfDetailPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <Suspense>
+              <SettingsPage />
+            </Suspense>
+          }
+        />
       </Route>
     </Routes>
   )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,24 @@ import { defineConfig } from "vite"
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  build: {
+    chunkSizeWarningLimit: 600,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("lightweight-charts")) return "lightweight-charts"
+          if (id.includes("@radix-ui")) return "radix-ui"
+          if (
+            id.includes("react-dom") ||
+            id.includes("react-router") ||
+            id.includes("scheduler")
+          )
+            return "react-vendor"
+          if (id.includes("@tanstack")) return "tanstack"
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- Route pages loaded lazily via `React.lazy()` + `Suspense` — only download code for the page you visit
- Vendor libraries split into cacheable chunks: `lightweight-charts` (176KB), `radix-ui` (115KB), `react-vendor` (297KB), `tanstack` (36KB)
- Monolithic 1,456KB single-chunk bundle → 20+ chunks with largest route chunk at 38KB (group-detail)
- `chunkSizeWarningLimit` set to 600KB for the shared app framework chunk (providers, hooks, API client)

Closes #461

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` passes, no chunk size warnings
- [x] Route-specific chunks visible in build output
- [ ] Manual: all routes load correctly with lazy loading
- [ ] Manual: no flash of blank content on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)