### PR TITLE
fix: normalise mixed date/datetime index from Yahoo intraday rows

### DIFF
--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -1,6 +1,6 @@
 """Price and indicator business logic — ensures data, caching, ephemeral fetch."""
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -65,8 +65,15 @@ async def _fetch_ephemeral(symbol: str, period: str, warmup: bool = False) -> pd
     if df.empty:
         raise HTTPException(404, f"No price data available for {symbol}")
 
-    if hasattr(df.index, "date"):
-        df.index = df.index.date
+    # Normalise index to plain date objects — Yahoo (and mocked providers)
+    # may return DatetimeIndex or mixed date/datetime indexes.
+    if isinstance(df.index, pd.DatetimeIndex):
+        df.index = pd.Index(df.index.date, name=df.index.name)
+    elif df.index.dtype == object and len(df) and isinstance(df.index[-1], datetime):
+        df.index = pd.Index(
+            [d.date() if isinstance(d, datetime) else d for d in df.index],
+            name=df.index.name,
+        )
 
     return df
 

--- a/backend/app/services/yahoo/history.py
+++ b/backend/app/services/yahoo/history.py
@@ -1,6 +1,6 @@
 """Yahoo Finance OHLCV history fetching."""
 
-from datetime import date
+from datetime import date, datetime
 
 import pandas as pd
 from yahooquery import Ticker
@@ -14,6 +14,22 @@ PERIOD_MAP = {
     "1y": "1y", "2y": "2y", "5y": "5y",
     "ytd": "ytd", "max": "max",
 }
+
+
+def _normalize_date_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure the DataFrame index contains only ``datetime.date`` objects.
+
+    Yahoo sometimes appends an intraday row (timezone-aware ``datetime``)
+    to otherwise ``date``-indexed daily data, producing a mixed-type object
+    index that breaks downstream comparisons.  This normalises every entry
+    to a plain ``date``.
+    """
+    name = df.index.name
+    if isinstance(df.index, pd.DatetimeIndex):
+        df.index = pd.Index(df.index.date, name=name)
+    elif df.index.dtype == object and len(df) and isinstance(df.index[-1], datetime):
+        df.index = pd.Index([d.date() if isinstance(d, datetime) else d for d in df.index], name=name)
+    return df
 
 
 @async_threadable
@@ -48,6 +64,7 @@ def fetch_history(
     _, divisor = resolve_currency(price_info, symbol)
     df = _normalize_ohlcv_df(df, divisor)
 
+    df = _normalize_date_index(df)
     return df
 
 
@@ -76,6 +93,7 @@ def _batch_fetch_history_sync(symbols: list[str], period: str = "1y") -> dict[st
                 info = price_data.get(sym, {}) if isinstance(price_data, dict) else {}
                 _, divisor = resolve_currency(info, sym)
                 df = _normalize_ohlcv_df(df, divisor)
+                df = _normalize_date_index(df)
                 result[sym] = df
         except KeyError:
             continue

--- a/backend/tests/services/test_yahoo_history.py
+++ b/backend/tests/services/test_yahoo_history.py
@@ -126,6 +126,30 @@ class TestFetchHistory:
         assert result.index.name == "date"
 
     @patch("app.services.yahoo.history.Ticker")
+    async def test_normalizes_mixed_date_datetime_index(self, mock_ticker_cls):
+        """Yahoo can append a tz-aware datetime row for intraday data to daily date index."""
+        import pytz
+        from datetime import datetime as dt
+
+        daily_dates = [date(2026, 4, 2), date(2026, 4, 3)]
+        intraday = dt(2026, 4, 6, 9, 0, tzinfo=pytz.timezone("Asia/Seoul"))
+        index = pd.Index(daily_dates + [intraday], name="date")
+        df = pd.DataFrame(
+            {"open": [100, 101, 102], "high": [101, 102, 103], "low": [99, 100, 101],
+             "close": [100.5, 101.5, 102.5], "volume": [1_000_000] * 3},
+            index=index,
+        )
+        ticker = MagicMock()
+        ticker.history.return_value = df
+        ticker.price = {"TEST.KS": {"currency": "KRW"}}
+        mock_ticker_cls.return_value = ticker
+
+        result = await fetch_history("TEST.KS")
+        assert all(type(v) is date for v in result.index), (
+            f"Expected all date, got {set(type(v) for v in result.index)}"
+        )
+
+    @patch("app.services.yahoo.history.Ticker")
     async def test_applies_currency_divisor(self, mock_ticker_cls):
         """GBp prices should be divided by 100."""
         df = pd.DataFrame(


### PR DESCRIPTION
## Summary
- Yahoo Finance can append a timezone-aware `datetime` row (e.g. Korean market intraday data at `2026-04-06 09:00:00+09:00`) to an otherwise `date`-indexed daily DataFrame, creating a mixed-type index
- Comparisons like `dt < start` in `_df_to_indicator_rows` / `_df_to_price_rows` then raise `TypeError: can't compare datetime.datetime to datetime.date`
- Added `_normalize_date_index()` in `yahoo/history.py` and a matching guard in `_fetch_ephemeral` to normalise the index to plain `date` objects

## Test plan
- [x] Added unit test reproducing the exact mixed `date` + tz-aware `datetime` index scenario
- [x] Full test suite passes (596/596)
- [x] Manually verified `GET /api/assets/277810.KS/detail` returns data instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)