### PR TITLE
fix(yahoo): drop 100× scale on change_percent from /v7/finance/quote

### DIFF
--- a/backend/app/services/yahoo/_parsers.py
+++ b/backend/app/services/yahoo/_parsers.py
@@ -110,7 +110,10 @@ def parse_quote_row(sym: str, info: dict) -> dict:
         "price": round(float(price) / divisor, 4) if price is not None else None,
         "previous_close": round(float(prev_close) / divisor, 4) if prev_close is not None else None,
         "change": round(float(change) / divisor, 4) if change is not None else None,
-        "change_percent": round(float(change_pct) * 100, 2) if change_pct is not None else None,
+        # ``ticker.quotes`` (/v7/finance/quote) returns this already in
+        # percent units (10.53 = 10.53%), unlike ``ticker.price`` which
+        # returned a decimal (0.1053). No ×100 needed.
+        "change_percent": round(float(change_pct), 2) if change_pct is not None else None,
         "volume": int(volume) if volume is not None else None,
         "avg_volume": int(avg_volume) if avg_volume is not None else None,
         "currency": currency,

--- a/backend/tests/services/test_yahoo_quotes.py
+++ b/backend/tests/services/test_yahoo_quotes.py
@@ -40,7 +40,8 @@ class TestParseQuotes:
                 "regularMarketPrice": 185.50,
                 "regularMarketPreviousClose": 184.00,
                 "regularMarketChange": 1.50,
-                "regularMarketChangePercent": 0.0082,
+                # /v7/finance/quote returns this in percent units, not decimal.
+                "regularMarketChangePercent": 0.82,
                 "regularMarketVolume": 50_000_000,
                 "averageDailyVolume10Day": 55_000_000,
                 "marketState": "REGULAR",
@@ -102,7 +103,7 @@ class TestParseQuotes:
                 "regularMarketPrice": 6500.0,
                 "regularMarketPreviousClose": 6400.0,
                 "regularMarketChange": 100.0,
-                "regularMarketChangePercent": 0.015625,
+                "regularMarketChangePercent": 1.5625,
                 "regularMarketVolume": 10_000_000,
                 "averageDailyVolume10Day": None,
                 "marketState": "REGULAR",
@@ -120,13 +121,13 @@ class TestParseQuotes:
             "AAPL": {
                 "currency": "USD", "regularMarketPrice": 185.0,
                 "regularMarketPreviousClose": 184.0, "regularMarketChange": 1.0,
-                "regularMarketChangePercent": 0.005, "regularMarketVolume": 50_000_000,
+                "regularMarketChangePercent": 0.5, "regularMarketVolume": 50_000_000,
                 "averageDailyVolume10Day": None, "marketState": "REGULAR",
             },
             "MSFT": {
                 "currency": "USD", "regularMarketPrice": 420.0,
                 "regularMarketPreviousClose": 418.0, "regularMarketChange": 2.0,
-                "regularMarketChangePercent": 0.005, "regularMarketVolume": 30_000_000,
+                "regularMarketChangePercent": 0.5, "regularMarketVolume": 30_000_000,
                 "averageDailyVolume10Day": None, "marketState": "REGULAR",
             },
         }
@@ -174,7 +175,7 @@ class TestQuotes:
         good = {"AAPL": {
             "currency": "USD", "regularMarketPrice": 185.0,
             "regularMarketPreviousClose": 184.0, "regularMarketChange": 1.0,
-            "regularMarketChangePercent": 0.005, "regularMarketVolume": 50_000_000,
+            "regularMarketChangePercent": 0.5, "regularMarketVolume": 50_000_000,
             "averageDailyVolume10Day": None, "marketState": "REGULAR",
         }}
 


### PR DESCRIPTION
## Summary
- PR #502 switched quote fetching to `ticker.quotes` (`/v7/finance/quote`) for batched calls. That endpoint returns `regularMarketChangePercent` already in percent units (10.53 = 10.53%), unlike the old `ticker.price` (`/v10/quoteSummary`) which returned a decimal (0.1053 = 10.53%).
- `parse_quote_row` still multiplied by 100, so every percent change shown to the frontend was 100× too large (PRY.MI displayed +1053.05% instead of +10.53%, PL displayed -622.73% instead of -6.23%, etc.).
- Drop the `×100` in `_parsers.py` and update the four test fixtures whose decimal-format inputs no longer match what the new endpoint actually sends.

## Test plan
- [x] `pytest tests/services/test_yahoo_quotes.py tests/integration/test_quotes.py` — 31 passed
- [x] Full backend suite (excluding network-bound `test_holdings`) — 614 passed
- [ ] Verify on dev environment that watchlist `Change %` column shows realistic values (e.g. single-digit/low-double-digit moves) before promoting to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)