### PR TITLE
feat: earnings countdown dial on stock detail page

### DIFF
--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -4,8 +4,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.constants import PeriodType
 from app.database import get_db
 from app.services.entity_lookups import find_asset, get_asset
+from app.schemas.earnings import EarningsResponse
 from app.schemas.price import AssetDetailResponse, IndicatorResponse, PriceResponse, RefreshResponse
 from app.services import price_service
+from app.services.earnings_cache import get_earnings
 
 router = APIRouter(prefix="/api/assets/{symbol}", tags=["prices"])
 
@@ -51,6 +53,13 @@ async def get_detail(symbol: str, period: PeriodType = Query("3mo"), db: AsyncSe
     """
     asset = await find_asset(symbol, db)
     return await price_service.get_detail(db, asset, symbol, period)
+
+
+@router.get("/earnings", response_model=EarningsResponse, summary="Get next earnings date")
+async def get_earnings_date(symbol: str):
+    """Return the next earnings date for a symbol (stocks only)."""
+    result = await get_earnings(symbol)
+    return EarningsResponse(**result) if result else EarningsResponse()
 
 
 @router.post("/refresh", response_model=RefreshResponse, status_code=200, summary="Force-refresh prices from Yahoo Finance")

--- a/backend/app/schemas/earnings.py
+++ b/backend/app/schemas/earnings.py
@@ -1,0 +1,9 @@
+import datetime
+
+from pydantic import BaseModel
+
+
+class EarningsResponse(BaseModel):
+    earnings_date: datetime.date | None = None
+    is_estimate: bool = True
+    last_reported_date: datetime.date | None = None

--- a/backend/app/services/earnings_cache.py
+++ b/backend/app/services/earnings_cache.py
@@ -1,0 +1,27 @@
+"""Earnings date cache with 24h TTL.
+
+Caches per-symbol earnings date lookups so the asset detail page
+doesn't hit Yahoo Finance on every load.
+"""
+
+import logging
+
+from app.services.yahoo.earnings import fetch_earnings_date
+from app.utils import TTLCache
+
+logger = logging.getLogger(__name__)
+
+_earnings_cache: TTLCache = TTLCache(default_ttl=86400, max_size=500, thread_safe=True)
+
+
+async def get_earnings(symbol: str) -> dict[str, object] | None:
+    """Return earnings date for symbol, using cache when available."""
+    upper = symbol.upper()
+    cached = _earnings_cache.get_value(upper)
+    if cached is not None:
+        return cached
+
+    result = await fetch_earnings_date(upper)
+    if result is not None:
+        _earnings_cache.set_value(upper, result)
+    return result

--- a/backend/app/services/yahoo/__init__.py
+++ b/backend/app/services/yahoo/__init__.py
@@ -36,6 +36,7 @@ from app.services.yahoo.quotes import (
     batch_fetch_currencies,
     batch_fetch_quotes,
 )
+from app.services.yahoo.earnings import fetch_earnings_date
 from app.services.yahoo.search import search
 from app.services.yahoo.validation import validate_symbol
 
@@ -61,6 +62,8 @@ __all__ = [
     # fundamentals
     "batch_fetch_fundamentals",
     "_batch_fetch_fundamentals_sync",
+    # earnings
+    "fetch_earnings_date",
     # search
     "search",
 ]

--- a/backend/app/services/yahoo/earnings.py
+++ b/backend/app/services/yahoo/earnings.py
@@ -1,0 +1,119 @@
+"""Yahoo Finance earnings date fetching."""
+
+import datetime
+import logging
+
+from yahooquery import Ticker
+
+from app.utils import async_threadable
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_earnings_date(raw: object) -> datetime.date | None:
+    """Parse Yahoo earnings date format into a date.
+
+    Yahoo returns formats like "2026-04-30 16:30:S" or plain "2026-04-30".
+    """
+    if raw is None:
+        return None
+    try:
+        s = str(raw).strip().split(" ")[0]
+        return datetime.date.fromisoformat(s)
+    except (ValueError, IndexError):
+        logger.debug("Could not parse earnings date: %r", raw)
+        return None
+
+
+def _extract_last_reported_date(earnings_data: dict) -> datetime.date | None:
+    """Extract the most recent reportedDate from earningsChart.quarterly.
+
+    Yahoo stores this as a unix timestamp in the quarterly entries.
+    """
+    chart = earnings_data.get("earningsChart", {})
+    if not isinstance(chart, dict):
+        return None
+    quarterly = chart.get("quarterly", [])
+    if not isinstance(quarterly, list) or not quarterly:
+        return None
+
+    # Find the most recent reportedDate
+    latest_ts = None
+    for q in quarterly:
+        if not isinstance(q, dict):
+            continue
+        ts = q.get("reportedDate")
+        if ts is not None and isinstance(ts, (int, float)):
+            if latest_ts is None or ts > latest_ts:
+                latest_ts = ts
+
+    if latest_ts is None:
+        return None
+
+    try:
+        return datetime.date.fromtimestamp(latest_ts)
+    except (OSError, ValueError):
+        return None
+
+
+def _fetch_earnings_date_sync(symbol: str) -> dict[str, object] | None:
+    """Fetch earnings dates from Yahoo Finance.
+
+    Uses calendar_events for the next earnings date, and earnings chart
+    for the most recent reported date (post-earnings detection).
+
+    Returns {"earnings_date": date, "is_estimate": bool,
+             "last_reported_date": date | None} or None.
+    """
+    try:
+        ticker = Ticker(symbol)
+        cal = ticker.calendar_events
+    except Exception:
+        logger.exception("Failed to fetch calendar_events for %s", symbol)
+        return None
+
+    # Yahoo returns a string error when data is unavailable
+    if not isinstance(cal, dict):
+        return None
+
+    sym_data = cal.get(symbol)
+    if not isinstance(sym_data, dict):
+        return None
+
+    earnings = sym_data.get("earnings", {})
+    if not isinstance(earnings, dict):
+        return None
+
+    dates = earnings.get("earningsDate", [])
+    if not isinstance(dates, list) or not dates:
+        return None
+
+    raw_date = dates[0]
+    parsed = _parse_earnings_date(raw_date)
+    if parsed is None:
+        return None
+
+    is_estimate = bool(earnings.get("isEarningsDateEstimate", True))
+
+    # Also try to get the last reported date from earnings chart
+    last_reported: datetime.date | None = None
+    try:
+        earnings_full = ticker.earnings
+        if isinstance(earnings_full, dict):
+            sym_earnings = earnings_full.get(symbol)
+            if isinstance(sym_earnings, dict):
+                last_reported = _extract_last_reported_date(sym_earnings)
+    except Exception:
+        logger.debug("Could not fetch earnings history for %s", symbol)
+
+    return {
+        "earnings_date": parsed,
+        "is_estimate": is_estimate,
+        "last_reported_date": last_reported,
+    }
+
+
+@async_threadable
+def fetch_earnings_date(symbol: str) -> dict[str, object] | None:
+    """Async wrapper for earnings date fetch."""
+    return _fetch_earnings_date_sync(symbol)

--- a/backend/tests/services/test_earnings.py
+++ b/backend/tests/services/test_earnings.py
@@ -1,0 +1,157 @@
+"""Tests for Yahoo Finance earnings date fetching."""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.yahoo.earnings import (
+    _extract_last_reported_date,
+    _fetch_earnings_date_sync,
+    _parse_earnings_date,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestParseEarningsDate:
+    def test_standard_format(self):
+        assert _parse_earnings_date("2026-04-30 16:30:S") == datetime.date(2026, 4, 30)
+
+    def test_date_only(self):
+        assert _parse_earnings_date("2026-04-30") == datetime.date(2026, 4, 30)
+
+    def test_none(self):
+        assert _parse_earnings_date(None) is None
+
+    def test_empty_string(self):
+        assert _parse_earnings_date("") is None
+
+    def test_invalid(self):
+        assert _parse_earnings_date("not-a-date") is None
+
+
+class TestExtractLastReportedDate:
+    def test_picks_most_recent(self):
+        data = {
+            "earningsChart": {
+                "quarterly": [
+                    {"date": "1Q2025", "reportedDate": 1746735000},
+                    {"date": "2Q2025", "reportedDate": 1754598163},
+                    {"date": "4Q2025", "reportedDate": 1772141075},
+                    {"date": "3Q2025", "reportedDate": 1762463400},
+                ]
+            }
+        }
+        result = _extract_last_reported_date(data)
+        assert result == datetime.date.fromtimestamp(1772141075)
+
+    def test_empty_quarterly(self):
+        assert _extract_last_reported_date({"earningsChart": {"quarterly": []}}) is None
+
+    def test_missing_chart(self):
+        assert _extract_last_reported_date({}) is None
+
+    def test_no_reported_date_field(self):
+        data = {"earningsChart": {"quarterly": [{"date": "1Q2025"}]}}
+        assert _extract_last_reported_date(data) is None
+
+
+class TestFetchEarningsDate:
+    @patch("app.services.yahoo.earnings.Ticker")
+    def test_confirmed_date_with_reported(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.calendar_events = {
+            "AAPL": {
+                "earnings": {
+                    "earningsDate": ["2026-04-30 16:30:S"],
+                    "isEarningsDateEstimate": False,
+                }
+            }
+        }
+        ticker.earnings = {
+            "AAPL": {
+                "earningsChart": {
+                    "quarterly": [
+                        {"date": "4Q2025", "reportedDate": 1772141075},
+                    ]
+                }
+            }
+        }
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_earnings_date_sync("AAPL")
+        assert result is not None
+        assert result["earnings_date"] == datetime.date(2026, 4, 30)
+        assert result["is_estimate"] is False
+        assert result["last_reported_date"] == datetime.date.fromtimestamp(1772141075)
+
+    @patch("app.services.yahoo.earnings.Ticker")
+    def test_estimated_date(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.calendar_events = {
+            "TSLA": {
+                "earnings": {
+                    "earningsDate": ["2026-07-15"],
+                    "isEarningsDateEstimate": True,
+                }
+            }
+        }
+        ticker.earnings = {"TSLA": {}}
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_earnings_date_sync("TSLA")
+        assert result is not None
+        assert result["earnings_date"] == datetime.date(2026, 7, 15)
+        assert result["is_estimate"] is True
+        assert result["last_reported_date"] is None
+
+    @patch("app.services.yahoo.earnings.Ticker")
+    def test_no_data_returns_none(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.calendar_events = {"AAPL": "No data found"}
+        mock_ticker_cls.return_value = ticker
+
+        assert _fetch_earnings_date_sync("AAPL") is None
+
+    @patch("app.services.yahoo.earnings.Ticker")
+    def test_string_error_returns_none(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.calendar_events = "No fundamentals data found"
+        mock_ticker_cls.return_value = ticker
+
+        assert _fetch_earnings_date_sync("AAPL") is None
+
+    @patch("app.services.yahoo.earnings.Ticker")
+    def test_empty_earnings_list_returns_none(self, mock_ticker_cls):
+        ticker = MagicMock()
+        ticker.calendar_events = {
+            "AAPL": {
+                "earnings": {
+                    "earningsDate": [],
+                }
+            }
+        }
+        mock_ticker_cls.return_value = ticker
+
+        assert _fetch_earnings_date_sync("AAPL") is None
+
+    @patch("app.services.yahoo.earnings.Ticker")
+    def test_earnings_history_error_still_returns_next_date(self, mock_ticker_cls):
+        """If ticker.earnings raises, we still get the next date."""
+        ticker = MagicMock()
+        ticker.calendar_events = {
+            "AAPL": {
+                "earnings": {
+                    "earningsDate": ["2026-04-30"],
+                    "isEarningsDateEstimate": True,
+                }
+            }
+        }
+        ticker.earnings = "No data found"  # string error
+        mock_ticker_cls.return_value = ticker
+
+        result = _fetch_earnings_date_sync("AAPL")
+        assert result is not None
+        assert result["earnings_date"] == datetime.date(2026, 4, 30)
+        assert result["last_reported_date"] is None

--- a/frontend/src/components/earnings-countdown.tsx
+++ b/frontend/src/components/earnings-countdown.tsx
@@ -1,0 +1,156 @@
+import { useMemo } from "react"
+import { useEarnings } from "@/lib/queries"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+
+const DIAL_SIZE = 96
+const STROKE = 6
+const RADIUS = (DIAL_SIZE - STROKE) / 2
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+const MAX_DAYS = 90
+const POST_EARNINGS_DAYS = 14
+
+function daysUntil(dateStr: string): number {
+  const target = new Date(dateStr + "T00:00:00")
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  return Math.round((target.getTime() - now.getTime()) / 86_400_000)
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function getColor(days: number): { stroke: string; text: string } {
+  if (days <= 14) return { stroke: "stroke-red-500", text: "text-red-500" }
+  if (days <= 30) return { stroke: "stroke-amber-500", text: "text-amber-500" }
+  return { stroke: "stroke-emerald-500", text: "text-emerald-500" }
+}
+
+export function EarningsCountdown({ symbol }: { symbol: string }) {
+  const { data, isLoading } = useEarnings(symbol)
+
+  const state = useMemo(() => {
+    if (!data?.earnings_date) return null
+
+    // Check if we're in the post-earnings window via last_reported_date
+    if (data.last_reported_date) {
+      const daysSinceReport = -daysUntil(data.last_reported_date)
+      if (daysSinceReport >= 0 && daysSinceReport <= POST_EARNINGS_DAYS) {
+        return { mode: "post-earnings" as const, daysSince: daysSinceReport, reportedDate: data.last_reported_date }
+      }
+    }
+
+    const days = daysUntil(data.earnings_date)
+    if (days < 0) return null
+
+    return { mode: "countdown" as const, days, date: data.earnings_date, isEstimate: data.is_estimate }
+  }, [data])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-24 w-24 rounded-full" />
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!state) return null
+
+  if (state.mode === "post-earnings") {
+    const { daysSince, reportedDate } = state
+    // Drain from full to empty over POST_EARNINGS_DAYS
+    const remaining = 1 - daysSince / POST_EARNINGS_DAYS
+    const postOffset = CIRCUMFERENCE * (1 - remaining)
+
+    return (
+      <div className="flex items-center gap-4">
+        <div className="relative" style={{ width: DIAL_SIZE, height: DIAL_SIZE }}>
+          <svg width={DIAL_SIZE} height={DIAL_SIZE} className="-rotate-90">
+            <circle
+              cx={DIAL_SIZE / 2}
+              cy={DIAL_SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              className="stroke-amber-500/15"
+              strokeWidth={STROKE}
+            />
+            <circle
+              cx={DIAL_SIZE / 2}
+              cy={DIAL_SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              className="stroke-amber-500 transition-all duration-500"
+              strokeWidth={STROKE}
+              strokeDasharray={CIRCUMFERENCE}
+              strokeDashoffset={postOffset}
+              strokeLinecap="round"
+            />
+          </svg>
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-xs font-bold text-amber-500 animate-pulse">POST</span>
+            <span className="text-[10px] text-amber-500/70">{daysSince}d ago</span>
+          </div>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-amber-500">Post-Earnings</p>
+          <p className="text-xs text-muted-foreground">
+            Reported {formatDate(reportedDate)} — price action may be noisy
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // Countdown mode
+  const { days, date, isEstimate } = state
+  const progress = Math.min(1, Math.max(0, 1 - days / MAX_DAYS))
+  const offset = CIRCUMFERENCE * (1 - progress)
+  const color = getColor(days)
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className="relative" style={{ width: DIAL_SIZE, height: DIAL_SIZE }}>
+        <svg width={DIAL_SIZE} height={DIAL_SIZE} className="-rotate-90">
+          <circle
+            cx={DIAL_SIZE / 2}
+            cy={DIAL_SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            className="stroke-muted"
+            strokeWidth={STROKE}
+          />
+          <circle
+            cx={DIAL_SIZE / 2}
+            cy={DIAL_SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            className={cn(color.stroke, "transition-all duration-500")}
+            strokeWidth={STROKE}
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={offset}
+            strokeLinecap="round"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className={cn("text-2xl font-bold tabular-nums", color.text)}>{days}</span>
+          <span className="text-[10px] text-muted-foreground">days</span>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-muted-foreground">Earnings Countdown</p>
+        <p className="text-sm">{formatDate(date)}</p>
+        {isEstimate && <Badge variant="outline" className="text-[10px]">Estimated</Badge>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   AssetDetail,
   AssetPerformance,
   ConstituentIndicator,
+  EarningsInfo,
   EtfHoldings,
   Group,
   GroupCreate,
@@ -81,6 +82,8 @@ export const api = {
       request<EtfHoldings>(`/assets/${symbol}/holdings`),
     holdingsIndicators: (symbol: string) =>
       request<HoldingIndicator[]>(`/assets/${symbol}/holdings/indicators`),
+    earnings: (symbol: string) =>
+      request<EarningsInfo>(`/assets/${symbol}/earnings`),
   },
   tags: {
     list: () => request<Tag[]>("/tags"),

--- a/frontend/src/lib/queries/earnings.ts
+++ b/frontend/src/lib/queries/earnings.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query"
+import { api } from "../api"
+import { keys, STALE_24H } from "./shared"
+
+export function useEarnings(symbol: string, enabled = true) {
+  return useQuery({
+    queryKey: keys.earnings(symbol),
+    queryFn: () => api.prices.earnings(symbol),
+    enabled: !!symbol && enabled,
+    staleTime: STALE_24H,
+  })
+}

--- a/frontend/src/lib/queries/index.ts
+++ b/frontend/src/lib/queries/index.ts
@@ -2,6 +2,7 @@ export { keys, STALE_1MIN, STALE_5MIN, STALE_24H, useInvalidatingMutation } from
 export { usePortfolioIndex, usePortfolioPerformers } from "./portfolio"
 export { useAssets, useCreateAsset, useLocalSearch, useYahooSearch } from "./assets"
 export { useAssetDetail, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
+export { useEarnings } from "./earnings"
 export { useTags, useCreateTag, useAttachTag, useDetachTag } from "./tags"
 export { useGroups, useCreateGroup, useUpdateGroup, useDeleteGroup, useReorderGroups, useAddAssetsToGroup, useRemoveAssetFromGroup, useGroup, useGroupSparklines, useGroupIndicators } from "./groups"
 export { useThesis, useUpdateThesis, useAnnotations, useCreateAnnotation, useDeleteAnnotation } from "./notes"

--- a/frontend/src/lib/queries/shared.ts
+++ b/frontend/src/lib/queries/shared.ts
@@ -41,6 +41,7 @@ export const keys = {
   pseudoEtfAnnotations: (id: number) => ["pseudo-etfs", id, "annotations"] as const,
   symbolSearchLocal: (q: string) => ["symbol-search-local", q] as const,
   symbolSearchYahoo: (q: string) => ["symbol-search-yahoo", q] as const,
+  earnings: (symbol: string) => ["earnings", symbol] as const,
   symbolSources: ["symbol-sources"] as const,
   symbolSourceProviders: ["symbol-source-providers"] as const,
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -256,3 +256,9 @@ export interface IntradayPoint {
   volume: number
   session: "pre" | "regular" | "post"
 }
+
+export interface EarningsInfo {
+  earnings_date: string | null
+  is_estimate: boolean
+  last_reported_date: string | null
+}

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -17,6 +17,7 @@ import { useQuote } from "@/lib/quote-stream"
 import { StatsPanel } from "@/components/stats-panel"
 import { Header, type ChartMode } from "./header"
 import { ChartSection } from "./chart-section"
+import { EarningsCountdown } from "@/components/earnings-countdown"
 import { HoldingsSection } from "./holdings-section"
 
 
@@ -53,6 +54,7 @@ export function AssetDetailPage() {
           quote={quote}
         />
       )}
+      {!isEtf && <EarningsCountdown symbol={symbol} />}
       {isEtf && <HoldingsSection symbol={symbol} />}
       {isTracked && (
         <>


### PR DESCRIPTION
## Summary
- Adds a circular SVG countdown dial on stock detail pages showing days until next earnings report (emerald →amber →red as it approaches)
- When earnings were reported within the last 14 days, shows an amber "Post-Earnings" warning — flagging potentially noisy price action
- Backend fetches from Yahoo Finance `calendar_events` + `earningsChart.quarterly.reportedDate`, cached with 24h TTL
- Hidden for ETFs, positioned between StatsPanel and HoldingsSection

## Test plan
- [x] Backend: 15 unit tests passing (`pytest tests/services/test_earnings.py`)
- [x] Frontend: lint clean, TypeScript build passes
- [ ] Manual: open a stock detail page (e.g., /assets/MNST) and verify post-earnings amber dial appears
- [ ] Manual: open a stock with upcoming earnings and verify countdown dial
- [ ] Manual: open an ETF detail page and verify no dial appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)