### PR TITLE
fix: decouple asset creation from default-group attachment

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -19,10 +19,11 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     """Add a new asset by ticker symbol. The symbol is validated against Yahoo Finance
     which also auto-detects the asset name, type (stock/etf), and currency.
 
-    By default the asset is added to the default group. Set `add_to_default_group=false`
-    to create the asset record without group membership (e.g. for pseudo-ETF constituents).
+    The asset is created without group membership. Use
+    ``POST /api/groups/{id}/assets`` afterwards to attach it to the Watchlist
+    or any other group.
     """
-    return await asset_service.create_asset(db, data.symbol, data.name, data.type, data.add_to_default_group)
+    return await asset_service.create_asset(db, data.symbol, data.name, data.type)
 
 
 @router.delete("/{symbol}", status_code=204, summary="Remove an asset from the default group")

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -10,7 +10,6 @@ class AssetCreate(BaseModel):
     symbol: str = Field(max_length=20, description="Ticker symbol (e.g. AAPL, VOO). Validated against Yahoo Finance.")
     name: str | None = Field(default=None, max_length=200, description="Display name. Auto-detected from Yahoo Finance if omitted.")
     type: AssetType = Field(default=AssetType.STOCK, description="Asset type: stock or etf. Auto-detected if name is omitted.")
-    add_to_default_group: bool = Field(default=True, description="If true, add to the default group after creation. Set false for pseudo-ETF constituents.")
 
 
 class TagBrief(BaseModel):

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import AssetType
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
-from app.services.currency_service import ensure_currency, lookup as currency_lookup
+from app.services.currency_service import ensure_currency
 from app.services.entity_lookups import get_asset
 from app.services.yahoo import validate_symbol
 
@@ -18,35 +18,24 @@ async def create_asset(
     symbol: str,
     name: str | None,
     asset_type: AssetType,
-    add_to_default_group: bool = True,
 ):
+    """Create an asset row. Group attachment is the caller's responsibility —
+    use ``POST /api/groups/{id}/assets`` afterwards to put it in a group
+    (Watchlist or otherwise)."""
     repo = AssetRepository(db)
     symbol = symbol.upper()
 
     existing = await repo.find_by_symbol(symbol)
     if existing:
-        if add_to_default_group:
-            # Add to default group if not already in it
-            group_repo = GroupRepository(db)
-            default_group = await group_repo.get_default()
-            if default_group and existing.id not in {a.id for a in default_group.assets}:
-                default_group.assets.append(existing)
-                await group_repo.save(default_group)
-            return existing
-        # Caller just needs the asset record (e.g. pseudo-ETF constituent picker)
         return existing
 
-    # Always call validate_symbol to detect currency (and name/type if not provided)
     info = await validate_symbol(symbol)
     if not info:
         if not name:
             raise HTTPException(404, f"Symbol {symbol} not found on Yahoo Finance")
-        # Name was provided manually — proceed with exchange-suffix currency fallback
         from app.services.yahoo import currency_from_suffix
         currency = currency_from_suffix(symbol) or "USD"
     else:
-        # Store raw Yahoo currency code (e.g. "GBp") — the currencies table
-        # provides display_code and divisor via lookup.
         currency = info.get("currency_code") or info.get("currency", "USD")
         if not name:
             name = info["name"]
