### PR TITLE
refactor: add PriceProvider abstraction (#480)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,6 +4,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://fibenchi:fibenchi@db:5432/fibenchi"
     refresh_cron: str = "0 23 * * *"
+    price_provider: str = "yahoo"
 
     model_config = {"env_prefix": ""}
 

--- a/backend/app/services/price_providers/__init__.py
+++ b/backend/app/services/price_providers/__init__.py
@@ -1,0 +1,37 @@
+"""Price provider registry — resolves a provider name to a singleton instance."""
+
+from app.config import settings
+from app.services.price_providers.base import PriceProvider
+from app.services.price_providers.yahoo import YahooPriceProvider
+
+__all__ = ["PriceProvider", "init_price_provider", "get_price_provider"]
+
+_PROVIDERS: dict[str, type[PriceProvider]] = {
+    "yahoo": YahooPriceProvider,
+}
+
+_instance: PriceProvider | None = None
+
+
+def init_price_provider() -> None:
+    """Instantiate the configured price provider (called once at startup)."""
+    global _instance
+    name = settings.price_provider
+    cls = _PROVIDERS.get(name)
+    if cls is None:
+        raise ValueError(
+            f"Unknown price provider: {name!r}. Available: {list(_PROVIDERS)}"
+        )
+    _instance = cls()
+
+
+def get_price_provider() -> PriceProvider:
+    """Return the active price provider singleton.
+
+    Raises RuntimeError if init_price_provider() hasn't been called yet.
+    """
+    if _instance is None:
+        raise RuntimeError(
+            "Price provider not initialized — call init_price_provider() first"
+        )
+    return _instance

--- a/backend/app/services/price_providers/base.py
+++ b/backend/app/services/price_providers/base.py
@@ -1,0 +1,54 @@
+"""Abstract base class for price data providers."""
+
+from abc import ABC, abstractmethod
+from datetime import date
+
+import pandas as pd
+
+
+class PriceProvider(ABC):
+    """Provider interface for OHLCV price data, quotes, and currency info.
+
+    Implementations wrap a specific data source (Yahoo Finance, IBKR, etc.).
+    Consumers call get_price_provider() and use this interface without
+    knowing which backend is active.
+    """
+
+    @abstractmethod
+    async def fetch_history(
+        self,
+        symbol: str,
+        period: str = "3mo",
+        interval: str = "1d",
+        start: date | None = None,
+        end: date | None = None,
+    ) -> pd.DataFrame:
+        """Fetch OHLCV history for a single symbol.
+
+        Returns DataFrame with index=date, columns=[open, high, low, close, volume].
+        Raises ValueError if no data is available.
+        """
+
+    @abstractmethod
+    async def batch_fetch_history(
+        self, symbols: list[str], period: str = "1y"
+    ) -> dict[str, pd.DataFrame]:
+        """Fetch OHLCV history for multiple symbols in one call.
+
+        Returns {symbol: DataFrame} for symbols that have data.
+        """
+
+    @abstractmethod
+    async def batch_fetch_quotes(self, symbols: list[str]) -> list[dict]:
+        """Fetch current market quotes for multiple symbols.
+
+        Returns list of dicts with keys: symbol, price, previous_close,
+        change, change_percent, volume, avg_volume, currency, market_state.
+        """
+
+    @abstractmethod
+    async def batch_fetch_currencies(self, symbols: list[str]) -> dict[str, str]:
+        """Fetch display currency codes for multiple symbols.
+
+        Returns {symbol: currency_code} (e.g. {"AAPL": "USD", "ABI.BR": "EUR"}).
+        """

--- a/backend/app/services/price_providers/yahoo.py
+++ b/backend/app/services/price_providers/yahoo.py
@@ -1,0 +1,41 @@
+"""Yahoo Finance price provider — thin wrapper around existing yahoo/ functions."""
+
+import asyncio
+from datetime import date
+
+import pandas as pd
+
+from app.services.price_providers.base import PriceProvider
+from app.services.yahoo import (
+    batch_fetch_history as _batch_fetch_history,
+    batch_fetch_quotes as _batch_fetch_quotes,
+    fetch_history as _fetch_history,
+)
+from app.services.yahoo.quotes import batch_fetch_currencies as _batch_fetch_currencies_sync
+
+
+class YahooPriceProvider(PriceProvider):
+    """Delegates all price operations to the existing yahoo/ service package."""
+
+    async def fetch_history(
+        self,
+        symbol: str,
+        period: str = "3mo",
+        interval: str = "1d",
+        start: date | None = None,
+        end: date | None = None,
+    ) -> pd.DataFrame:
+        return await _fetch_history(
+            symbol, period=period, interval=interval, start=start, end=end,
+        )
+
+    async def batch_fetch_history(
+        self, symbols: list[str], period: str = "1y"
+    ) -> dict[str, pd.DataFrame]:
+        return await _batch_fetch_history(symbols, period=period)
+
+    async def batch_fetch_quotes(self, symbols: list[str]) -> list[dict]:
+        return await _batch_fetch_quotes(symbols)
+
+    async def batch_fetch_currencies(self, symbols: list[str]) -> dict[str, str]:
+        return await asyncio.to_thread(_batch_fetch_currencies_sync, symbols)

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -14,8 +14,8 @@ from app.schemas.price import AssetDetailResponse, IndicatorResponse, PriceRespo
 from app.services.compute.indicators import INDICATOR_REGISTRY, compute_indicators, safe_round
 from app.services.compute.utils import prices_to_df
 from app.services.fundamentals_cache import merge_fundamentals_into_rows
+from app.services.price_providers import get_price_provider
 from app.services.price_sync import sync_asset_prices, sync_asset_prices_range
-from app.services.yahoo import fetch_history
 from app.utils import TTLCache
 
 # In-memory indicator cache: keyed by "SYMBOL:period:last_price_date"
@@ -57,7 +57,8 @@ async def _fetch_ephemeral(symbol: str, period: str, warmup: bool = False) -> pd
         days += WARMUP_DAYS
     start_date = date.today() - timedelta(days=days)
     try:
-        df = await fetch_history(symbol.upper(), start=start_date, end=date.today())
+        provider = get_price_provider()
+        df = await provider.fetch_history(symbol.upper(), start=start_date, end=date.today())
     except (ValueError, KeyError):
         raise HTTPException(404, f"No price data available for {symbol}")
 

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -8,7 +8,7 @@ import time as _time
 from app.database import async_session
 from app.repositories.asset_repo import AssetRepository
 from app.services.intraday import get_intraday_bars
-from app.services.yahoo import batch_fetch_quotes
+from app.services.price_providers import get_price_provider
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ async def get_quotes(symbols: str) -> list[dict]:
     symbol_list = [s.strip().upper() for s in symbols.split(",") if s.strip()]
     if not symbol_list:
         return []
-    return await batch_fetch_quotes(symbol_list)
+    return await get_price_provider().batch_fetch_quotes(symbol_list)
 
 
 async def quote_event_generator():
@@ -66,7 +66,7 @@ async def quote_event_generator():
                 await asyncio.sleep(60)
                 continue
 
-            quotes = await batch_fetch_quotes(symbols)
+            quotes = await get_price_provider().batch_fetch_quotes(symbols)
 
             # Build keyed payload
             full_payload: dict[str, dict] = {}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,7 @@ from app.main import app
 from app.models.currency import Currency
 from app.models.group import Group
 from app.services.currency_service import load_cache as load_currency_cache
+from app.services.price_providers import init_price_provider
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
@@ -43,6 +44,8 @@ async def setup_db():
     # Populate in-memory currency cache
     async with TestSession() as session:
         await load_currency_cache(session)
+    # Initialize price provider singleton (mirrors main.py lifespan)
+    init_price_provider()
     yield
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -2,7 +2,7 @@
 
 import pytest
 from datetime import date
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 import pandas as pd
 
@@ -29,6 +29,14 @@ def _make_df(n=10, base_price=100.0):
     }, index=dates)
 
 
