### PR TITLE
fix(assets): list endpoint must include orphan assets (#507)

### DIFF
--- a/backend/app/repositories/asset_repo.py
+++ b/backend/app/repositories/asset_repo.py
@@ -58,7 +58,7 @@ class AssetRepository:
         return list(result.all())
 
     async def list_all(self) -> list[Asset]:
-        result = await self.db.execute(select(Asset))
+        result = await self.db.execute(select(Asset).order_by(Asset.symbol))
         return list(result.scalars().all())
 
     async def get_by_ids(self, ids: list[int]) -> list[Asset]:

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -8,9 +8,14 @@ from app.services import asset_service
 router = APIRouter(prefix="/api/assets", tags=["assets"])
 
 
-@router.get("", response_model=list[AssetResponse], summary="List grouped assets")
+@router.get("", response_model=list[AssetResponse], summary="List all assets")
 async def list_assets(db: AsyncSession = Depends(get_db)):
-    """Return all assets that belong to at least one group, ordered alphabetically by symbol."""
+    """Return all assets, ordered alphabetically by symbol.
+
+    Includes assets not attached to any group — newly-created assets are orphans
+    until ``POST /api/groups/{id}/assets`` attaches them. Internal views that need
+    only grouped assets use repository-level filters directly.
+    """
     return await asset_service.list_assets(db)
 
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -10,7 +10,7 @@ from app.services.yahoo import currency_from_suffix, yahoo_client
 
 
 async def list_assets(db: AsyncSession):
-    return await AssetRepository(db).list_in_any_group()
+    return await AssetRepository(db).list_all()
 
 
 async def create_asset(

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -101,6 +101,9 @@ async def test_create_duplicate_asset_returns_existing(client):
 
 
 async def test_delete_asset(client):
+    """``DELETE /api/assets/{symbol}`` is a soft-delete: the row is preserved
+    so pseudo-ETF constituent relationships stay intact. The asset remains
+    visible in the listing — only group membership is removed."""
     mock_info = {"symbol": "AAPL", "name": "Apple", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
     with _mock_validate(return_value=mock_info):
         await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple"})
@@ -108,7 +111,7 @@ async def test_delete_asset(client):
     assert resp.status_code == 204
 
     resp = await client.get("/api/assets")
-    assert resp.json() == []
+    assert [a["symbol"] for a in resp.json()] == ["AAPL"]
 
 
 async def test_delete_nonexistent_asset(client):
@@ -117,25 +120,28 @@ async def test_delete_nonexistent_asset(client):
 
 
 async def test_list_assets_returns_created(client):
-    """``GET /api/assets`` returns assets that belong to at least one group.
-
-    ``POST /api/assets`` no longer auto-attaches to the Watchlist, so the
-    test must explicitly add each asset to a group.
-    """
+    """``GET /api/assets`` returns every asset, ordered by symbol —
+    including orphans not yet attached to any group."""
     mock_aapl = {"symbol": "AAPL", "name": "Apple", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
     mock_msft = {"symbol": "MSFT", "name": "Microsoft", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
     with _mock_validate(side_effect=[mock_aapl, mock_msft]):
-        a1 = await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple"})
-        a2 = await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft"})
-
-    groups = (await client.get("/api/groups")).json()
-    watchlist_id = next(g["id"] for g in groups if g["is_default"])
-    await client.post(
-        f"/api/groups/{watchlist_id}/assets",
-        json={"asset_ids": [a1.json()["id"], a2.json()["id"]]},
-    )
+        await client.post("/api/assets", json={"symbol": "AAPL", "name": "Apple"})
+        await client.post("/api/assets", json={"symbol": "MSFT", "name": "Microsoft"})
 
     resp = await client.get("/api/assets")
     assert resp.status_code == 200
     symbols = [a["symbol"] for a in resp.json()]
     assert symbols == ["AAPL", "MSFT"]
+
+
+async def test_list_assets_includes_orphans(client):
+    """Regression for #507: a freshly POSTed asset must appear in GET /api/assets
+    even before it has been attached to any group."""
+    mock_info = {"symbol": "OKLO", "name": "Oklo", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        await client.post("/api/assets", json={"symbol": "OKLO", "name": "Oklo"})
+
+    resp = await client.get("/api/assets")
+    assert resp.status_code == 200
+    symbols = [a["symbol"] for a in resp.json()]
+    assert "OKLO" in symbols

--- a/backend/tests/services/test_asset_service.py
+++ b/backend/tests/services/test_asset_service.py
@@ -28,12 +28,12 @@ async def test_list_assets_delegates_to_repo(MockRepo):
     db = AsyncMock()
     mock_repo = MockRepo.return_value
     expected = [_make_asset()]
-    mock_repo.list_in_any_group = AsyncMock(return_value=expected)
+    mock_repo.list_all = AsyncMock(return_value=expected)
 
     result = await list_assets(db)
 
     MockRepo.assert_called_once_with(db)
-    mock_repo.list_in_any_group.assert_awaited_once()
+    mock_repo.list_all.assert_awaited_once()
     assert result == expected
 
 


### PR DESCRIPTION
Closes #507.

## Summary
After PR #499 deliberately decoupled asset creation from default-group attachment, freshly-POSTed assets are orphans by design until the caller explicitly attaches them via `POST /api/groups/{id}/assets`. The leftover orphan filter on `GET /api/assets` meant those assets silently vanished from listings — POST returned 201 with an asset object, GET pretended it didn't exist.

## Approach
The issue lists three fix options. Going with a tightened version of Option C:

- Schema and POST are already correct after #499 — `add_to_default_group` is not advertised, the router docstring already states the post-decoupling contract. The issue's claim that the schema "drops the flag" describes a stale CLI client, not a server contract.
- The only real backend bug is the LIST endpoint hiding orphans. That's a leftover from the old auto-attach world.
- Option A (honor the flag + migration to set Watchlist as default) would *revert* #499's intentional decoupling.

So this PR is a minimal, targeted fix.

## Changes
- `asset_service.list_assets` calls `AssetRepository.list_all` instead of `list_in_any_group`
- `list_all()` now orders by symbol so the public endpoint's contract is preserved
- Router summary updated to "List all assets" + docstring clarifies orphans are included
- Internal narrowed views (`portfolio.py` compute, batch ops) keep using `list_in_any_group_*` repo helpers — those are computational, not API-facing
- `test_delete_asset` updated: soft-delete preserves the row in listings (only group membership is removed — matches the existing `delete_asset` design)
- New `test_list_assets_includes_orphans` as regression guard

## Frontend impact (no code change)
Three consumers of `useAssets()`, all benefit from including orphans:
- `use-tracked-symbols` (search "already tracked" indicator) → now correctly recognises orphan assets, prevents misleading "add" state
- `add-constituent-picker` (pseudo-ETF builder) → can pick from all assets
- `asset-detail` siblings → unaffected behavior

Targeting `dev` because this is a contract change to a public LIST endpoint.

## Test plan
- [x] `pytest` 626/626 passes locally
- [x] New regression test `test_list_assets_includes_orphans` covers the bug
- [x] Updated `test_delete_asset` reflects corrected soft-delete semantics
- [ ] Verify on dev env: POST /api/assets → asset immediately appears in GET /api/assets without group attachment
- [ ] Verify on dev env: search picker correctly marks already-tracked orphans as tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)