@@ -54,18 +43,9 @@ async def create_asset(
             asset_type = AssetType.ETF
 
     await ensure_currency(db, currency)
-    asset = await repo.create(
+    return await repo.create(
         symbol=symbol, name=name, type=asset_type, currency=currency,
     )
-
-    if add_to_default_group:
-        group_repo = GroupRepository(db)
-        default_group = await group_repo.get_default()
-        if default_group:
-            default_group.assets.append(asset)
-            await group_repo.save(default_group)
-
-    return asset
 
 
 async def delete_asset(db: AsyncSession, symbol: str):

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -10,10 +10,28 @@ from app.models import Asset, AssetType, PriceHistory
 from app.repositories.group_repo import GroupRepository
 
 
-async def create_asset_via_api(client, symbol: str, name: str, **kwargs) -> dict:
-    """Create an asset through the HTTP API and return the JSON response."""
+async def create_asset_via_api(
+    client, symbol: str, name: str, attach_to_watchlist: bool = True, **kwargs
+) -> dict:
+    """Create an asset through the HTTP API and return the JSON response.
+
+    ``POST /api/assets`` no longer attaches to any group. By default this
+    helper also adds the new asset to the seeded Watchlist group so it
+    appears in ``GET /api/assets`` listings (the historical behaviour most
+    integration tests depend on). Pass ``attach_to_watchlist=False`` for
+    tests that want a group-less asset.
+    """
     resp = await client.post("/api/assets", json={"symbol": symbol, "name": name, **kwargs})
-    return resp.json()
+    asset = resp.json()
+    if attach_to_watchlist and resp.status_code == 201:
+        groups = (await client.get("/api/groups")).json()
+        watchlist_id = next((g["id"] for g in groups if g["is_default"]), None)
+        if watchlist_id is not None:
+            await client.post(
+                f"/api/groups/{watchlist_id}/assets",
+                json={"asset_ids": [asset["id"]]},
+            )
+    return asset
 
 
 async def seed_asset_with_prices(

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -93,11 +93,23 @@ async def test_delete_nonexistent_asset(client):
 
 
 async def test_list_assets_returns_created(client):
+    """``GET /api/assets`` returns assets that belong to at least one group.
+
+    ``POST /api/assets`` no longer auto-attaches to the Watchlist, so the
+    test must explicitly add each asset to a group.
+    """
     mock_aapl = {"symbol": "AAPL", "name": "Apple", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
     mock_msft = {"symbol": "MSFT", "name": "Microsoft", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
     with patch("app.services.asset_service.validate_symbol", side_effect=[mock_aapl, mock_msft]):
-        await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple"})
-        await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft"})
+        a1 = await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple"})
+        a2 = await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft"})
+
+    groups = (await client.get("/api/groups")).json()
+    watchlist_id = next(g["id"] for g in groups if g["is_default"])
+    await client.post(
+        f"/api/groups/{watchlist_id}/assets",
+        json={"asset_ids": [a1.json()["id"], a2.json()["id"]]},
+    )
 
     resp = await client.get("/api/assets")
     assert resp.status_code == 200

--- a/backend/tests/integration/test_quotes.py
+++ b/backend/tests/integration/test_quotes.py
@@ -126,7 +126,10 @@ async def test_stream_quotes_no_tracked(client):
 
 async def test_stream_quotes_emits_event(client):
     """SSE stream emits quote data for tracked assets."""
-    await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
+    a = (await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})).json()
+    groups = (await client.get("/api/groups")).json()
+    watchlist_id = next(g["id"] for g in groups if g["is_default"])
+    await client.post(f"/api/groups/{watchlist_id}/assets", json={"asset_ids": [a["id"]]})
 
     _reset_asset_list_cache()
     mock_prov = _mock_provider(quotes_return=[_MOCK_QUOTES[0]])
@@ -160,8 +163,11 @@ async def test_stream_quotes_cache_headers(client):
 
 async def test_stream_quotes_multiple_symbols(client):
     """SSE stream includes all tracked symbols in first event."""
-    await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})
-    await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft", "type": "stock"})
+    a1 = (await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple", "type": "stock"})).json()
+    a2 = (await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft", "type": "stock"})).json()
+    groups = (await client.get("/api/groups")).json()
+    watchlist_id = next(g["id"] for g in groups if g["is_default"])
+    await client.post(f"/api/groups/{watchlist_id}/assets", json={"asset_ids": [a1["id"], a2["id"]]})
 
     _reset_asset_list_cache()
     mock_prov = _mock_provider(quotes_return=_MOCK_QUOTES)

--- a/backend/tests/services/test_asset_service.py
+++ b/backend/tests/services/test_asset_service.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.models import Asset, AssetType
+from app.models import AssetType
 from app.services.asset_service import create_asset, delete_asset, list_assets
 from tests.helpers import make_model_asset as _make_asset
 
@@ -38,10 +38,9 @@ async def test_list_assets_delegates_to_repo(MockRepo):
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)
-@patch("app.services.asset_service.GroupRepository")
 @patch("app.services.asset_service.validate_symbol", new_callable=AsyncMock)
 @patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_uppercase_symbol(MockAssetRepo, mock_validate, MockGroupRepo, _mock_ensure):
+async def test_create_asset_uppercase_symbol(MockAssetRepo, mock_validate, _mock_ensure):
     db = AsyncMock()
     mock_repo = MockAssetRepo.return_value
     mock_repo.find_by_symbol = AsyncMock(return_value=None)
@@ -49,79 +48,56 @@ async def test_create_asset_uppercase_symbol(MockAssetRepo, mock_validate, MockG
     new_asset = _make_asset()
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=_make_default_group())
-    mock_group_repo.save = AsyncMock()
-
-    result = await create_asset(db, symbol="aapl", name="Apple", asset_type=AssetType.STOCK, add_to_default_group=True)
+    await create_asset(db, symbol="aapl", name="Apple", asset_type=AssetType.STOCK)
 
     mock_repo.create.assert_awaited_once()
     call_kwargs = mock_repo.create.call_args[1]
     assert call_kwargs["symbol"] == "AAPL"
 
 
-@patch("app.services.asset_service.GroupRepository")
 @patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_existing_adds_to_default_group(MockAssetRepo, MockGroupRepo):
-    """When an existing asset is not in the default group, adding with
-    add_to_default_group=True adds it to the group."""
+async def test_create_asset_existing_returns_record_without_group_mutation(MockAssetRepo):
+    """When the asset already exists, return it without touching any group.
+
+    Regression: previously the existing-asset branch silently re-added the
+    asset to the default Watchlist group, which clobbered intentional
+    removals.
+    """
     db = AsyncMock()
     mock_repo = MockAssetRepo.return_value
     existing = _make_asset()
     mock_repo.find_by_symbol = AsyncMock(return_value=existing)
 
-    default_group = _make_default_group(assets=[])  # asset not in group
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=default_group)
-    mock_group_repo.save = AsyncMock()
-
-    result = await create_asset(db, symbol="AAPL", name="Apple", asset_type=AssetType.STOCK, add_to_default_group=True)
-
-    assert result is existing
-    assert existing in default_group.assets
-    mock_group_repo.save.assert_awaited_once()
-
-
-@patch("app.services.asset_service.GroupRepository")
-@patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_existing_already_in_group_returns_existing(MockAssetRepo, MockGroupRepo):
-    """When an existing asset is already in the default group, just return it."""
-    db = AsyncMock()
-    mock_repo = MockAssetRepo.return_value
-    existing = _make_asset()
-    mock_repo.find_by_symbol = AsyncMock(return_value=existing)
-
-    default_group = _make_default_group(assets=[existing])  # already in group
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=default_group)
-
-    result = await create_asset(db, symbol="AAPL", name="Apple", asset_type=AssetType.STOCK, add_to_default_group=True)
-
-    assert result is existing
-    mock_group_repo.save.assert_not_called()
-
-
-@patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_existing_no_group_returns_existing(MockRepo):
-    """When asset already exists and caller passes add_to_default_group=False (e.g. pseudo-ETF
-    constituent picker), return the existing record without touching groups."""
-    db = AsyncMock()
-    mock_repo = MockRepo.return_value
-    existing = _make_asset()
-    mock_repo.find_by_symbol = AsyncMock(return_value=existing)
-
-    result = await create_asset(db, symbol="AAPL", name="Apple", asset_type=AssetType.STOCK, add_to_default_group=False)
+    with patch("app.services.asset_service.GroupRepository") as MockGroupRepo:
+        result = await create_asset(db, symbol="AAPL", name="Apple", asset_type=AssetType.STOCK)
 
     assert result is existing
     mock_repo.save.assert_not_called()
     mock_repo.create.assert_not_called()
