### PR TITLE
feat(assets): edit asset metadata via context menu

### DIFF
--- a/backend/alembic/versions/0013_fix_index_enum_uppercase.py
+++ b/backend/alembic/versions/0013_fix_index_enum_uppercase.py
@@ -1,0 +1,37 @@
+"""Add 'INDEX' (uppercase) to assettype enum.
+
+0012 mistakenly added the lowercase value ``'index'`` to the Postgres
+``assettype`` enum, but SQLAlchemy's ``Enum(AssetType)`` column stores
+the enum *name* (``'STOCK'``, ``'ETF'``, ``'INDEX'``), not the value.
+That left writes of ``AssetType.INDEX`` raising ``invalid input value
+for enum assettype: 'INDEX'`` while the orphan ``'index'`` value
+hung around unused.
+
+This migration adds the correct uppercase variant. The orphaned
+lowercase ``'index'`` is harmless (no rows ever referenced it, since
+the bug prevented inserts) and Postgres can't drop enum values, so
+we leave it.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-05-05
+"""
+
+from alembic import op
+
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE assettype ADD VALUE IF NOT EXISTS 'INDEX'")
+
+
+def downgrade() -> None:
+    # PostgreSQL doesn't support removing enum values; downgrade is a no-op.
+    pass

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.asset import AssetCreate, AssetResponse
+from app.schemas.asset import AssetCreate, AssetResponse, AssetUpdate
 from app.services import asset_service
 
 router = APIRouter(prefix="/api/assets", tags=["assets"])
