### PR TITLE
perf: add per-symbol quote subscription to reduce SSE re-render scope

### DIFF
--- a/frontend/src/lib/quote-stream.tsx
+++ b/frontend/src/lib/quote-stream.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from "react"
 import type { Quote } from "./api"
 import type { IntradayPoint } from "./types"
 
@@ -6,20 +6,85 @@ type QuoteMap = Record<string, Quote>
 type IntradayMap = Record<string, IntradayPoint[]>
 type ConnectionStatus = "connecting" | "connected" | "reconnecting" | "disconnected"
 
+// ---------------------------------------------------------------------------
+// Per-symbol subscription store (avoids full-map re-renders)
+// ---------------------------------------------------------------------------
+
+type Listener = () => void
+
+/** Ref-based store that tracks per-symbol subscribers and only notifies
+ *  listeners whose symbol actually changed in the latest SSE tick. */
+class QuoteStore {
+  private _quotes: QuoteMap = {}
+  private _listeners = new Map<string, Set<Listener>>()
+  private _globalListeners = new Set<Listener>()
+
+  getQuotes(): QuoteMap {
+    return this._quotes
+  }
+
+  getQuote(symbol: string): Quote | undefined {
+    return this._quotes[symbol]
+  }
+
+  /** Merge incoming delta and notify only affected subscribers. */
+  merge(delta: QuoteMap) {
+    const changedSymbols = Object.keys(delta)
+    if (changedSymbols.length === 0) return
+
+    this._quotes = { ...this._quotes, ...delta }
+
+    // Notify per-symbol listeners for changed symbols only
+    for (const sym of changedSymbols) {
+      const listeners = this._listeners.get(sym)
+      if (listeners) {
+        for (const cb of listeners) cb()
+      }
+    }
+    // Notify global listeners (useQuotes consumers)
+    for (const cb of this._globalListeners) cb()
+  }
+
+  subscribeSymbol(symbol: string, listener: Listener): () => void {
+    let set = this._listeners.get(symbol)
+    if (!set) {
+      set = new Set()
+      this._listeners.set(symbol, set)
+    }
+    set.add(listener)
+    return () => {
+      set!.delete(listener)
+      if (set!.size === 0) this._listeners.delete(symbol)
+    }
+  }
+
+  subscribeAll(listener: Listener): () => void {
+    this._globalListeners.add(listener)
+    return () => {
+      this._globalListeners.delete(listener)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
 interface QuoteStreamState {
-  quotes: QuoteMap
+  store: QuoteStore
   intraday: IntradayMap
   status: ConnectionStatus
 }
 
+const defaultStore = new QuoteStore()
 const QuoteStreamContext = createContext<QuoteStreamState>({
-  quotes: {},
+  store: defaultStore,
   intraday: {},
   status: "connecting",
 })
 
 export function QuoteStreamProvider({ children }: { children: React.ReactNode }) {
-  const [quotes, setQuotes] = useState<QuoteMap>({})
+  const [storeRef] = useState(() => new QuoteStore())
   const [intraday, setIntraday] = useState<IntradayMap>({})
   const [status, setStatus] = useState<ConnectionStatus>("connecting")
   const esRef = useRef<EventSource | null>(null)
@@ -36,7 +101,7 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
           const data = JSON.parse(e.data) as QuoteMap
           const count = Object.keys(data).length
           if (count === 0) return
-          setQuotes((prev) => ({ ...prev, ...data }))
+          storeRef.merge(data)
           setStatus("connected")
           backoffMs.current = 1_000 // reset backoff on successful data
         } catch (err) {
@@ -112,18 +177,39 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
       esRef.current = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
     }
-  }, [])
+  }, [storeRef])
 
   return (
-    <QuoteStreamContext.Provider value={{ quotes, intraday, status }}>
+    <QuoteStreamContext.Provider value={{ store: storeRef, intraday, status }}>
       {children}
     </QuoteStreamContext.Provider>
   )
 }
 
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/** Return the full quote map. Re-renders on every SSE tick.
+ *  Prefer `useQuote(symbol)` when only one symbol is needed. */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useQuotes(): QuoteMap {
-  return useContext(QuoteStreamContext).quotes
+  const { store } = useContext(QuoteStreamContext)
+  const subscribe = useCallback((cb: Listener) => store.subscribeAll(cb), [store])
+  const getSnapshot = useCallback(() => store.getQuotes(), [store])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** Return a single symbol's quote. Only re-renders when that symbol changes. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useQuote(symbol: string): Quote | undefined {
+  const { store } = useContext(QuoteStreamContext)
+  const subscribe = useCallback(
+    (cb: Listener) => store.subscribeSymbol(symbol, cb),
+    [store, symbol],
+  )
+  const getSnapshot = useCallback(() => store.getQuote(symbol), [store, symbol])
+  return useSyncExternalStore(subscribe, getSnapshot)
 }
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/frontend/src/pages/asset-detail/chart-section.tsx
+++ b/frontend/src/pages/asset-detail/chart-section.tsx
@@ -2,7 +2,7 @@ import { PriceChart } from "@/components/price-chart"
 import { ChartSkeleton } from "@/components/chart-skeleton"
 import { IntradayChart } from "@/components/intraday-chart"
 import { useAssetDetail, useAnnotations } from "@/lib/queries"