+    MockGroupRepo.assert_not_called()
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)
-@patch("app.services.asset_service.GroupRepository")
 @patch("app.services.asset_service.validate_symbol", new_callable=AsyncMock)
 @patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_auto_resolves_from_yahoo(MockAssetRepo, mock_validate, MockGroupRepo, _mock_ensure):
+async def test_create_asset_does_not_touch_groups(MockAssetRepo, mock_validate, _mock_ensure):
+    """A successful create should never load or mutate any group."""
+    db = AsyncMock()
+    mock_repo = MockAssetRepo.return_value
+    mock_repo.find_by_symbol = AsyncMock(return_value=None)
+    mock_validate.return_value = {"symbol": "AAPL", "name": "Apple Inc.", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    mock_repo.create = AsyncMock(return_value=_make_asset())
+
+    with patch("app.services.asset_service.GroupRepository") as MockGroupRepo:
+        await create_asset(db, symbol="AAPL", name="Apple", asset_type=AssetType.STOCK)
+
+    MockGroupRepo.assert_not_called()
+
+
+@patch(_ensure_patch, new_callable=AsyncMock)
+@patch("app.services.asset_service.validate_symbol", new_callable=AsyncMock)
+@patch("app.services.asset_service.AssetRepository")
+async def test_create_asset_auto_resolves_from_yahoo(MockAssetRepo, mock_validate, _mock_ensure):
     db = AsyncMock()
     mock_repo = MockAssetRepo.return_value
     mock_repo.find_by_symbol = AsyncMock(return_value=None)
@@ -130,11 +106,7 @@ async def test_create_asset_auto_resolves_from_yahoo(MockAssetRepo, mock_validat
     new_asset = _make_asset(symbol="NVDA", name="NVIDIA Corporation")
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=_make_default_group())
-    mock_group_repo.save = AsyncMock()
-
-    result = await create_asset(db, symbol="NVDA", name=None, asset_type=AssetType.STOCK, add_to_default_group=True)
+    await create_asset(db, symbol="NVDA", name=None, asset_type=AssetType.STOCK)
 
     mock_validate.assert_awaited_once_with("NVDA")
     call_kwargs = mock_repo.create.call_args[1]
@@ -152,15 +124,14 @@ async def test_create_asset_yahoo_not_found_raises_404(MockRepo, mock_validate):
 
     from fastapi import HTTPException
     with pytest.raises(HTTPException) as exc_info:
-        await create_asset(db, symbol="XXXX", name=None, asset_type=AssetType.STOCK, add_to_default_group=True)
+        await create_asset(db, symbol="XXXX", name=None, asset_type=AssetType.STOCK)
     assert exc_info.value.status_code == 404
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)
-@patch("app.services.asset_service.GroupRepository")
 @patch("app.services.asset_service.validate_symbol", new_callable=AsyncMock)
 @patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_detects_etf_type(MockAssetRepo, mock_validate, MockGroupRepo, _mock_ensure):
