### PR TITLE
feat: batch data query endpoint (GET /api/data)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from starlette.responses import FileResponse
 from app.config import settings as app_settings
 
 from app.database import async_session, engine
-from app.routers import annotations, assets, groups, holdings, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, symbol_sources, tags, thesis
+from app.routers import annotations, assets, data, groups, holdings, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, symbol_sources, tags, thesis
 from app.services.price_sync import sync_all_prices
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
@@ -187,6 +187,15 @@ app = FastAPI(
             "description": "Manage tracked stocks and ETFs. Assets are identified by ticker symbol and auto-validated against Yahoo Finance.",
         },
         {
+            "name": "data",
+            "description": (
+                "General-purpose batch data query for external tooling. Fetch quotes, indicator "
+                "snapshots, prices, and/or technical indicators for multiple tickers in a single "
+                "request. Works for any ticker — tracked assets use cached DB data, untracked "
+                "symbols are fetched ephemerally from the price provider."
+            ),
+        },
+        {
             "name": "prices",
             "description": "OHLCV price data and technical indicators (RSI, SMA 20/50, Bollinger Bands, MACD) for individual assets. Supports both persisted (grouped) and ephemeral (ungrouped) price fetching.",
         },
@@ -239,6 +248,7 @@ app = FastAPI(
 )
 
 app.include_router(assets.router)
+app.include_router(data.router)
 app.include_router(groups.router)
 app.include_router(tags.router)
 app.include_router(tags.asset_tag_router)

