### PR TITLE
fix: add 'Add to Group' dropdown on asset detail page

### DIFF
--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -1,13 +1,20 @@
 import { Link } from "react-router-dom"
-import { ArrowLeft, ExternalLink, RefreshCw, Plus } from "lucide-react"
+import { ArrowLeft, ExternalLink, RefreshCw, Plus, FolderPlus } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { PeriodSelector } from "@/components/period-selector"
 import { MarketStatusDot } from "@/components/market-status-dot"
+import { resolveIcon } from "@/lib/icon-utils"
 import { buildYahooFinanceUrl, formatPrice, formatCompactPrice, formatChangePct } from "@/lib/format"
 import { useQuote } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
-import { useRefreshPrices, useCreateAsset } from "@/lib/queries"
+import { useRefreshPrices, useCreateAsset, useGroups, useAddAssetsToGroup } from "@/lib/queries"
 import { useSettings } from "@/lib/settings"
 
 export type ChartMode = "live" | "historical"
@@ -19,6 +26,7 @@ export function Header({
   period,
   setPeriod,
   isTracked,
+  assetId,
   mode,
   setMode,
 }: {
@@ -28,12 +36,15 @@ export function Header({
   period: string
   setPeriod: (p: string) => void
   isTracked: boolean
+  assetId?: number
   mode: ChartMode
   setMode: (m: ChartMode) => void
 }) {
   const { settings } = useSettings()
   const refresh = useRefreshPrices(symbol)
   const createAsset = useCreateAsset()
+  const { data: groups } = useGroups()
+  const addToGroup = useAddAssetsToGroup()
   const quote = useQuote(symbol.toUpperCase())
   const price = quote?.price ?? null
   const changePct = quote?.change_percent ?? null
@@ -95,6 +106,36 @@ export function Header({
             {createAsset.isPending ? "Adding..." : "Track"}
           </Button>
         )}
+        {isTracked && assetId != null && groups && (() => {
+          const availableGroups = groups.filter(
+            (g) => !g.is_default && !g.assets.some((a) => a.id === assetId),
+          )
+          if (availableGroups.length === 0) return null
+          return (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm">
+                  <FolderPlus className="h-3.5 w-3.5 mr-1.5" />
+                  Add to Group
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                {availableGroups.map((g) => {
+                  const Icon = resolveIcon(g.icon)
+                  return (
+                    <DropdownMenuItem
+                      key={g.id}
+                      onClick={() => addToGroup.mutate({ groupId: g.id, assetIds: [assetId] })}
+                    >
+                      <Icon className="h-4 w-4" />
+                      {g.name}
+                    </DropdownMenuItem>
+                  )
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )
+        })()}
       </div>
       <div className="flex items-center gap-2">
         <Tabs value={mode} onValueChange={(v) => setMode(v as ChartMode)}>

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -36,7 +36,7 @@ export function AssetDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isTracked={isTracked} mode={mode} setMode={setMode} />
+      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
       <ChartSection
         symbol={symbol}
         period={period}


### PR DESCRIPTION
## Summary
- Adds an "Add to Group" dropdown button to the asset detail header for tracked assets
- Shows only non-default groups the asset isn't already a member of
- Button auto-hides when the asset is in all available groups
- Uses existing `useAddAssetsToGroup` mutation and `resolveIcon` for group icons

Closes #479

## Changes
- `frontend/src/pages/asset-detail/header.tsx`: Added `DropdownMenu` with group list, new `assetId` prop, imported `useGroups`/`useAddAssetsToGroup`
- `frontend/src/pages/asset-detail/index.tsx`: Passes `assetId` to `Header`

## Test plan
- [ ] Navigate to a tracked asset via global search (Cmd+K)
- [ ] Verify "Add to Group" button appears with available groups
- [ ] Click a group — asset is added, button updates (group disappears from list)
- [ ] Verify button hides when asset is in all non-default groups
- [ ] Verify untracked assets still show "Track" instead
- [ ] `pnpm lint` and `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)