+async def test_create_asset_detects_etf_type(MockAssetRepo, mock_validate, _mock_ensure):
     db = AsyncMock()
     mock_repo = MockAssetRepo.return_value
     mock_repo.find_by_symbol = AsyncMock(return_value=None)
@@ -168,21 +139,16 @@ async def test_create_asset_detects_etf_type(MockAssetRepo, mock_validate, MockG
     new_asset = _make_asset(symbol="SPY", type=AssetType.ETF)
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=_make_default_group())
-    mock_group_repo.save = AsyncMock()
-
-    await create_asset(db, symbol="SPY", name=None, asset_type=AssetType.STOCK, add_to_default_group=True)
+    await create_asset(db, symbol="SPY", name=None, asset_type=AssetType.STOCK)
 
     call_kwargs = mock_repo.create.call_args[1]
     assert call_kwargs["type"] == AssetType.ETF
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)
-@patch("app.services.asset_service.GroupRepository")
 @patch("app.services.asset_service.validate_symbol", new_callable=AsyncMock)
 @patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_krw_currency_from_yahoo(MockAssetRepo, mock_validate, MockGroupRepo, _mock_ensure):
+async def test_create_asset_krw_currency_from_yahoo(MockAssetRepo, mock_validate, _mock_ensure):
     """Regression test for #213: KRW-denominated assets should detect currency correctly."""
     db = AsyncMock()
     mock_repo = MockAssetRepo.return_value
