### PR TITLE
fix: bump fastapi and starlette for CVE fixes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
-fastapi==0.115.12
+fastapi==0.135.0
+starlette>=0.49.1
 uvicorn[standard]==0.34.3
 sqlalchemy[asyncio]==2.0.41
 asyncpg==0.31.0


### PR DESCRIPTION
## Summary
- Bumps `fastapi` from 0.115.12 to 0.135.0
- Pins `starlette>=0.49.1` to resolve CVE-2025-54121 and CVE-2025-62727
- `fastapi==0.115.12` capped starlette at `<0.47.0`, preventing the security fix from being installed

## Test plan
- [x] All 580 backend tests pass
- [x] Backend starts successfully with new deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)