### PR TITLE
feat(assets): add INDEX type and adjust display for indices

### DIFF
--- a/backend/alembic/versions/0012_add_index_asset_type.py
+++ b/backend/alembic/versions/0012_add_index_asset_type.py
@@ -1,0 +1,27 @@
+"""Add 'index' value to assettype enum
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-05-04
+"""
+
+from alembic import op
+
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # PostgreSQL: ALTER TYPE ... ADD VALUE cannot run inside a transaction
+    # in older versions, but it works fine in PG 12+ which is our target.
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE assettype ADD VALUE IF NOT EXISTS 'index'")
+
+
+def downgrade() -> None:
+    # PostgreSQL doesn't support removing enum values; downgrade is a no-op.
+    pass

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -10,6 +10,7 @@ from app.database import Base
 class AssetType(str, enum.Enum):
     STOCK = "stock"
     ETF = "etf"
+    INDEX = "index"
 
 
 class Asset(Base):

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -17,7 +17,7 @@ class AppSettingsData(BaseModel):
     group_macd_style: Literal["classic", "divergence"] | None = None
     group_show_sparkline: bool | None = None
     group_view_mode: Literal["card", "table", "scanner", "live"] | None = None
-    group_type_filter: Literal["all", "stock", "etf"] | None = None
+    group_type_filter: Literal["all", "stock", "etf", "index"] | None = None
     group_sort_by: str | None = None
     group_sort_dir: Literal["asc", "desc"] | None = None
     group_table_columns: dict[str, bool] | None = None

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -40,6 +40,8 @@ async def create_asset(
             name = info["name"]
         if info["type"] == "ETF":
             asset_type = AssetType.ETF
+        elif info["type"] == "INDEX":
+            asset_type = AssetType.INDEX
 
     await ensure_currency(db, currency)
     return await repo.create(

--- a/backend/tests/services/test_asset_service.py
+++ b/backend/tests/services/test_asset_service.py
@@ -148,6 +148,25 @@ async def test_create_asset_detects_etf_type(MockAssetRepo, mock_validate, _mock
 @patch(_ensure_patch, new_callable=AsyncMock)
 @patch("app.services.asset_service.yahoo_client")
 @patch("app.services.asset_service.AssetRepository")
+async def test_create_asset_detects_index_type(MockAssetRepo, mock_validate, _mock_ensure):
+    db = AsyncMock()
+    mock_repo = MockAssetRepo.return_value
+    mock_repo.find_by_symbol = AsyncMock(return_value=None)
+    mock_validate.validate = AsyncMock(); mock_validate.validate.return_value = {
+        "symbol": "^TYX", "name": "Treasury Yield 30 Years", "type": "INDEX", "currency": "USD", "currency_code": "USD",
+    }
+    new_asset = _make_asset(symbol="^TYX", type=AssetType.INDEX)
+    mock_repo.create = AsyncMock(return_value=new_asset)
+
+    await create_asset(db, symbol="^TYX", name=None, asset_type=AssetType.STOCK)
+
+    call_kwargs = mock_repo.create.call_args[1]
+    assert call_kwargs["type"] == AssetType.INDEX
+
+
+@patch(_ensure_patch, new_callable=AsyncMock)
+@patch("app.services.asset_service.yahoo_client")
+@patch("app.services.asset_service.AssetRepository")
 async def test_create_asset_krw_currency_from_yahoo(MockAssetRepo, mock_validate, _mock_ensure):
     """Regression test for #213: KRW-denominated assets should detect currency correctly."""
     db = AsyncMock()

--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -9,7 +9,7 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { DeferredSparkline } from "@/components/sparkline"
 import { TagBadge } from "@/components/tag-badge"
 import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary } from "@/lib/api"
-import { formatPrice, formatCompactPrice, changeColor, formatChangePct } from "@/lib/format"
+import { formatAssetPrice, formatAssetCompactPrice, changeColor, formatChangePct } from "@/lib/format"
 import { getCardDescriptors, isVisibleAt, type IndicatorDescriptor, type Placement } from "@/lib/indicator-registry"
 import { IndicatorValue } from "@/components/indicator-value"
 import { usePriceFlash } from "@/lib/use-price-flash"
@@ -98,11 +98,11 @@ export const AssetCard = memo(function AssetCard({
                   <span
                     ref={priceRef}
                     className="ml-auto text-base font-semibold tabular-nums rounded px-1 -mx-1"
-                    title={settings.compact_numbers ? formatPrice(lastPrice, currency, undefined, settings.thousands_separator) : undefined}
+                    title={settings.compact_numbers ? formatAssetPrice(lastPrice, { type, symbol, currency }, undefined, settings.thousands_separator) : undefined}
                   >
                     {settings.compact_numbers
-                      ? formatCompactPrice(lastPrice, currency)
-                      : formatPrice(lastPrice, currency, undefined, settings.thousands_separator)}
+                      ? formatAssetCompactPrice(lastPrice, { type, symbol, currency })
+                      : formatAssetPrice(lastPrice, { type, symbol, currency }, undefined, settings.thousands_separator)}
                   </span>
                 ) : (
                   <Skeleton className="ml-auto h-5 w-16 rounded" />

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -9,7 +9,7 @@ import { TagBadge } from "@/components/tag-badge"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { ExpandedAssetChart } from "@/components/expanded-asset-chart"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
-import { formatPrice, formatCompactPrice, formatCompactNumber, changeColor, formatChangePct } from "@/lib/format"
+import { formatAssetPrice, formatAssetCompactPrice, formatCompactNumber, changeColor, formatChangePct } from "@/lib/format"
 import {
   getNumericValue,
   extractMacdValues,
@@ -158,11 +158,11 @@ export const TableRow = memo(function TableRow({
                 <span
                   ref={priceRef}
                   className={`font-medium rounded px-1 -mx-1 ${staleClass}`}
-                  title={settings.compact_numbers ? formatPrice(displayPrice, asset.currency, undefined, settings.thousands_separator) : undefined}
+                  title={settings.compact_numbers ? formatAssetPrice(displayPrice, asset, undefined, settings.thousands_separator) : undefined}
                 >
                   {settings.compact_numbers
-                    ? formatCompactPrice(displayPrice, asset.currency)
-                    : formatPrice(displayPrice, asset.currency, undefined, settings.thousands_separator)}
+                    ? formatAssetCompactPrice(displayPrice, asset)
+                    : formatAssetPrice(displayPrice, asset, undefined, settings.thousands_separator)}
                 </span>
               ) : (
                 <Skeleton className="h-4 w-14 ml-auto rounded" />

--- a/frontend/src/components/price-chart.tsx
+++ b/frontend/src/components/price-chart.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback } from "react"
-import type { Price, Indicator, Annotation } from "@/lib/api"
+import type { Price, Indicator, Annotation, AssetType } from "@/lib/api"
 import { ChartSyncProvider } from "./chart/chart-sync-provider"
 import { CandlestickChart } from "./chart/candlestick-chart"
 import { SubChart } from "./chart/sub-chart"
@@ -21,6 +21,8 @@ interface PriceChartProps {
   mainChartHeight?: number
   /** ISO 4217 currency code for formatting price-denominated indicators (e.g. ATR). */
   currency?: string
+  /** Asset type — indices have no meaningful volume, so the bars are suppressed. */
+  assetType?: AssetType
 }
 
 export function PriceChart({
@@ -32,13 +34,19 @@ export function PriceChart({
   chartType = "candle",
   mainChartHeight = 400,
   currency,
+  assetType,
 }: PriceChartProps) {
+  const effectiveExcludes = useMemo(() => {
+    const base = excludeIndicators ?? []
+    return assetType === "index" ? [...base, "volume"] : base
+  }, [excludeIndicators, assetType])
+
   const isVisible = useCallback(
     (id: string) => {
-      if (excludeIndicators?.includes(id)) return false
+      if (effectiveExcludes.includes(id)) return false
       return isVisibleAt(indicatorVisibility, id, "detail_chart")
     },
-    [indicatorVisibility, excludeIndicators],
+    [indicatorVisibility, effectiveExcludes],
   )
 
   const enabledSubCharts = useMemo(
@@ -60,6 +68,7 @@ export function PriceChart({
         <CandlestickChart
           annotations={annotations}
           indicatorVisibility={indicatorVisibility}
+          excludeIndicators={effectiveExcludes}
           chartType={chartType}
           height={mainChartHeight}
           hideTimeAxis={hasSubCharts}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,3 +1,5 @@
+import type { AssetType } from "@/lib/types"
+
 const CURRENCY_SYMBOLS: Record<string, string> = {
   USD: "$",
   EUR: "\u20ac",
@@ -9,6 +11,18 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   JPY: "\u00a5",
   KRW: "\u20a9",
   CHF: "CHF\u00a0",
+}
+
+const YIELD_INDICES = new Set(["^TYX", "^TNX", "^FVX", "^IRX"])
+
+export interface AssetFormatHints {
+  type: AssetType
+  symbol: string
+  currency: string
+}
+
+function isYieldIndex(symbol: string): boolean {
+  return YIELD_INDICES.has(symbol.toUpperCase())
 }
 
 const ZERO_DECIMAL_CURRENCIES = new Set(["KRW", "JPY", "IDR", "HUF", "VND", "CLP", "TWD"])
@@ -28,6 +42,21 @@ export function formatPrice(value: number, currency: string, decimals?: number, 
   const [int, frac] = fixed.split(".")
   const grouped = int.replace(/\B(?=(\d{3})+(?!\d))/g, ",")
   return `${currencySymbol(currency)}${frac !== undefined ? `${grouped}.${frac}` : grouped}`
+}
+
+export function formatAssetPrice(
+  value: number,
+  asset: AssetFormatHints,
+  decimals?: number,
+  groupDigits = false,
+): string {
+  if (asset.type !== "index") return formatPrice(value, asset.currency, decimals, groupDigits)
+  const d = decimals ?? 2
+  const fixed = value.toFixed(d)
+  const [int, frac] = fixed.split(".")
+  const grouped = groupDigits ? int.replace(/\B(?=(\d{3})+(?!\d))/g, ",") : int
+  const body = frac !== undefined ? `${grouped}.${frac}` : grouped
+  return isYieldIndex(asset.symbol) ? `${body}%` : body
 }
 
 export function formatCompactPrice(value: number, currency: string): string {
@@ -50,6 +79,11 @@ export function formatCompactPrice(value: number, currency: string): string {
     return `${sym}${scaled}K`
   }
   return formatPrice(value, currency)
+}
+
+export function formatAssetCompactPrice(value: number, asset: AssetFormatHints): string {
+  if (asset.type !== "index") return formatCompactPrice(value, asset.currency)
+  return formatAssetPrice(value, asset, 2)
 }
 
 export function formatCompactNumber(value: number): string {

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useState, useCallback, type React
 import { INDICATOR_REGISTRY, type Placement } from "@/lib/indicator-registry"
 import { api } from "@/lib/api"
 
-export type AssetTypeFilter = "all" | "stock" | "etf"
+export type AssetTypeFilter = "all" | "stock" | "etf" | "index"
 export type GroupSortBy = string
 export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,6 +1,6 @@
 // TypeScript types matching backend Pydantic schemas
 
-export type AssetType = "stock" | "etf"
+export type AssetType = "stock" | "etf" | "index"
 
 export interface TagBrief {
   id: number

--- a/frontend/src/pages/asset-detail/chart-section.tsx
+++ b/frontend/src/pages/asset-detail/chart-section.tsx
@@ -4,6 +4,7 @@ import { IntradayChart } from "@/components/intraday-chart"
 import { useAssetDetail, useAnnotations } from "@/lib/queries"
 import { useIntraday, useQuote } from "@/lib/quote-stream"
 import type { Placement } from "@/lib/indicator-registry"
+import type { AssetType } from "@/lib/api"
 import type { ChartMode } from "./header"
 
 export function ChartSection({
@@ -12,6 +13,7 @@ export function ChartSection({
   indicatorVisibility,
   chartType,
   currency,
+  assetType,
   mode,
 }: {
   symbol: string
@@ -19,6 +21,7 @@ export function ChartSection({
   indicatorVisibility: Record<string, Placement[]>
   chartType: "candle" | "line"
   currency?: string
+  assetType?: AssetType
   mode: ChartMode
 }) {
   if (mode === "live") {
@@ -31,6 +34,7 @@ export function ChartSection({
       indicatorVisibility={indicatorVisibility}
       chartType={chartType}
       currency={currency}
+      assetType={assetType}
     />
   )
 }
@@ -63,12 +67,14 @@ function HistoricalChartSection({
   indicatorVisibility,
   chartType,
   currency,
+  assetType,
 }: {
   symbol: string
   period: string
   indicatorVisibility: Record<string, Placement[]>
   chartType: "candle" | "line"
   currency?: string
+  assetType?: AssetType
 }) {
   const { data: detail, isLoading: detailLoading, isFetching: detailFetching } = useAssetDetail(symbol, period)
   const prices = detail?.prices
@@ -101,6 +107,7 @@ function HistoricalChartSection({
         indicatorVisibility={indicatorVisibility}
         chartType={chartType}
         currency={currency}
+        assetType={assetType}
       />
     </div>
   )

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -11,7 +11,8 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { PeriodSelector } from "@/components/period-selector"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { resolveIcon } from "@/lib/icon-utils"
-import { buildYahooFinanceUrl, buildYahooQuoteUrl, formatPrice, formatCompactPrice, formatChangePct } from "@/lib/format"
+import { buildYahooFinanceUrl, buildYahooQuoteUrl, formatAssetPrice, formatAssetCompactPrice, formatChangePct } from "@/lib/format"
+import type { AssetType } from "@/lib/api"
 import { useQuote } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useRefreshPrices, useCreateAsset, useGroups, useAddAssetsToGroup } from "@/lib/queries"
@@ -23,6 +24,7 @@ export function Header({
   symbol,
   name,
   currency,
+  type,
   period,
   setPeriod,
   isTracked,
@@ -33,6 +35,7 @@ export function Header({
   symbol: string
   name?: string
   currency: string
+  type: AssetType
   period: string
   setPeriod: (p: string) => void
   isTracked: boolean
@@ -70,11 +73,11 @@ export function Header({
           <span
             ref={priceRef}
             className="text-xl font-semibold tabular-nums rounded px-1"
-            title={settings.compact_numbers ? formatPrice(price, currency, undefined, settings.thousands_separator) : undefined}
+            title={settings.compact_numbers ? formatAssetPrice(price, { type, symbol, currency }, undefined, settings.thousands_separator) : undefined}
           >
             {settings.compact_numbers
-              ? formatCompactPrice(price, currency)
-              : formatPrice(price, currency, undefined, settings.thousands_separator)}
+              ? formatAssetCompactPrice(price, { type, symbol, currency })
+              : formatAssetPrice(price, { type, symbol, currency }, undefined, settings.thousands_separator)}
           </span>
         )}
         {changeFmt && (

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -37,13 +37,14 @@ export function AssetDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} period={period} setPeriod={setPeriod} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
+      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} type={asset?.type ?? "stock"} period={period} setPeriod={setPeriod} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
       <ChartSection
         symbol={symbol}
         period={period}
         indicatorVisibility={settings.indicator_visibility}
         chartType={settings.chart_type}
         currency={asset?.currency}
+        assetType={asset?.type}
         mode={mode}
       />
       {mode === "historical" && detail?.indicators && detail.indicators.length > 0 && (

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -107,6 +107,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
               { value: "all", label: "All" },
               { value: "stock", label: "Stocks" },
               { value: "etf", label: "ETFs" },
+              { value: "index", label: "Indices" },
             ]}
             value={typeFilter}
             onChange={setTypeFilter}


### PR DESCRIPTION
## Summary
- Adds `AssetType.INDEX` so symbols like `^TYX`, `^GSPC` get a dedicated type instead of being coerced to STOCK
- Auto-detects INDEX from Yahoo's `quoteType` in `asset_service.create_asset`
- Frontend formatters drop the `$` for indices; yield indices (`^TYX`/`^TNX`/`^FVX`/`^IRX`) render with a `%` suffix
- Volume histogram is suppressed on the price chart for indices (always zero anyway)
- Group filter gains an "Indices" chip alongside Stocks/ETFs

## Migration
`0012_add_index_asset_type.py` runs `ALTER TYPE assettype ADD VALUE IF NOT EXISTS 'index'` on PG. No-op on SQLite (tests use `Base.metadata.create_all`). Targets `dev` so the migration can be validated before reaching `main`.

## Test plan
- [x] `pytest` (622 passed) — includes new `test_create_asset_detects_index_type`
- [x] `pnpm run build` — clean typecheck + bundle
- [x] eslint clean on changed files
- [ ] Manual: add `^TYX` via UI, verify badge shows "index", price renders as e.g. `4.85%`, no volume bars
- [ ] Manual: add `^GSPC`, verify bare-number price (no `$`), no volume bars
- [ ] Manual: alembic upgrade applies cleanly on dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)