@@ -193,21 +159,16 @@ async def test_create_asset_krw_currency_from_yahoo(MockAssetRepo, mock_validate
     new_asset = _make_asset(symbol="006260.KS", name="LS Corp", currency="KRW")
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=_make_default_group())
-    mock_group_repo.save = AsyncMock()
-
-    result = await create_asset(db, symbol="006260.KS", name=None, asset_type=AssetType.STOCK, add_to_default_group=True)
+    await create_asset(db, symbol="006260.KS", name=None, asset_type=AssetType.STOCK)
 
     call_kwargs = mock_repo.create.call_args[1]
     assert call_kwargs["currency"] == "KRW"
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)
-@patch("app.services.asset_service.GroupRepository")
 @patch("app.services.asset_service.validate_symbol", new_callable=AsyncMock)
 @patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_with_name_still_detects_currency(MockAssetRepo, mock_validate, MockGroupRepo, _mock_ensure):
+async def test_create_asset_with_name_still_detects_currency(MockAssetRepo, mock_validate, _mock_ensure):
     """When name is provided, currency should still be detected from Yahoo Finance."""
     db = AsyncMock()
     mock_repo = MockAssetRepo.return_value
@@ -218,14 +179,7 @@ async def test_create_asset_with_name_still_detects_currency(MockAssetRepo, mock
     new_asset = _make_asset(symbol="006260.KS", name="LS Corp", currency="KRW")
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=_make_default_group())
-    mock_group_repo.save = AsyncMock()
-
-    # Even with name provided, currency should come from Yahoo
-    result = await create_asset(
-        db, symbol="006260.KS", name="LS Corp", asset_type=AssetType.STOCK, add_to_default_group=True,
-    )
+    await create_asset(db, symbol="006260.KS", name="LS Corp", asset_type=AssetType.STOCK)
 
     mock_validate.assert_awaited_once_with("006260.KS")
     call_kwargs = mock_repo.create.call_args[1]
@@ -234,10 +188,9 @@ async def test_create_asset_with_name_still_detects_currency(MockAssetRepo, mock
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)
-@patch("app.services.asset_service.GroupRepository")
 @patch("app.services.asset_service.validate_symbol", new_callable=AsyncMock)
 @patch("app.services.asset_service.AssetRepository")
-async def test_create_asset_with_name_yahoo_fails_uses_suffix(MockAssetRepo, mock_validate, MockGroupRepo, _mock_ensure):
+async def test_create_asset_with_name_yahoo_fails_uses_suffix(MockAssetRepo, mock_validate, _mock_ensure):
     """When name is provided but Yahoo fails, fall back to exchange suffix for currency."""
     db = AsyncMock()
     mock_repo = MockAssetRepo.return_value
