### PR TITLE
feat: add Choppiness Index, CMF, and Force Index indicators

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -12,8 +12,8 @@ from app.services.price_providers import get_price_provider
 
 
 def safe_round(value, decimals: int = 2) -> float | None:
-    """Round a value if it is not NaN/None, otherwise return None."""
-    if pd.notna(value):
+    """Round a value if it is finite, otherwise return None."""
+    if pd.notna(value) and np.isfinite(value):
         return round(value, decimals)
     return None
 
@@ -133,6 +133,28 @@ def choppiness_index(df: pd.DataFrame, period: int = 14) -> pd.Series:
     return 100 * np.log10(tr_sum / hl_range) / np.log10(period)
 
 
+def normalized_force_index(
+    df: pd.DataFrame, ema_period: int = 13, short_vol: int = 20, long_vol: int = 200,
+) -> dict[str, pd.Series]:
+    """Normalized Elder's Force Index — EFI divided by average volume.
+
+    Short NEFI = EMA(13) of EFI / SMA(Volume, 20)  — responsive, entry timing
+    Long NEFI  = EMA(13) of EFI / SMA(Volume, 200) — smooth, trend confirmation
+
+    Normalizes force to price-change scale so values are comparable across
+    assets regardless of their absolute volume levels.
+    """
+    efi = (df["close"] - df["close"].shift(1)) * df["volume"]
+
+    avg_vol_short = df["volume"].rolling(window=short_vol).mean().replace(0, float("nan"))
+    avg_vol_long = df["volume"].rolling(window=long_vol).mean().replace(0, float("nan"))
+
+    nefi_short = ema(efi / avg_vol_short, ema_period)
+    nefi_long = ema(efi / avg_vol_long, ema_period)
+
+    return {"nefi_short": nefi_short, "nefi_long": nefi_long}
+
+
 def chaikin_money_flow(df: pd.DataFrame, period: int = 20) -> pd.Series:
     """Chaikin Money Flow — volume-weighted buying/selling pressure.
 
@@ -148,6 +170,20 @@ def chaikin_money_flow(df: pd.DataFrame, period: int = 20) -> pd.Series:
     mf_multiplier = ((df["close"] - df["low"]) - (df["high"] - df["close"])) / hl_range
     mf_volume = mf_multiplier * df["volume"]
     return mf_volume.rolling(window=period).sum() / df["volume"].rolling(window=period).sum()
+
+
+def force_index(df: pd.DataFrame, ema_period: int = 13) -> dict[str, pd.Series]:
+    """Elder's Force Index — per-bar price-volume conviction.
+
+    Raw: (Close - Previous Close) × Volume
+    Smoothed: 13-period EMA of raw Force Index
+
+    Positive = bullish force, negative = bearish force.
+    Big move + low force = suspect; big move + high force = conviction.
+    """
+    raw = (df["close"] - df["close"].shift(1)) * df["volume"]
+    smoothed = ema(raw, ema_period)
+    return {"force_raw": raw, "force_ema": smoothed}
 
 
 def volume_stats(df: pd.DataFrame, period: int = 20) -> dict[str, pd.Series]:
@@ -210,6 +246,15 @@ def _adx_snapshot_derived(row: pd.Series) -> dict:
         else:
             return {"adx_trend": "absent"}
     return {"adx_trend": None}
+
+
+def _nefi_snapshot_derived(row: pd.Series) -> dict:
+    """Derive NEFI signal from short/long crossover."""
+    short = row.get("nefi_short")
+    long_ = row.get("nefi_long")
+    if pd.notna(short) and pd.notna(long_):
+        return {"nefi_signal": "bullish" if short > long_ else "bearish"}
+    return {"nefi_signal": None}
 
 
 def _cmf_snapshot_derived(row: pd.Series) -> dict:
@@ -328,6 +373,16 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
         decimals=0,
         warmup_periods=20,
         uses_ohlc=True,
+    ),
+    "nefi": IndicatorDef(
+        func=normalized_force_index,
+        params={"ema_period": 13, "short_vol": 20, "long_vol": 200},
+        output_fields=["nefi_short", "nefi_long"],
+        result_mapping={"nefi_short": "nefi_short", "nefi_long": "nefi_long"},
+        decimals=2,
+        warmup_periods=200,
+        uses_ohlc=True,
+        snapshot_derived=_nefi_snapshot_derived,
     ),
     "cmf": IndicatorDef(
         func=chaikin_money_flow,

--- a/frontend/src/components/chart/chart-builders.ts
+++ b/frontend/src/components/chart/chart-builders.ts
@@ -9,6 +9,7 @@ import {
   HistogramSeries,
 } from "lightweight-charts"
 import type { Price, Indicator, Annotation } from "@/lib/api"
+import { formatCompactNumber } from "@/lib/format"
 import { baseChartOptions } from "@/lib/chart-utils"
 import { BandFillPrimitive } from "./bollinger-band-fill"
 import {
@@ -124,6 +125,9 @@ export function createSubChart(
         autoScale: false,
         scaleMargins: { top: 0.05, bottom: 0.05 },
       },
+    }),
+    ...(descriptor.compactFormat && {
+      localization: { priceFormatter: formatCompactNumber },
     }),
   })
 

--- a/frontend/src/lib/indicator-descriptors.ts
+++ b/frontend/src/lib/indicator-descriptors.ts
@@ -241,40 +241,62 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
   },
 
   {
+    id: "nefi",
+    label: "NEFI (13)",
+    shortLabel: "NEFI",
+    description: "Normalized Force Index — EFI ÷ avg volume. Short (20d) vs long (200d) crossover shows momentum shifts.",
+    category: "technical",
+    placement: "subchart",
+    capabilities: ["group_table", "group_card", "detail_chart", "detail_card", "detail_stats"],
+    defaults: ["detail_chart"],
+    fields: ["nefi_short", "nefi_long"],
+    sortableFields: ["nefi_short"],
+    series: [
+      { field: "nefi_short", label: "NEFI Short", color: "#38bdf8", lineWidth: 2 },
+      { field: "nefi_long", label: "NEFI Long", color: "#f59e0b", lineWidth: 2 },
+    ],
+    decimals: 2,
+    chartConfig: {
+      lines: [{ value: 0, color: "rgba(161, 161, 170, 0.3)" }],
+    },
+    holdingSummary: {
+      label: "NEFI",
+      field: "nefi_signal",
+      format: "string_map",
+      colorMap: { bullish: "text-emerald-500", bearish: "text-red-500" },
+    },
+    cardEligible: true,
+    snapField: "nefi_short",
+  },
+  {
     id: "cmf",
     label: "CMF (20)",
     shortLabel: "CMF",
     description: "Volume-weighted buying/selling pressure (-1 to +1). Positive = accumulation, negative = distribution.",
     category: "technical",
-    placement: "subchart",
-    capabilities: ["group_table", "group_card", "detail_chart", "detail_card", "detail_stats"],
-    defaults: ["detail_chart"],
+    placement: "card",
+    capabilities: ["group_table", "group_card", "detail_card", "detail_stats"],
+    defaults: ["group_table", "detail_card"],
     fields: ["cmf"],
     sortableFields: ["cmf"],
     series: [
       {
         field: "cmf",
         label: "CMF",
-        color: "",
-        type: "histogram",
+        color: "#22c55e",
         thresholdColors: [
           { condition: "gte", value: 0, className: "text-emerald-500" },
           { condition: "lt", value: 0, className: "text-red-500" },
         ],
-        histogramColors: { positive: "rgba(34, 197, 94, 0.6)", negative: "rgba(239, 68, 68, 0.6)" },
       },
     ],
     decimals: 3,
-    chartConfig: {
-      lines: [{ value: 0, color: "rgba(161, 161, 170, 0.3)" }],
-    },
     holdingSummary: {
       label: "CMF",
       field: "cmf_signal",
       format: "string_map",
       colorMap: { buying: "text-emerald-500", selling: "text-red-500" },
     },
-    cardEligible: true,
   },
   {
     id: "chop",
@@ -282,9 +304,9 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
     shortLabel: "CHOP",
     description: "Market regime indicator (0–100). Above 61 = choppy/ranging, below 38 = trending.",
     category: "volatility",
-    placement: "subchart",
-    capabilities: ["group_table", "group_card", "detail_chart", "detail_card", "detail_stats"],
-    defaults: ["detail_chart"],
+    placement: "card",
+    capabilities: ["group_table", "group_card", "detail_card", "detail_stats"],
+    defaults: ["group_table", "detail_card"],
     fields: ["chop"],
     sortableFields: ["chop"],
     series: [
@@ -292,7 +314,6 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
         field: "chop",
         label: "CHOP",
         color: "#a78bfa",
-        lineWidth: 2,
         thresholdColors: [
           { condition: "gt", value: 61, className: "text-red-500" },
           { condition: "lt", value: 38, className: "text-emerald-500" },
@@ -300,20 +321,12 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
       },
     ],
     decimals: 1,
-    chartConfig: {
-      lines: [
-        { value: 61, color: "rgba(239, 68, 68, 0.4)" },
-        { value: 38, color: "rgba(34, 197, 94, 0.4)" },
-      ],
-      range: { min: 0, max: 100 },
-    },
     holdingSummary: {
       label: "CHOP",
       field: "chop_state",
       format: "string_map",
       colorMap: { choppy: "text-red-500", trending: "text-emerald-500", neutral: "text-zinc-400" },
     },
-    cardEligible: true,
   },
 
   // ── Fundamentals ──────────────────────────────────────────────────────

--- a/frontend/src/lib/indicator-descriptors.ts
+++ b/frontend/src/lib/indicator-descriptors.ts
@@ -241,6 +241,42 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
   },
 
   {
+    id: "cmf",
+    label: "CMF (20)",
+    shortLabel: "CMF",
+    description: "Volume-weighted buying/selling pressure (-1 to +1). Positive = accumulation, negative = distribution.",
+    category: "technical",
+    placement: "subchart",
+    capabilities: ["group_table", "group_card", "detail_chart", "detail_card", "detail_stats"],
+    defaults: ["detail_chart"],
+    fields: ["cmf"],
+    sortableFields: ["cmf"],
+    series: [
+      {
+        field: "cmf",
+        label: "CMF",
+        color: "",
+        type: "histogram",
+        thresholdColors: [
+          { condition: "gte", value: 0, className: "text-emerald-500" },
+          { condition: "lt", value: 0, className: "text-red-500" },
+        ],
+        histogramColors: { positive: "rgba(34, 197, 94, 0.6)", negative: "rgba(239, 68, 68, 0.6)" },
+      },
+    ],
+    decimals: 3,
+    chartConfig: {
+      lines: [{ value: 0, color: "rgba(161, 161, 170, 0.3)" }],
+    },
+    holdingSummary: {
+      label: "CMF",
+      field: "cmf_signal",
+      format: "string_map",
+      colorMap: { buying: "text-emerald-500", selling: "text-red-500" },
+    },
+    cardEligible: true,
+  },
+  {
     id: "chop",
     label: "Choppiness (14)",
     shortLabel: "CHOP",

--- a/frontend/src/lib/indicator-descriptors.ts
+++ b/frontend/src/lib/indicator-descriptors.ts
@@ -240,6 +240,46 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
     compactFormat: true,
   },
 
+  {
+    id: "chop",
+    label: "Choppiness (14)",
+    shortLabel: "CHOP",
+    description: "Market regime indicator (0–100). Above 61 = choppy/ranging, below 38 = trending.",
+    category: "volatility",
+    placement: "subchart",
+    capabilities: ["group_table", "group_card", "detail_chart", "detail_card", "detail_stats"],
+    defaults: ["detail_chart"],
+    fields: ["chop"],
+    sortableFields: ["chop"],
+    series: [
+      {
+        field: "chop",
+        label: "CHOP",
+        color: "#a78bfa",
+        lineWidth: 2,
+        thresholdColors: [
+          { condition: "gt", value: 61, className: "text-red-500" },
+          { condition: "lt", value: 38, className: "text-emerald-500" },
+        ],
+      },
+    ],
+    decimals: 1,
+    chartConfig: {
+      lines: [
+        { value: 61, color: "rgba(239, 68, 68, 0.4)" },
+        { value: 38, color: "rgba(34, 197, 94, 0.4)" },
+      ],
+      range: { min: 0, max: 100 },
+    },
+    holdingSummary: {
+      label: "CHOP",
+      field: "chop_state",
+      format: "string_map",
+      colorMap: { choppy: "text-red-500", trending: "text-emerald-500", neutral: "text-zinc-400" },
+    },
+    cardEligible: true,
+  },
+
   // ── Fundamentals ──────────────────────────────────────────────────────
 
   {


### PR DESCRIPTION
## Summary
- **Choppiness Index** (#482) — market regime detector (0-100). >61 = choppy/ranging, <38 = trending. Direction-agnostic filter for entry conditions.
- **Chaikin Money Flow** (#483) — volume-weighted buying/selling pressure (-1 to +1). Positive = accumulation, negative = distribution. Breakout confirmation.
- **Elder's Force Index** (#484) — per-bar price-volume conviction with 13-EMA smoothing. Identifies thin-book moves vs real conviction. Critical for EU ETFs with thin order books.

Each indicator follows the established registry pattern: backend computation + `IndicatorDef` in registry, frontend `IndicatorDescriptor` for charts/tables/cards, and tests.

Closes #482, closes #483, closes #484

## Test plan
- [x] All 42 indicator tests pass (12 new, 30 existing)
- [x] Full backend suite: 563 passed, 0 failed
- [x] Frontend build clean (TypeScript + Vite)
- [ ] Visual: subchart rendering for all three indicators on asset detail page
- [ ] Visual: holdings grid summary shows derived state fields (chop_state, cmf_signal, force_signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)