+def _mock_provider(**overrides):
+    """Create a mock PriceProvider with async method stubs."""
+    provider = MagicMock()
+    provider.fetch_history = AsyncMock(return_value=overrides.get("fetch_history", _make_df()))
+    provider.batch_fetch_history = AsyncMock(return_value=overrides.get("batch_fetch_history", {}))
+    return provider
+
+
 # --- sync_asset_prices ---
 
 async def test_sync_calls_fetch_with_period(db):
@@ -37,12 +45,12 @@ async def test_sync_calls_fetch_with_period(db):
     db.add(asset)
     await db.flush()
 
-    mock_df = _make_df()
-    with patch("app.services.price_sync.fetch_history", return_value=mock_df) as mock_fetch, \
+    mock_prov = _mock_provider()
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
          patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=10):
         count = await sync_asset_prices(db, asset, period="6mo")
 
-    mock_fetch.assert_called_once_with("TEST", period="6mo")
+    mock_prov.fetch_history.assert_awaited_once_with("TEST", period="6mo")
     assert count == 10
 
 
@@ -52,7 +60,8 @@ async def test_sync_returns_upsert_count(db):
     db.add(asset)
     await db.flush()
 
-    with patch("app.services.price_sync.fetch_history", return_value=_make_df()), \
+    mock_prov = _mock_provider()
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
          patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=7):
         assert await sync_asset_prices(db, asset) == 7
 