@@ -247,13 +200,7 @@ async def test_create_asset_with_name_yahoo_fails_uses_suffix(MockAssetRepo, moc
     new_asset = _make_asset(symbol="006260.KS", name="LS Corp", currency="KRW")
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    mock_group_repo = MockGroupRepo.return_value
-    mock_group_repo.get_default = AsyncMock(return_value=_make_default_group())
-    mock_group_repo.save = AsyncMock()
-
-    result = await create_asset(
-        db, symbol="006260.KS", name="LS Corp", asset_type=AssetType.STOCK, add_to_default_group=True,
-    )
+    await create_asset(db, symbol="006260.KS", name="LS Corp", asset_type=AssetType.STOCK)
 
     call_kwargs = mock_repo.create.call_args[1]
     assert call_kwargs["currency"] == "KRW"  # from suffix fallback

--- a/frontend/src/components/add-constituent-picker.tsx
+++ b/frontend/src/components/add-constituent-picker.tsx
@@ -40,7 +40,7 @@ export function AddConstituentPicker({
     if (!sym) return
     setTickerError("")
     createAsset.mutate(
-      { symbol: sym, add_to_default_group: false },
+      { symbol: sym },
       {
         onSuccess: (asset) => {
           addConstituents.mutate(

--- a/frontend/src/components/add-symbol-dialog.tsx
+++ b/frontend/src/components/add-symbol-dialog.tsx
@@ -50,11 +50,13 @@ export function AddSymbolDialog({ groupId }: { groupId?: number }) {
   const handleAdd = () => {
     const s = symbol.trim().toUpperCase()
     if (!s) return
+    // If no non-default group is selected, fall back to the default Watchlist
+    // group so the asset always lands somewhere.
+    const gid = resolveTargetGroup(targetGroupId) ?? groups?.find((g) => g.is_default)?.id
     createAsset.mutate(
       { symbol: s },
       {
         onSuccess: (asset) => {
-          const gid = resolveTargetGroup(targetGroupId)
           if (gid) {
             addAssetsToGroup.mutate(
               { groupId: gid, assetIds: [asset.id] },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -40,7 +40,6 @@ export interface AssetCreate {
   symbol: string
   name?: string
   type?: AssetType
-  add_to_default_group?: boolean
 }
 
 export interface SymbolSearchResult {


### PR DESCRIPTION
## Summary
- Fixes a long-standing bug where adding a ticker to any group also silently added it to the Watchlist (the default group).
- Root cause: `POST /api/assets` defaulted `add_to_default_group=True`, and the existing-asset branch re-added to Watchlist even when the user had previously removed it.
- Refactor: split asset creation from group attachment. `POST /api/assets` only creates the row; callers explicitly `POST /api/groups/{id}/assets` to attach. Drops the `add_to_default_group` flag entirely.

## Changes
**Backend**
- `services/asset_service.py:create_asset` — single responsibility, no group mutation.
- `schemas/asset.py:AssetCreate` — `add_to_default_group` removed.
- `routers/assets.py` — docstring points to the group endpoint for attachment.

**Frontend**
- `components/add-symbol-dialog.tsx` — after creating, always calls `addAssetsToGroup`. Falls back to the default Watchlist group when no other group is selected.
- `components/add-constituent-picker.tsx` — drops the now-redundant `add_to_default_group: false`.
- `lib/types.ts:AssetCreate` — flag removed.

**Tests**
- `tests/helpers.py:create_asset_via_api` now also attaches to Watchlist by default to preserve historical behaviour for downstream tests.
- `tests/services/test_asset_service.py` rewritten — drops existing-asset group-mutation tests, adds a "create does not touch groups" guard.
- `tests/integration/test_assets.py` and `test_quotes.py` SSE tests now explicitly POST to the watchlist group where needed.

## Test plan
- [x] Backend: `pytest` — 588 passing
- [x] Frontend: `pnpm run build` — succeeds
- [ ] Manual smoke test on dev: add a ticker to a non-Watchlist group, verify it does NOT appear in Watchlist
- [ ] Manual smoke test on dev: add a ticker without a target group, verify it lands in Watchlist (fallback path)
- [ ] Manual smoke test: pseudo-ETF constituent picker still works (creates asset without group attachment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)