-import { useIntraday, useQuotes } from "@/lib/quote-stream"
+import { useIntraday, useQuote } from "@/lib/quote-stream"
 import type { Placement } from "@/lib/indicator-registry"
 import type { ChartMode } from "./header"
 
@@ -37,9 +37,9 @@ export function ChartSection({
 
 function LiveChartSection({ symbol }: { symbol: string }) {
   const intraday = useIntraday()
-  const quotes = useQuotes()
-  const points = intraday[symbol.toUpperCase()]
-  const quote = quotes[symbol.toUpperCase()]
+  const upperSymbol = symbol.toUpperCase()
+  const points = intraday[upperSymbol]
+  const quote = useQuote(upperSymbol)
   const previousClose = quote?.previous_close ?? null
 
   if (!points || points.length === 0) {

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -5,7 +5,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { PeriodSelector } from "@/components/period-selector"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { buildYahooFinanceUrl, formatPrice, formatCompactPrice, formatChangePct } from "@/lib/format"
-import { useQuotes } from "@/lib/quote-stream"
+import { useQuote } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useRefreshPrices, useCreateAsset } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
@@ -34,8 +34,7 @@ export function Header({
   const { settings } = useSettings()
   const refresh = useRefreshPrices(symbol)
   const createAsset = useCreateAsset()
-  const quotes = useQuotes()
-  const quote = quotes[symbol.toUpperCase()]
+  const quote = useQuote(symbol.toUpperCase())
   const price = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
   const [priceRef, pctRef] = usePriceFlash(price)

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -13,7 +13,7 @@ import {
   useUpdateThesis,
 } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
-import { useQuotes } from "@/lib/quote-stream"
+import { useQuote } from "@/lib/quote-stream"
 import { StatsPanel } from "@/components/stats-panel"
 import { Header, type ChartMode } from "./header"
 import { ChartSection } from "./chart-section"
@@ -28,8 +28,7 @@ export function AssetDetailPage() {
   const { data: assets } = useAssets()
   const asset = assets?.find((a) => a.symbol === symbol?.toUpperCase())
   const { data: detail } = useAssetDetail(symbol ?? "", period, { enabled: !!symbol && mode !== "live" })
-  const quotes = useQuotes()
-  const quote = symbol ? quotes[symbol.toUpperCase()] : undefined
+  const quote = useQuote(symbol?.toUpperCase() ?? "")
   const isTracked = !!asset
   const isEtf = asset?.type === "etf"
 


### PR DESCRIPTION
## Summary
- New `QuoteStore` class replaces React context state with a ref-based store that tracks per-symbol subscribers
- New `useQuote(symbol)` hook via `useSyncExternalStore` — only re-renders when that specific symbol's quote changes
- Asset detail page (index, header, chart-section) updated to use `useQuote(symbol)` instead of `useQuotes()` full map
- `useQuotes()` still available and uses `useSyncExternalStore` with global listeners for components needing the full map (group page sorting/filtering)
- Combined with #462 (memoization), this eliminates virtually all unnecessary re-renders from SSE quote ticks

Closes #463

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` passes
- [ ] Manual: asset detail page price still updates in real-time
- [ ] Manual: group page still shows live prices for all assets
- [ ] Manual: price flash animation works on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)