@@ -24,6 +24,21 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     or any other group.
     """
     return await asset_service.create_asset(db, data.symbol, data.name, data.type)
+
+
+@router.patch("/{asset_id}", response_model=AssetResponse, summary="Update asset metadata")
+async def update_asset(asset_id: int, data: AssetUpdate, db: AsyncSession = Depends(get_db)):
+    """Patch an asset's metadata (name, type, currency). Useful for reclassifying
+    a ticker (e.g. stock → index) or fixing an incorrect auto-detected currency.
+    Fields omitted from the request body are left untouched.
+    """
+    return await asset_service.update_asset(
+        db,
+        asset_id,
+        name=data.name,
+        asset_type=data.type,
+        currency=data.currency,
+    )
 
 
 @router.delete("/{symbol}", status_code=204, summary="Remove an asset from the default group")

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -12,6 +12,12 @@ class AssetCreate(BaseModel):
     type: AssetType = Field(default=AssetType.STOCK, description="Asset type: stock or etf. Auto-detected if name is omitted.")
 
 
+class AssetUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=200, description="New display name.")
+    type: AssetType | None = Field(default=None, description="Override asset type (stock/etf/index).")
+    currency: str | None = Field(default=None, max_length=10, description="Override currency code (e.g. 'USD', 'EUR').")
+
+
 class TagBrief(BaseModel):
     id: int = Field(description="Tag ID")
     name: str = Field(description="Tag label (e.g. 'tech', 'growth')")

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import AssetType
+from app.models import Asset, AssetType
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
 from app.services.currency_service import ensure_currency
@@ -47,6 +47,34 @@ async def create_asset(
     return await repo.create(
         symbol=symbol, name=name, type=asset_type, currency=currency,
     )
+
+
+async def update_asset(
+    db: AsyncSession,
+    asset_id: int,
+    name: str | None = None,
+    asset_type: AssetType | None = None,
+    currency: str | None = None,
+):
+    """Apply partial updates to an asset row (name, type, currency).
+
+    Lets users reclassify a ticker after the fact (e.g. flip an index that
+    was auto-detected as a stock to ``AssetType.INDEX``) and override the
+    Yahoo-derived currency. None-valued fields are left untouched.
+    """
+    asset = await db.get(Asset, asset_id)
+    if not asset:
+        raise HTTPException(404, f"Asset {asset_id} not found")
+
+    if name is not None:
+        asset.name = name
+    if asset_type is not None:
+        asset.type = asset_type
+    if currency is not None:
+        await ensure_currency(db, currency)
+        asset.currency = currency
+
+    return await AssetRepository(db).save(asset)
 
 
 async def delete_asset(db: AsyncSession, symbol: str):

--- a/backend/tests/services/test_asset_service.py
+++ b/backend/tests/services/test_asset_service.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.models import AssetType
-from app.services.asset_service import create_asset, delete_asset, list_assets
+from app.services.asset_service import create_asset, delete_asset, list_assets, update_asset
 from tests.helpers import make_model_asset as _make_asset
 
 # Patch ensure_currency globally for all tests in this module since
@@ -223,6 +223,49 @@ async def test_create_asset_with_name_yahoo_fails_uses_suffix(MockAssetRepo, moc
 
     call_kwargs = mock_repo.create.call_args[1]
     assert call_kwargs["currency"] == "KRW"  # from suffix fallback
+
+
+@patch("app.services.asset_service.AssetRepository")
+async def test_update_asset_partial_fields_left_untouched(MockAssetRepo):
+    """Only fields explicitly provided are mutated; the rest stay as they were."""
+    db = AsyncMock()
+    asset = _make_asset(name="Old Name", type=AssetType.STOCK, currency="USD")
+    db.get = AsyncMock(return_value=asset)
+    mock_repo = MockAssetRepo.return_value
+    mock_repo.save = AsyncMock(return_value=asset)
+
+    await update_asset(db, asset_id=1, asset_type=AssetType.INDEX)
+
+    assert asset.type == AssetType.INDEX
+    assert asset.name == "Old Name"
+    assert asset.currency == "USD"
+    mock_repo.save.assert_awaited_once_with(asset)
+
+
+@patch(_ensure_patch, new_callable=AsyncMock)
+@patch("app.services.asset_service.AssetRepository")
+async def test_update_asset_currency_ensures_registration(MockAssetRepo, mock_ensure):
+    """Updating the currency must register it via ensure_currency before assigning."""
+    db = AsyncMock()
+    asset = _make_asset(currency="USD")
+    db.get = AsyncMock(return_value=asset)
+    mock_repo = MockAssetRepo.return_value
+    mock_repo.save = AsyncMock(return_value=asset)
+
+    await update_asset(db, asset_id=1, currency="EUR")
+
+    mock_ensure.assert_awaited_once_with(db, "EUR")
+    assert asset.currency == "EUR"
+
+
+async def test_update_asset_missing_raises_404():
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await update_asset(db, asset_id=999, name="x")
+    assert exc_info.value.status_code == 404
 
 
 @patch("app.services.asset_service.GroupRepository")

--- a/frontend/src/components/asset-card.tsx
+++ b/frontend/src/components/asset-card.tsx
@@ -1,10 +1,11 @@
-import { memo, useMemo } from "react"
+import { memo, useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu"
 import { AssetContextMenuContent } from "@/components/asset-context-menu"
+import { EditAssetDialog } from "@/components/edit-asset-dialog"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { DeferredSparkline } from "@/components/sparkline"
 import { TagBadge } from "@/components/tag-badge"
@@ -81,6 +82,7 @@ export const AssetCard = memo(function AssetCard({
   const changeCls = changeColor(changePct)
 
   const [priceRef, pctRef] = usePriceFlash(lastPrice)
+  const [editOpen, setEditOpen] = useState(false)
 
   return (
     <ContextMenu>
@@ -157,7 +159,13 @@ export const AssetCard = memo(function AssetCard({
         groupId={groupId}
         assetId={assetId}
         symbol={symbol}
+        onEdit={() => setEditOpen(true)}
         onRemove={() => onDelete(symbol)}
+      />
+      <EditAssetDialog
+        asset={{ id: assetId, symbol, name, type, currency, tags, created_at: "" }}
+        open={editOpen}
+        onOpenChange={setEditOpen}
       />
     </ContextMenu>
   )

--- a/frontend/src/components/asset-context-menu.tsx
+++ b/frontend/src/components/asset-context-menu.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightLeft, Copy, Trash2 } from "lucide-react"
+import { ArrowRightLeft, Copy, Pencil, Trash2 } from "lucide-react"
 import { resolveIcon } from "@/lib/icon-utils"
 import {
   ContextMenuContent,
@@ -14,6 +14,7 @@ interface AssetContextMenuContentProps {
   groupId: number
   assetId: number
   symbol: string
+  onEdit: () => void
   onRemove: () => void
 }
 
@@ -21,6 +22,7 @@ export function AssetContextMenuContent({
   groupId,
   assetId,
   symbol,
+  onEdit,
   onRemove,
 }: AssetContextMenuContentProps) {
   const { data: groups } = useGroups()
@@ -92,6 +94,11 @@ export function AssetContextMenuContent({
           <ContextMenuSeparator />
         </>
       )}
+      <ContextMenuItem onClick={onEdit}>
+        <Pencil className="h-4 w-4" />
+        Edit asset…
+      </ContextMenuItem>
+      <ContextMenuSeparator />
       <ContextMenuItem variant="destructive" onClick={onRemove}>
         <Trash2 className="h-4 w-4" />
         Remove from group

--- a/frontend/src/components/edit-asset-dialog.tsx
+++ b/frontend/src/components/edit-asset-dialog.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useUpdateAsset } from "@/lib/queries"
+import type { Asset, AssetType } from "@/lib/api"
+
+interface EditAssetDialogProps {
+  asset: Asset | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const TYPE_OPTIONS: { value: AssetType; label: string }[] = [
+  { value: "stock", label: "Stock" },
+  { value: "etf", label: "ETF" },
+  { value: "index", label: "Index" },
+]
+
+function EditAssetForm({ asset, onClose }: { asset: Asset; onClose: () => void }) {
+  const updateAsset = useUpdateAsset()
+  const [name, setName] = useState(asset.name)
+  const [type, setType] = useState<AssetType>(asset.type)
+  const [currency, setCurrency] = useState(asset.currency)
+
+  const dirty =
+    name.trim() !== asset.name ||
+    type !== asset.type ||
+    currency.trim().toUpperCase() !== asset.currency.toUpperCase()
+
+  const handleSave = () => {
+    if (!name.trim() || !currency.trim()) return
+    updateAsset.mutate(
+      {
+        id: asset.id,
+        data: {
+          name: name.trim() !== asset.name ? name.trim() : undefined,
+          type: type !== asset.type ? type : undefined,
+          currency:
+            currency.trim().toUpperCase() !== asset.currency.toUpperCase()
+              ? currency.trim().toUpperCase()
+              : undefined,
+        },
+      },
+      { onSuccess: onClose },
+    )
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Edit {asset.symbol}</DialogTitle>
+      </DialogHeader>
+      <div className="space-y-4 py-2">
+        <div className="space-y-2">
+          <Label htmlFor="asset-name">Name</Label>
+          <Input
+            id="asset-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="asset-type">Type</Label>
+          <Select value={type} onValueChange={(v) => setType(v as AssetType)}>
+            <SelectTrigger id="asset-type" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TYPE_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="asset-currency">Currency</Label>
+          <Input
+            id="asset-currency"
+            value={currency}
+            onChange={(e) => setCurrency(e.target.value)}
+            maxLength={10}
+            placeholder="USD, EUR, GBP, ..."
+          />
+        </div>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={!dirty || !name.trim() || !currency.trim() || updateAsset.isPending}
+        >
+          Save
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+export function EditAssetDialog({ asset, open, onOpenChange }: EditAssetDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[400px]">
+        {asset && (
+          <EditAssetForm
+            key={asset.id}
+            asset={asset}
+            onClose={() => onOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu"
 import { AssetContextMenuContent } from "@/components/asset-context-menu"
+import { EditAssetDialog } from "@/components/edit-asset-dialog"
 import { TagBadge } from "@/components/tag-badge"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { ExpandedAssetChart } from "@/components/expanded-asset-chart"
@@ -105,6 +106,7 @@ export const TableRow = memo(function TableRow({
   const handleToggle = useCallback(() => onToggle(asset.symbol), [onToggle, asset.symbol])
   const handleDelete = useCallback(() => onDelete(asset.symbol), [onDelete, asset.symbol])
   const handleHover = useCallback(() => onHover(asset.symbol), [onHover, asset.symbol])
+  const [editOpen, setEditOpen] = useState(false)
 
   return (
     <ContextMenu>
@@ -260,8 +262,10 @@ export const TableRow = memo(function TableRow({
         groupId={groupId}
         assetId={asset.id}
         symbol={asset.symbol}
+        onEdit={() => setEditOpen(true)}
         onRemove={handleDelete}
       />
+      <EditAssetDialog asset={asset} open={editOpen} onOpenChange={setEditOpen} />
       {expanded && (
         <tr>
           <td colSpan={totalColSpan} className="bg-muted/20 p-4 border-b border-border">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   Asset,
   AssetCreate,
   AssetDetail,
+  AssetUpdate,
   AssetPerformance,
   ConstituentIndicator,
   EarningsInfo,
@@ -72,6 +73,8 @@ export const api = {
     list: () => request<Asset[]>("/assets"),
     create: (data: AssetCreate) =>
       request<Asset>("/assets", { method: "POST", body: JSON.stringify(data) }),
+    update: (id: number, data: AssetUpdate) =>
+      request<Asset>(`/assets/${id}`, { method: "PATCH", body: JSON.stringify(data) }),
   },
   prices: {
     detail: (symbol: string, period?: string) =>

--- a/frontend/src/lib/queries/assets.ts
+++ b/frontend/src/lib/queries/assets.ts
@@ -1,5 +1,5 @@
 import { useQuery, keepPreviousData } from "@tanstack/react-query"
-import { api, type AssetCreate, type SymbolSearchResult } from "../api"
+import { api, type AssetCreate, type AssetUpdate, type SymbolSearchResult } from "../api"
 import { keys, STALE_1MIN, STALE_5MIN, useInvalidatingMutation } from "./shared"
 
 export function useAssets() {
@@ -9,6 +9,13 @@ export function useAssets() {
 export function useCreateAsset() {
   return useInvalidatingMutation(
     (data: AssetCreate) => api.assets.create(data),
+    [keys.assets, keys.groups],
+  )
+}
+
+export function useUpdateAsset() {
+  return useInvalidatingMutation(
+    ({ id, data }: { id: number; data: AssetUpdate }) => api.assets.update(id, data),
     [keys.assets, keys.groups],
   )
 }

--- a/frontend/src/lib/queries/index.ts
+++ b/frontend/src/lib/queries/index.ts
@@ -1,6 +1,6 @@
 export { keys, STALE_1MIN, STALE_5MIN, STALE_24H, useInvalidatingMutation } from "./shared"
 export { usePortfolioIndex, usePortfolioPerformers } from "./portfolio"
-export { useAssets, useCreateAsset, useLocalSearch, useYahooSearch } from "./assets"
+export { useAssets, useCreateAsset, useUpdateAsset, useLocalSearch, useYahooSearch } from "./assets"
 export { useAssetDetail, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
 export { useEarnings } from "./earnings"
 export { useTags, useCreateTag, useAttachTag, useDetachTag } from "./tags"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -42,6 +42,12 @@ export interface AssetCreate {
   type?: AssetType
 }
 
+export interface AssetUpdate {
+  name?: string
+  type?: AssetType
+  currency?: string
+}
+
 export interface SymbolSearchResult {
   symbol: string
   name: string


### PR DESCRIPTION
## Summary
- Adds an "Edit asset…" item to the row context menu (group table + asset cards) opening a dialog to change name, type (stock/etf/index), and currency — fixes the case where Yahoo auto-detection misclassifies a ticker (e.g. an index coming in as a stock) without forcing a delete-and-re-add.
- Backend: new `PATCH /api/assets/{id}` accepting partial `AssetUpdate`; `update_asset()` applies only non-None fields and registers unknown currency codes via `ensure_currency` before assignment.
- Frontend: new `EditAssetDialog` (shadcn Dialog + Select), submit only sends changed fields, Save disabled until form is dirty; `useUpdateAsset()` invalidates `assets` + `groups` query keys.
- Migration `0013` — fixes the `assettype` enum: `0012` added lowercase `'index'`, but SQLAlchemy's `Enum(AssetType)` column stores the enum *name* (`'INDEX'`), so any insert/update with `AssetType.INDEX` raised `invalid input value for enum assettype: 'INDEX'`, silently blocking the index-detection path on production-shaped data. `0013` adds uppercase `'INDEX'`. Orphaned lowercase `'index'` is left in place (no rows reference it, and Postgres can't drop enum values).

Targeting `dev` because of the schema migration.

## Test plan
- [x] Backend suite 618/618 (per commit verification)
- [x] PATCH succeeds end-to-end against running Postgres
- [x] 404 / 422 paths return correctly
- [ ] Verify on dev env: edit existing asset's type from stock → index, confirm group table reflects change without refresh
- [ ] Verify on dev env: edit currency to a previously-unseen code, confirm `ensure_currency` registers it
- [ ] Verify on dev env: migration `0013` applies cleanly on a DB that already ran `0012`

🤖 Generated with [Claude Code](https://claude.com/claude-code)