@@ -66,11 +75,12 @@ async def test_sync_range_passes_dates(db):
     await db.flush()
 
     start, end = date(2025, 1, 1), date(2025, 6, 30)
-    with patch("app.services.price_sync.fetch_history", return_value=_make_df()) as mock_fetch, \
+    mock_prov = _mock_provider()
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
          patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=5):
         count = await sync_asset_prices_range(db, asset, start, end)
 
-    mock_fetch.assert_called_once_with("RNG", start=start, end=end)
+    mock_prov.fetch_history.assert_awaited_once_with("RNG", start=start, end=end)
     assert count == 5
 
 
@@ -92,12 +102,13 @@ async def test_sync_all_fetches_batch(db):
     await db.commit()
 
     mock_data = {"AAPL": _make_df(), "MSFT": _make_df()}
-    with patch("app.services.price_sync.batch_fetch_history", return_value=mock_data) as mock_fetch, \
+    mock_prov = _mock_provider(batch_fetch_history=mock_data)
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
          patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=10):
         counts = await sync_all_prices(db, period="1y")
 
     # Verify batch_fetch_history was called with both symbols
-    call_args = mock_fetch.call_args
+    call_args = mock_prov.batch_fetch_history.call_args
     assert set(call_args[0][0]) == {"AAPL", "MSFT"}
     assert call_args[1]["period"] == "1y"
     assert counts == {"AAPL": 10, "MSFT": 10}
@@ -110,14 +121,15 @@ async def test_sync_all_empty_db(db):
 
 
 async def test_sync_all_skips_unknown_symbols(db):
-    """Symbols returned by Yahoo but not in DB are ignored."""
+    """Symbols returned by the provider but not in DB are ignored."""
     a1 = Asset(symbol="AAPL", name="Apple", type=AssetType.STOCK, currency="USD")
     db.add(a1)
     await db.commit()
 
-    # Yahoo returns data for AAPL and an unknown EXTRA symbol
+    # Provider returns data for AAPL and an unknown EXTRA symbol
     mock_data = {"AAPL": _make_df(), "EXTRA": _make_df()}
-    with patch("app.services.price_sync.batch_fetch_history", return_value=mock_data), \
+    mock_prov = _mock_provider(batch_fetch_history=mock_data)
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
          patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=10):
         counts = await sync_all_prices(db, period="1y")
 


### PR DESCRIPTION
## Summary
- Introduce `PriceProvider` ABC with `fetch_history`, `batch_fetch_history`, `batch_fetch_quotes`, `batch_fetch_currencies` methods
- `YahooPriceProvider` wraps existing `services/yahoo/` functions — no logic duplication
- Registry + factory pattern (`init_price_provider()` / `get_price_provider()`) matches existing `symbol_providers/` design
- Migrate all 5 consumer files (`price_sync`, `price_service`, `quote_service`, `main.py`, `compute/indicators`) to use the provider interface
- Add `PRICE_PROVIDER` env var (defaults to `"yahoo"`)

Prepares for IBKR Gateway as an alternative data source for EU symbols (issue #480) without scattering conditionals in consumer code.

## What does NOT change
- `services/yahoo/` package stays intact (implementation detail of YahooPriceProvider)
- Yahoo-only consumers stay as direct imports: `asset_service` (validate_symbol), `search_service`, `holdings_service` (fetch_etf_holdings), `fundamentals_cache`, `intraday` (resolve_currency)
- Frontend, schema, migrations — untouched

## Test plan
- [x] All 545 backend tests pass
- [x] Frontend lint + build clean
- [x] Integration tests updated to mock `get_price_provider()` instead of direct Yahoo imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)