### PR TITLE
refactor: add typed backend settings schema with validation

### DIFF
--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -22,4 +22,5 @@ async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_d
     """Replace the user settings object. The `data` field is a free-form JSON
     object storing preferences like `group_show_rsi`, `compact_mode`, etc.
     """
-    return await settings_service.update_settings(db, body.data)
+    data_dict = body.data.model_dump(exclude_none=True)
+    return await settings_service.update_settings(db, data_dict)

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,23 +1,55 @@
 import json
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 MAX_SETTINGS_BYTES = 65_536  # 64 KB
 
 
+class AppSettingsData(BaseModel):
+    """Typed settings schema mirroring the frontend's AppSettings interface.
+
+    All fields are optional so partial updates (patches) are accepted.
+    Unknown keys from newer frontend versions are preserved via extra="allow".
+    """
+
+    indicator_visibility: dict[str, list[str]] | None = None
+    group_macd_style: Literal["classic", "divergence"] | None = None
+    group_show_sparkline: bool | None = None
+    group_view_mode: Literal["card", "table", "scanner", "live"] | None = None
+    group_type_filter: Literal["all", "stock", "etf"] | None = None
+    group_sort_by: str | None = None
+    group_sort_dir: Literal["asc", "desc"] | None = None
+    group_table_columns: dict[str, bool] | None = None
+    group_table_column_widths: dict[str, float] | None = None
+    chart_default_period: str | None = None
+    chart_type: Literal["candle", "line"] | None = None
+    theme: Literal["dark", "light", "system"] | None = None
+    compact_mode: bool | None = None
+    compact_numbers: bool | None = None
+    show_asset_type_badge: bool | None = None
+    decimal_places: int | None = None
+    sync_pseudo_etf_crosshairs: bool | None = None
+    show_indicator_deltas: bool | None = None
+    thousands_separator: bool | None = None
+
+    model_config = {"extra": "allow"}
+
+
 class SettingsResponse(BaseModel):
-    data: dict = Field(description="Free-form settings object (e.g. group_show_rsi, compact_mode)")
+    data: dict = Field(description="Settings object with typed keys (see AppSettingsData)")
 
     model_config = {"from_attributes": True}
 
 
 class SettingsUpdate(BaseModel):
-    data: dict = Field(description="Complete settings object — replaces the existing value")
+    data: AppSettingsData = Field(description="Settings object — validated against AppSettingsData schema")
 
-    @field_validator("data")
+    @field_validator("data", mode="before")
     @classmethod
-    def limit_payload_size(cls, v: dict) -> dict:
-        size = len(json.dumps(v, separators=(",", ":")))
+    def limit_payload_size(cls, v: dict | AppSettingsData) -> dict | AppSettingsData:
+        raw = v if isinstance(v, dict) else v.model_dump(exclude_none=True)
+        size = len(json.dumps(raw, separators=(",", ":")))
         if size > MAX_SETTINGS_BYTES:
             raise ValueError(f"settings payload too large ({size} bytes, max {MAX_SETTINGS_BYTES})")
         return v

--- a/backend/tests/integration/test_settings.py
+++ b/backend/tests/integration/test_settings.py
@@ -30,3 +30,19 @@ async def test_put_overwrites(client):
     await client.put("/api/settings", json={"data": {"theme": "light", "extra": 1}})
     resp = await client.get("/api/settings")
     assert resp.json()["data"] == {"theme": "light", "extra": 1}
+
+
+async def test_put_rejects_invalid_theme(client):
+    resp = await client.put("/api/settings", json={"data": {"theme": "neon"}})
+    assert resp.status_code == 422
+
+
+async def test_put_rejects_invalid_chart_type(client):
+    resp = await client.put("/api/settings", json={"data": {"chart_type": "bar"}})
+    assert resp.status_code == 422
+
+
+async def test_put_accepts_unknown_keys(client):
+    resp = await client.put("/api/settings", json={"data": {"future_setting": True}})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["future_setting"] is True


### PR DESCRIPTION
## Summary
- New `AppSettingsData` Pydantic model mirrors the frontend's `AppSettings` TypeScript interface
- Known settings fields are validated (e.g. `theme` must be `dark|light|system`, `chart_type` must be `candle|line`)
- Unknown keys preserved via `extra="allow"` for forward compatibility — newer frontend versions can add settings without requiring backend changes
- 64KB payload size limit protects against unbounded JSON storage
- 3 new integration tests: rejects invalid theme, rejects invalid chart_type, accepts unknown future keys

Closes #427

## Test plan
- [x] All 545 backend tests pass (542 existing + 3 new)
- [x] Existing settings roundtrip test still works (no breaking changes)
- [x] Invalid values return 422
- [x] Unknown keys accepted and persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)