### PR TITLE
Add Yahoo Finance quote link mode setting

### DIFF
--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -87,6 +87,10 @@ export function formatChangePct(v: number | null): { text: string | null; classN
   }
 }
 
+export function buildYahooQuoteUrl(symbol: string): string {
+  return `https://finance.yahoo.com/quote/${encodeURIComponent(symbol)}/`
+}
+
 /**
  * Build a Yahoo Finance advanced chart URL with pre-configured indicators.
  * Config includes: candlestick + volume, Bollinger Bands (20,2), RSI (14), MACD (12,26,9), 1Y daily.

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -7,6 +7,7 @@ export type GroupSortBy = string
 export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"
 export type GroupViewMode = "card" | "table" | "scanner" | "live"
+export type YahooLinkMode = "chart" | "quote"
 
 export interface AppSettings {
   /** Per-indicator placement visibility matrix. Missing key = use descriptor defaults. */
@@ -29,6 +30,7 @@ export interface AppSettings {
   sync_pseudo_etf_crosshairs: boolean
   show_indicator_deltas: boolean
   thousands_separator: boolean
+  yahoo_link_mode: YahooLinkMode
   _updated_at?: number
 }
 
@@ -74,6 +76,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   sync_pseudo_etf_crosshairs: false,
   show_indicator_deltas: true,
   thousands_separator: true,
+  yahoo_link_mode: "chart",
 }
 
 

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -11,7 +11,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { PeriodSelector } from "@/components/period-selector"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { resolveIcon } from "@/lib/icon-utils"
-import { buildYahooFinanceUrl, formatPrice, formatCompactPrice, formatChangePct } from "@/lib/format"
+import { buildYahooFinanceUrl, buildYahooQuoteUrl, formatPrice, formatCompactPrice, formatChangePct } from "@/lib/format"
 import { useQuote } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useRefreshPrices, useCreateAsset, useGroups, useAddAssetsToGroup } from "@/lib/queries"
@@ -86,7 +86,7 @@ export function Header({
           </span>
         )}
         <a
-          href={buildYahooFinanceUrl(symbol)}
+          href={settings.yahoo_link_mode === "quote" ? buildYahooQuoteUrl(symbol) : buildYahooFinanceUrl(symbol)}
           target="_blank"
           rel="noopener noreferrer"
           title="View on Yahoo Finance"

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -9,7 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { useSettings, type AppSettings, type GroupViewMode } from "@/lib/settings"
+import { useSettings, type AppSettings, type GroupViewMode, type YahooLinkMode } from "@/lib/settings"
 import { VisibilityToggle } from "@/components/visibility-toggle"
 import { IndicatorVisibilityEditor } from "@/components/indicator-visibility-editor"
 import { SymbolSourcesSettings } from "@/components/symbol-sources-settings"
@@ -94,6 +94,21 @@ export function SettingsPage() {
                 <SelectItem value="1y">1Y</SelectItem>
                 <SelectItem value="2y">2Y</SelectItem>
                 <SelectItem value="5y">5Y</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center justify-between">
+            <Label>Yahoo Finance Link</Label>
+            <Select
+              value={draft.yahoo_link_mode}
+              onValueChange={(v) => change({ yahoo_link_mode: v as YahooLinkMode })}
+            >
+              <SelectTrigger className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="chart">Chart</SelectItem>
+                <SelectItem value="quote">Quote</SelectItem>
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
## Summary
- Adds `yahoo_link_mode` setting (`chart` | `quote`) to control whether the Yahoo Finance external link opens the advanced chart view or the simpler quote page
- New setting appears under "Chart Preferences" in the settings page
- Defaults to `chart` (existing behavior)

Closes #497

## Changes
- `frontend/src/lib/format.ts` — new `buildYahooQuoteUrl()` function
- `frontend/src/lib/settings.tsx` — `YahooLinkMode` type + `yahoo_link_mode` in `AppSettings` 
- `frontend/src/pages/asset-detail/header.tsx` — respects setting when building link href
- `frontend/src/pages/settings.tsx` — dropdown selector for the setting

## Test plan
- [ ] Open asset detail page → link should default to chart URL (existing behavior)
- [ ] Change setting to "Quote" → link should open `finance.yahoo.com/quote/SYMBOL/`
- [ ] Setting persists across page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)