### PR TITLE
perf: memoize AssetCard and GroupTable rows

### DIFF
--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react"
 import { Link } from "react-router-dom"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -27,8 +28,8 @@ export interface AssetCardProps {
   quote?: Quote
   sparklineData?: SparklinePoint[]
   indicatorData?: IndicatorSummary
-  onDelete: () => void
-  onHover: () => void
+  onDelete: (symbol: string) => void
+  onHover: (symbol: string) => void
   showSparkline: boolean
   indicatorVisibility: Record<string, Placement[]>
 }
@@ -54,7 +55,7 @@ function MiniIndicatorCard({
   )
 }
 
-export function AssetCard({
+export const AssetCard = memo(function AssetCard({
   groupId,
   assetId,
   symbol,
@@ -71,8 +72,9 @@ export function AssetCard({
   indicatorVisibility,
 }: AssetCardProps) {
   const { settings } = useSettings()
-  const enabledCards = CARD_DESCRIPTORS.filter(
-    (d) => isVisibleAt(indicatorVisibility, d.id, "group_card"),
+  const enabledCards = useMemo(
+    () => CARD_DESCRIPTORS.filter((d) => isVisibleAt(indicatorVisibility, d.id, "group_card")),
+    [indicatorVisibility],
   )
   const lastPrice = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
@@ -83,7 +85,7 @@ export function AssetCard({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <Card className="group relative hover:border-primary/50 data-[state=open]:border-primary/50 transition-colors" onMouseEnter={onHover}>
+        <Card className="group relative hover:border-primary/50 data-[state=open]:border-primary/50 transition-colors" onMouseEnter={() => onHover(symbol)}>
           <Link to={`/asset/${symbol}`}>
             <CardHeader className="pb-2">
               <div className="flex items-center gap-2">
@@ -155,8 +157,8 @@ export function AssetCard({
         groupId={groupId}
         assetId={assetId}
         symbol={symbol}
-        onRemove={onDelete}
+        onRemove={() => onDelete(symbol)}
       />
     </ContextMenu>
   )
-}
+})

--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { ChevronsUpDown, ChevronsDownUp } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
@@ -6,6 +6,8 @@ import type { GroupSortBy, SortDir } from "@/lib/settings"
 import { getSeriesByField } from "@/lib/indicator-registry"
 import { toggleSetItem } from "@/lib/utils"
 import { useSettings } from "@/lib/settings"
+const noop = () => {}
+
 import { SortableHeader } from "./sortable-header"
 import { ColumnVisibilityMenu } from "./column-visibility-menu"
 import { TableRow } from "./table-row"
@@ -33,9 +35,9 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
   const responsiveHidden = useResponsiveHidden()
   const { getColumnStyle, startResize, resetWidth } = useColumnResize()
 
-  const toggleExpand = (symbol: string) => {
+  const toggleExpand = useCallback((symbol: string) => {
     setExpandedSymbols((prev) => toggleSetItem(prev, symbol))
-  }
+  }, [])
 
   const toggleColumn = (key: string) => {
     const current = isColumnVisible(columnSettings, key)
@@ -160,9 +162,9 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
               quote={quotes[asset.symbol]}
               indicator={indicators?.[asset.symbol]}
               expanded={expandedSymbols.has(asset.symbol)}
-              onToggle={() => toggleExpand(asset.symbol)}
-              onDelete={() => onDelete(asset.symbol)}
-              onHover={() => onHover?.(asset.symbol)}
+              onToggle={toggleExpand}
+              onDelete={onDelete}
+              onHover={onHover ?? noop}
               compactMode={compactMode}
               columnSettings={columnSettings}
               visibleIndicatorFields={visibleIndicatorFields}

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { memo, useCallback, useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { ChevronRight, ChevronDown } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -54,7 +54,7 @@ function LazyExpandedChart({ symbol, currency }: { symbol: string; currency: str
   )
 }
 
-export function TableRow({
+export const TableRow = memo(function TableRow({
   groupId,
   asset,
   quote,
@@ -73,9 +73,9 @@ export function TableRow({
   quote?: Quote
   indicator?: IndicatorSummary
   expanded: boolean
-  onToggle: () => void
-  onDelete: () => void
-  onHover: () => void
+  onToggle: (symbol: string) => void
+  onDelete: (symbol: string) => void
+  onHover: (symbol: string) => void
   compactMode: boolean
   columnSettings: Record<string, boolean>
   visibleIndicatorFields: string[]
@@ -102,13 +102,17 @@ export function TableRow({
   const py = compactMode ? "py-1.5" : "py-2.5"
   const staleClass = showStale ? "stale-price" : ""
 
+  const handleToggle = useCallback(() => onToggle(asset.symbol), [onToggle, asset.symbol])
+  const handleDelete = useCallback(() => onDelete(asset.symbol), [onDelete, asset.symbol])
+  const handleHover = useCallback(() => onHover(asset.symbol), [onHover, asset.symbol])
+
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <tr
           className="border-b border-border hover:bg-muted/30 data-[state=open]:bg-muted/30 cursor-pointer group transition-colors"
-          onClick={onToggle}
-          onMouseEnter={onHover}
+          onClick={handleToggle}
+          onMouseEnter={handleHover}
         >
           <td className={`${py} pl-2`}>
             {expanded ? (
@@ -256,7 +260,7 @@ export function TableRow({
         groupId={groupId}
         assetId={asset.id}
         symbol={asset.symbol}
-        onRemove={onDelete}
+        onRemove={handleDelete}
       />
       {expanded && (
         <tr>
@@ -269,4 +273,4 @@ export function TableRow({
       )}
     </ContextMenu>
   )
-}
+})

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useTransition } from "react"
+import { useCallback, useState, useMemo, useTransition } from "react"
 import { Activity, ArrowDownAZ, ArrowUpAZ, LayoutGrid, Pencil, ScanLine, Star, Table, TrendingUp } from "lucide-react"
 import { resolveIcon } from "@/lib/icon-utils"
 import { Button } from "@/components/ui/button"
@@ -83,10 +83,10 @@ export function GroupPage({ groupId }: { groupId: number }) {
     }
   }
 
-  const handleRemove = (symbol: string) => {
+  const handleRemove = useCallback((symbol: string) => {
     const asset = allAssets?.find((a) => a.symbol === symbol)
     if (asset) removeFromGroup.mutate({ groupId, assetId: asset.id })
-  }
+  }, [allAssets, removeFromGroup, groupId])
 
   const toggleTag = (id: number) =>
     setSelectedTags((prev) =>
@@ -251,8 +251,8 @@ export function GroupPage({ groupId }: { groupId: number }) {
               quote={quotes[asset.symbol]}
               sparklineData={batchSparklines?.[asset.symbol]}
               indicatorData={batchIndicators?.[asset.symbol]}
-              onDelete={() => handleRemove(asset.symbol)}
-              onHover={() => prefetch(asset.symbol)}
+              onDelete={handleRemove}
+              onHover={prefetch}
               showSparkline={settings.group_show_sparkline}
               indicatorVisibility={settings.indicator_visibility}
             />


### PR DESCRIPTION
## Summary
- `AssetCard` wrapped in `React.memo()` — only re-renders when its specific quote/data changes
- `TableRow` wrapped in `React.memo()` — same per-row isolation
- Callback props restructured from inline closures to stable `useCallback` references with symbol-based signatures
- `enabledCards` computation memoized with `useMemo`
- Prevents 25-100+ unnecessary re-renders on every SSE quote tick (every 15s during market hours)

Closes #462

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` passes
- [ ] Manual: price flash animation still works on quote updates
- [ ] Manual: sparklines and indicator cards render correctly
- [ ] Manual: context menu (remove asset) still works
- [ ] Manual: table row expand/collapse still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)