--- a/backend/app/routers/data.py
+++ b/backend/app/routers/data.py
@@ -1,0 +1,74 @@
+"""Batch data query endpoint for external tooling."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.constants import PeriodType
+from app.database import get_db
+from app.services.data_service import ALLOWED_FIELDS, MAX_SYMBOLS, query_batch_data
+
+router = APIRouter(prefix="/api/data", tags=["data"])
+
+
+@router.get(
+    "",
+    summary="Batch data query for multiple symbols",
+    response_description="Dict keyed by symbol with requested data fields, or per-symbol error.",
+)
+async def get_data(
+    symbols: str = Query(
+        ...,
+        min_length=1,
+        description="Comma-separated ticker symbols (e.g. RKLB,IONQ,NET). Max 50.",
+    ),
+    fields: str = Query(
+        "quote,snapshot",
+        description="Comma-separated data fields: quote, snapshot, prices, indicators.",
+    ),
+    period: PeriodType = Query(
+        "3mo",
+        description="Time period for prices/indicators fields.",
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """Fetch quotes, indicator snapshots, prices, and/or technical indicators
+    for one or more ticker symbols in a single request.
+
+    Works for any ticker — tracked assets use cached DB data, untracked symbols
+    are fetched ephemerally from the price provider (Yahoo Finance).
+
+    **Fields:**
+
+    - `quote` — Real-time price, change, volume, market state
+    - `snapshot` — Latest indicator values (RSI, MACD, ATR, ADX…) and derived signals
+    - `prices` — OHLCV price history for the given period
+    - `indicators` — Full indicator time series for the given period
+
+    **Response shape:**
+
+        {
+          "RKLB": {"quote": {...}, "snapshot": {...}},
+          "BADTICKER": {"error": "No data available for BADTICKER"}
+        }
+    """
+    # Parse symbols
+    symbol_list = [s.strip().upper() for s in symbols.split(",") if s.strip()]
+    if not symbol_list:
+        raise HTTPException(status_code=422, detail="At least one symbol is required")
+    if len(symbol_list) > MAX_SYMBOLS:
+        raise HTTPException(
+            status_code=422, detail=f"Maximum {MAX_SYMBOLS} symbols per request"
+        )
+
+    # Parse and validate fields
+    field_set = {f.strip().lower() for f in fields.split(",") if f.strip()}
+    invalid = field_set - ALLOWED_FIELDS
+    if invalid:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid fields: {', '.join(sorted(invalid))}. Allowed: {', '.join(sorted(ALLOWED_FIELDS))}",
+        )
+    if not field_set:
+        raise HTTPException(status_code=422, detail="At least one field is required")
+
+    return await query_batch_data(db, symbol_list, field_set, period)

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -1,0 +1,127 @@
+"""Batch data query service — fetches quotes, snapshots, prices, and indicators for arbitrary symbols."""
+
+import logging
+from datetime import date
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Asset
+from app.services import price_service
+from app.services.compute.indicators import compute_batch_indicator_snapshots
+from app.services.entity_lookups import find_asset
+from app.services.price_providers import get_price_provider
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_FIELDS = frozenset({"quote", "snapshot", "prices", "indicators"})
+MAX_SYMBOLS = 50
+
+
+def _serialize_price(p) -> dict:
+    """Convert a PriceHistory ORM object or PriceResponse Pydantic model to a plain dict."""
+    if hasattr(p, "model_dump"):
+        d = p.model_dump()
+        if isinstance(d.get("date"), date):
+            d["date"] = d["date"].isoformat()
+        return d
+    return {
+        "date": p.date.isoformat() if isinstance(p.date, date) else str(p.date),
+        "open": round(float(p.open), 4),
+        "high": round(float(p.high), 4),
+        "low": round(float(p.low), 4),
+        "close": round(float(p.close), 4),
+        "volume": int(p.volume),
+    }
+
+
+def _serialize_indicator(row) -> dict:
+    """Convert an IndicatorResponse Pydantic model to a plain dict."""
+    d = row.model_dump()
+    if isinstance(d.get("date"), date):
+        d["date"] = d["date"].isoformat()
+    return d
+
+
+async def query_batch_data(
+    db: AsyncSession,
+    symbols: list[str],
+    fields: set[str],
+    period: str,
+) -> dict[str, dict]:
+    """Fetch requested data fields for multiple symbols.
+
+    Returns a dict keyed by symbol. Each value is a dict with the requested
+    field data, or ``{"error": "..."}`` if the symbol failed entirely.
+
+    Tracked assets (in DB) use cached prices; untracked symbols are fetched
+    ephemerally from the configured price provider.
+    """
+    results: dict[str, dict] = {sym: {} for sym in symbols}
+    symbol_errors: dict[str, str] = {}
+
+    # --- Batch: quotes (single provider call for all symbols) ---
+    if "quote" in fields:
+        try:
+            quotes = await get_price_provider().batch_fetch_quotes(symbols)
+            for q in quotes:
+                sym = q.get("symbol")
+                if sym and sym in results:
+                    results[sym]["quote"] = q
+        except Exception:
+            logger.exception("Batch quote fetch failed")
+
+    # --- Batch: snapshots (single provider call for all symbols) ---
+    if "snapshot" in fields:
+        try:
+            snapshots = await compute_batch_indicator_snapshots(symbols)
+            for snap in snapshots:
+                sym = snap.get("symbol")
+                if sym and sym in results:
+                    snap_data = {k: v for k, v in snap.items() if k != "symbol"}
+                    # Only include if we got actual computed data
+                    if snap_data.get("close") is not None:
+                        results[sym]["snapshot"] = snap_data
+        except Exception:
+            logger.exception("Batch snapshot fetch failed")
+
+    # --- Per-symbol: prices and/or indicators ---
+    if fields & {"prices", "indicators"}:
+        asset_map: dict[str, Asset | None] = {}
+        for sym in symbols:
+            asset_map[sym] = await find_asset(sym, db)
+
+        for sym in symbols:
+            asset = asset_map.get(sym)
+
+            if "prices" in fields and sym not in symbol_errors:
+                try:
+                    raw = await price_service.get_prices(db, asset, sym, period)
+                    results[sym]["prices"] = [_serialize_price(p) for p in raw]
+                except HTTPException:
+                    symbol_errors[sym] = f"No price data available for {sym}"
+                except Exception:
+                    logger.exception(f"Price fetch failed for {sym}")
+                    symbol_errors[sym] = f"Price fetch failed for {sym}"
+
+            if "indicators" in fields and sym not in symbol_errors:
+                try:
+                    raw = await price_service.get_indicators(db, asset, sym, period)
+                    results[sym]["indicators"] = [_serialize_indicator(i) for i in raw]
+                except HTTPException:
+                    symbol_errors.setdefault(sym, f"No indicator data available for {sym}")
+                except Exception:
+                    logger.exception(f"Indicator fetch failed for {sym}")
+                    symbol_errors.setdefault(sym, f"Indicator fetch failed for {sym}")
+
+    # Build final response
+    final: dict[str, dict] = {}
+    for sym in symbols:
+        if results[sym]:
+            final[sym] = results[sym]
+        elif sym in symbol_errors:
+            final[sym] = {"error": symbol_errors[sym]}
+        else:
+            final[sym] = {"error": f"No data available for {sym}"}
+
+    return final

--- a/backend/tests/integration/test_data.py
+++ b/backend/tests/integration/test_data.py
@@ -1,0 +1,283 @@
+"""Tests for GET /api/data batch query endpoint."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tests.helpers import make_yahoo_df, seed_asset_with_prices
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_symbols_422(client):
+    resp = await client.get("/api/data")
+    assert resp.status_code == 422
+
+
+async def test_empty_symbols_422(client):
+    resp = await client.get("/api/data?symbols=")
+    assert resp.status_code == 422
+
+
+async def test_too_many_symbols_422(client):
+    syms = ",".join(f"SYM{i}" for i in range(51))
+    resp = await client.get(f"/api/data?symbols={syms}")
+    assert resp.status_code == 422
+    assert "50" in resp.json()["detail"]
+
+
+async def test_invalid_field_422(client):
+    resp = await client.get("/api/data?symbols=AAPL&fields=bogus")
+    assert resp.status_code == 422
+    assert "bogus" in resp.json()["detail"]
+
+
+async def test_invalid_period_422(client):
+    resp = await client.get("/api/data?symbols=AAPL&fields=quote&period=99y")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Quote field
+# ---------------------------------------------------------------------------
+
+
+async def test_quote_field(client):
+    mock_quotes = [{"symbol": "AAPL", "price": 185.50, "change": 1.2}]
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
+    with patch("app.services.data_service.get_price_provider", return_value=mock_prov):
+        resp = await client.get("/api/data?symbols=AAPL&fields=quote")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "AAPL" in data
+    assert "quote" in data["AAPL"]
+    assert data["AAPL"]["quote"]["price"] == 185.50
+
+
+async def test_quote_multiple_symbols(client):
+    mock_quotes = [
+        {"symbol": "AAPL", "price": 185.50},
+        {"symbol": "MSFT", "price": 420.00},
+    ]
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
+    with patch("app.services.data_service.get_price_provider", return_value=mock_prov):
+        resp = await client.get("/api/data?symbols=AAPL,MSFT&fields=quote")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "AAPL" in data
+    assert "MSFT" in data
+    assert data["AAPL"]["quote"]["price"] == 185.50
+    assert data["MSFT"]["quote"]["price"] == 420.00
+
+
+# ---------------------------------------------------------------------------
+# Snapshot field
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_field(client):
+    mock_snapshots = [
+        {"symbol": "AAPL", "close": 185.5, "change_pct": 0.65, "currency": "USD", "values": {"rsi": 62.3}},
+    ]
+    with patch("app.services.data_service.compute_batch_indicator_snapshots", new_callable=AsyncMock, return_value=mock_snapshots):
+        resp = await client.get("/api/data?symbols=AAPL&fields=snapshot")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "AAPL" in data
+    assert "snapshot" in data["AAPL"]
+    assert data["AAPL"]["snapshot"]["close"] == 185.5
+    # symbol key should be removed from the snapshot data
+    assert "symbol" not in data["AAPL"]["snapshot"]
+
+
+# ---------------------------------------------------------------------------
+# Prices field
+# ---------------------------------------------------------------------------
+
+
+async def test_prices_tracked_asset(client, db):
+    """Tracked assets return prices from DB."""
+    await seed_asset_with_prices(db, symbol="TEST")
+    resp = await client.get("/api/data?symbols=TEST&fields=prices&period=3mo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "TEST" in data
+    assert "prices" in data["TEST"]
+    assert len(data["TEST"]["prices"]) > 0
+    assert set(data["TEST"]["prices"][0].keys()) == {"date", "open", "high", "low", "close", "volume"}
+
+
+async def test_prices_untracked_ephemeral(client):
+    """Untracked symbols fetch prices ephemerally from the provider."""
+    mock_df = make_yahoo_df()
+    mock_prov = MagicMock()
+    mock_prov.fetch_history = AsyncMock(return_value=mock_df)
+    with patch("app.services.price_service.get_price_provider", return_value=mock_prov):
+        resp = await client.get("/api/data?symbols=UNKNOWN&fields=prices&period=3mo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "UNKNOWN" in data
+    assert "prices" in data["UNKNOWN"]
+    assert len(data["UNKNOWN"]["prices"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Indicators field
+# ---------------------------------------------------------------------------
+
+
+async def test_indicators_tracked_asset(client, db):
+    """Tracked assets return computed indicators from DB prices."""
+    await seed_asset_with_prices(db, symbol="TEST")
+    resp = await client.get("/api/data?symbols=TEST&fields=indicators&period=3mo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "TEST" in data
+    assert "indicators" in data["TEST"]
+    assert len(data["TEST"]["indicators"]) > 0
+    row = data["TEST"]["indicators"][0]
+    assert "date" in row
+    assert "close" in row
+    assert "values" in row
+
+
+# ---------------------------------------------------------------------------
+# Default fields (quote + snapshot)
+# ---------------------------------------------------------------------------
+
+
+async def test_default_fields(client):
+    """Omitting fields parameter returns quote + snapshot."""
+    mock_quotes = [{"symbol": "AAPL", "price": 185.50}]
+    mock_snapshots = [{"symbol": "AAPL", "close": 185.5, "values": {"rsi": 55.0}}]
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
+    with (
+        patch("app.services.data_service.get_price_provider", return_value=mock_prov),
+        patch("app.services.data_service.compute_batch_indicator_snapshots", new_callable=AsyncMock, return_value=mock_snapshots),
+    ):
+        resp = await client.get("/api/data?symbols=AAPL")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "AAPL" in data
+    assert "quote" in data["AAPL"]
+    assert "snapshot" in data["AAPL"]
+
+
+# ---------------------------------------------------------------------------
+# All fields combined
+# ---------------------------------------------------------------------------
+
+
+async def test_all_fields(client, db):
+    await seed_asset_with_prices(db, symbol="TEST")
+    mock_quotes = [{"symbol": "TEST", "price": 150.0}]
+    mock_snapshots = [{"symbol": "TEST", "close": 150.0, "values": {"rsi": 55.0}}]
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
+    with (
+        patch("app.services.data_service.get_price_provider", return_value=mock_prov),
+        patch("app.services.data_service.compute_batch_indicator_snapshots", new_callable=AsyncMock, return_value=mock_snapshots),
+    ):
+        resp = await client.get("/api/data?symbols=TEST&fields=quote,snapshot,prices,indicators&period=3mo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "TEST" in data
+    assert "quote" in data["TEST"]
+    assert "snapshot" in data["TEST"]
+    assert "prices" in data["TEST"]
+    assert "indicators" in data["TEST"]
+
+
+# ---------------------------------------------------------------------------
+# Symbol handling
+# ---------------------------------------------------------------------------
+
+
+async def test_symbols_uppercase_normalization(client):
+    mock_quotes = [{"symbol": "AAPL", "price": 185.50}]
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
+    with patch("app.services.data_service.get_price_provider", return_value=mock_prov):
+        resp = await client.get("/api/data?symbols=aapl&fields=quote")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "AAPL" in data
+
+
+async def test_invalid_symbol_returns_error_not_500(client):
+    """Invalid symbols get a per-symbol error, not a 500."""
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=[])
+    mock_prov.fetch_history = AsyncMock(side_effect=ValueError("No data"))
+    with (
+        patch("app.services.data_service.get_price_provider", return_value=mock_prov),
+        patch("app.services.price_service.get_price_provider", return_value=mock_prov),
+    ):
+        resp = await client.get("/api/data?symbols=BADTICKER&fields=quote,prices")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "BADTICKER" in data
+    # quote was empty (not in batch result) and prices failed
+    assert "error" in data["BADTICKER"]
+
+
+async def test_mixed_tracked_untracked(client, db):
+    """Request with both tracked and untracked symbols returns data for both."""
+    await seed_asset_with_prices(db, symbol="TRACKED")
+    mock_quotes = [
+        {"symbol": "TRACKED", "price": 150.0},
+        {"symbol": "UNTRACKED", "price": 200.0},
+    ]
+    mock_df = make_yahoo_df()
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
+    mock_prov.fetch_history = AsyncMock(return_value=mock_df)
+    with (
+        patch("app.services.data_service.get_price_provider", return_value=mock_prov),
+        patch("app.services.price_service.get_price_provider", return_value=mock_prov),
+    ):
+        resp = await client.get("/api/data?symbols=TRACKED,UNTRACKED&fields=quote,prices&period=3mo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "TRACKED" in data
+    assert "UNTRACKED" in data
+    assert "quote" in data["TRACKED"]
+    assert "prices" in data["TRACKED"]
+    assert "prices" in data["UNTRACKED"]
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+
+async def test_response_only_requested_fields(client):
+    """Response should only contain the fields that were requested."""
+    mock_quotes = [{"symbol": "AAPL", "price": 185.50}]
+    mock_prov = MagicMock()
+    mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
+    with patch("app.services.data_service.get_price_provider", return_value=mock_prov):
+        resp = await client.get("/api/data?symbols=AAPL&fields=quote")
+    data = resp.json()
+    assert "quote" in data["AAPL"]
+    # These fields were not requested, so they should not be present
+    assert "snapshot" not in data["AAPL"]
+    assert "prices" not in data["AAPL"]
+    assert "indicators" not in data["AAPL"]
+
+
+async def test_period_applied_to_prices(client, db):
+    """Period param affects the date range of returned prices."""
+    await seed_asset_with_prices(db, symbol="TEST")
+    resp_3mo = await client.get("/api/data?symbols=TEST&fields=prices&period=3mo")
+    resp_1y = await client.get("/api/data?symbols=TEST&fields=prices&period=1y")
+    prices_3mo = resp_3mo.json()["TEST"]["prices"]
+    prices_1y = resp_1y.json()["TEST"]["prices"]
+    assert len(prices_1y) > len(prices_3mo)


### PR DESCRIPTION
## Summary
- New `GET /api/data` endpoint for batch-fetching quotes, indicators, prices for arbitrary tickers
- Configurable fields (`quote`, `snapshot`, `prices`, `indicators`) with `period` support
- Works for any ticker (tracked → DB cache, untracked → ephemeral Yahoo fetch)
- Per-symbol error handling (one bad ticker doesn't fail the request)
- 18 integration tests covering validation, all field types, and mixed symbol handling

Closes #486, #487, #488, #489

## Test plan
- [x] 580 backend tests passing (18 new)
- [x] Frontend build clean
- [ ] Manual: `curl /api/data?symbols=RKLB,IONQ&fields=quote,snapshot`
- [ ] Manual: `curl /api/data?symbols=AAPL&fields=prices,indicators&period=1y`

🤖 Generated with [Claude Code](https://claude.com/claude-code)