### PR TITLE
fix(assets): loud delete_asset error + default-group repair migration (#507)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Two long-lived branches: `main` (production, `fibenchi:latest`) and `dev` (stagi
 
 ### Backend Layout
 
-- `models/` — SQLAlchemy declarative models with `Mapped[]` type hints. Asset has a `type` enum (stock/etf) and `watchlisted` bool.
+- `models/` — SQLAlchemy declarative models with `Mapped[]` type hints. Asset has a `type` enum (stock/etf/index). Group has an `is_default` bool — exactly one row should carry it (the seeded "Watchlist" group); migration 0014 repairs drift.
 - `schemas/` — Pydantic v2 request/response models with `from_attributes` config. All router endpoints use `response_model` for typed OpenAPI schemas.
 - `routers/` — FastAPI routers, all prefixed under `/api`. Dependency-injected `AsyncSession` via `get_db()`. Period params use `PeriodType = Literal["1mo","3mo","6mo","1y","2y","5y"]` with `Query()` for automatic 422 validation.
 - `services/yahoo.py` — Yahoo Finance integration via `yahooquery`. Fetches OHLCV history, validates symbols, detects asset types, fetches ETF holdings.
@@ -124,11 +124,11 @@ On startup (`main.py` lifespan):
 
 ## Key Patterns
 
-- **Watchlist decoupling:** Deleting an asset sets `watchlisted=false` instead of removing the row. This preserves pseudo-ETF constituent relationships. Dashboard filters by `watchlisted=true`.
+- **Default-group soft delete:** The `Watchlist` group (flagged `is_default=true`, seeded by migration 0004) acts as the default container. `DELETE /api/assets/{symbol}` removes the asset from this default group only — the row and any other group memberships are preserved (so pseudo-ETF constituent relationships remain intact). If no default group exists, the endpoint raises HTTP 500; migration 0014 self-heals drifted instances.
 - **Pseudo-ETFs:** User-created baskets with equal-weight allocation, quarterly rebalancing (months 1,4,7,10), separate thesis/annotations tables.
 - **Generic components:** `ThesisEditor` and `AnnotationsList` accept data + callbacks as props, reused across asset detail and pseudo-ETF detail pages.
 - **Price warmup:** Indicator endpoint fetches `WARMUP_DAYS` extra calendar days before the display period to warm up SMA50/Bollinger Bands. Derived from `max_warmup_periods * 2.3`.
-- **SSE quote stream:** Backend pushes watchlisted quotes via SSE with adaptive intervals (15s during market hours, 60s pre/post, 300s closed). Frontend reconnects with exponential backoff (1s→30s) on disconnect.
+- **SSE quote stream:** Backend pushes quotes for assets in any group via SSE (`AssetRepository.list_in_any_group_id_symbol_pairs`) with adaptive intervals (15s during market hours, 60s pre/post, 300s closed). Frontend reconnects with exponential backoff (1s→30s) on disconnect.
 - **Stale price animation:** Group table falls back to DB-cached indicator prices when no live SSE quote is available. During market hours, stale values show a pulsing opacity animation (`.stale-price` CSS class). Suppressed when `market_state` is `CLOSED` or `POSTMARKET`.
 - **Price flash:** `usePriceFlash` hook triggers green/red background fade animation (1.8s) on price tick changes, using a reflow trick to restart CSS animations on repeated same-direction ticks.
 - **SPA fallback:** In production, the root `Dockerfile` copies the built SPA into `static/`. `main.py` mounts it and serves `index.html` for all non-API, non-asset routes. In dev, this directory doesn't exist so the mount is skipped.

--- a/backend/alembic/versions/0014_repair_default_group_flag.py
+++ b/backend/alembic/versions/0014_repair_default_group_flag.py
@@ -1,0 +1,67 @@
+"""Repair the is_default flag on the groups table if it has drifted.
+
+Migration 0004 originally seeded ``is_default = true`` on the Watchlist
+group, but at least one production database has drifted such that no
+group carries the flag. ``GroupRepository.get_default()`` then returns
+``None`` and ``DELETE /api/assets/{symbol}`` becomes a silent no-op
+(see issue #507).
+
+This migration is idempotent and self-healing:
+
+- If exactly one group has ``is_default = true``, do nothing.
+- If multiple groups have it set, keep the lowest-id one and demote the rest.
+- If zero groups have it set, promote the group named ``Watchlist`` (case
+  exact, matches what 0004 seeded). If no such group exists, do nothing —
+  the upgraded ``delete_asset`` raises a 500 with a clear message so the
+  operator knows what to fix.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-05-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    default_count = conn.execute(
+        sa.text("SELECT COUNT(*) FROM groups WHERE is_default = true")
+    ).scalar() or 0
+
+    if default_count == 1:
+        return
+
+    if default_count > 1:
+        keep_id = conn.execute(
+            sa.text("SELECT MIN(id) FROM groups WHERE is_default = true")
+        ).scalar()
+        conn.execute(
+            sa.text(
+                "UPDATE groups SET is_default = false "
+                "WHERE is_default = true AND id != :id"
+            ),
+            {"id": keep_id},
+        )
+        return
+
+    watchlist = conn.execute(
+        sa.text("SELECT id FROM groups WHERE name = 'Watchlist' LIMIT 1")
+    ).fetchone()
+    if watchlist:
+        conn.execute(
+            sa.text("UPDATE groups SET is_default = true WHERE id = :id"),
+            {"id": watchlist[0]},
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -86,6 +86,11 @@ async def delete_asset(db: AsyncSession, symbol: str):
     asset = await get_asset(symbol, db)
     group_repo = GroupRepository(db)
     default_group = await group_repo.get_default()
-    if default_group:
-        default_group.assets = [a for a in default_group.assets if a.id != asset.id]
-        await group_repo.save(default_group)
+    if default_group is None:
+        raise HTTPException(
+            500,
+            "No default group is configured. Set is_default=true on exactly one "
+            "group (typically 'Watchlist'). Migration 0014 repairs this on deploy.",
+        )
+    default_group.assets = [a for a in default_group.assets if a.id != asset.id]
+    await group_repo.save(default_group)

--- a/backend/tests/services/test_asset_service.py
+++ b/backend/tests/services/test_asset_service.py
@@ -284,3 +284,25 @@ async def test_delete_asset_removes_from_default_group(MockAssetRepo, MockGroupR
 
     assert asset not in default_group.assets
     mock_group_repo.save.assert_awaited_once()
+
+
+@patch("app.services.asset_service.GroupRepository")
+@patch("app.services.asset_service.AssetRepository")
+async def test_delete_asset_raises_when_no_default_group(MockAssetRepo, MockGroupRepo):
+    """Regression for #507: silently no-op'ing when no group has is_default=true
+    is the worst-case UX. Surface it as 500 instead so the misconfig is loud."""
+    from fastapi import HTTPException
+
+    db = AsyncMock()
+    asset = _make_asset()
+
+    mock_group_repo = MockGroupRepo.return_value
+    mock_group_repo.get_default = AsyncMock(return_value=None)
+    mock_group_repo.save = AsyncMock()
+
+    with patch("app.services.asset_service.get_asset", new_callable=AsyncMock, return_value=asset):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_asset(db, "AAPL")
+
+    assert exc_info.value.status_code == 500
+    mock_group_repo.save.assert_not_called()


### PR DESCRIPTION
Companion to #509 — together they close #507.

## Summary
`DELETE /api/assets/{symbol}` previously *silently* no-op'd on databases where no group had `is_default = true`. The caller got a 204 even though nothing happened — the worst kind of UX failure. Migration 0004 originally seeded `is_default=true` on Watchlist, but at least one production instance has drifted.

This PR layers two fixes:

1. **Loud failure** — `asset_service.delete_asset` now raises HTTP 500 with a clear remediation message when no default group exists. Future drift surfaces immediately instead of hiding.
2. **Self-healing migration 0014** — idempotently repairs the invariant on every deploy:
   - 1 default group → no-op
   - >1 → keep the lowest-id, demote the rest
   - 0 → promote a group named `Watchlist` if it exists; otherwise do nothing (the loud 500 from delete_asset will tell the operator)

Verified locally: applied 0014 against a DB that already had Watchlist correctly flagged, confirmed it's a no-op (`is_default=true` count stayed at 1, on the existing Watchlist row).

## CLAUDE.md cleanup (also in this PR)
Three stale references corrected:
- ``Asset has a `type` enum (stock/etf) and `watchlisted` bool`` → enum is stock/etf/index, no watchlisted field exists; replaced with accurate Group `is_default` description
- "Watchlist decoupling" pattern referenced a non-existent Dashboard and a `watchlisted=false` soft-delete that doesn't happen → replaced with "Default-group soft delete" describing actual behavior
- "SSE quote stream pushes watchlisted quotes" → it actually queries `list_in_any_group_id_symbol_pairs`, fixed

## Test plan
- [x] New `test_delete_asset_raises_when_no_default_group` covers the loud failure
- [x] Existing `test_delete_asset_removes_from_default_group` still passes (default group exists in test fixture)
- [x] `pytest` 626/626 (was 625, +1 new test on this branch)
- [x] `alembic upgrade head` ran cleanly against local Postgres, post-migration invariant verified via SQL
- [ ] Verify on dev env: deploy applies 0014 with no errors
- [ ] Verify on dev env: DELETE /api/assets/{symbol} succeeds end-to-end (regression: still works on a healthy DB)
- [ ] Verify on dev env: DELETE returns 500 with clear message if `is_default` is manually unset on Watchlist (smoke test for the loud-failure path)

## Coordination with #509
Both target `dev` and both close #507. They touch different concerns and can merge in either order:
- #509: drops orphan filter on `GET /api/assets` (3-line fix)
- This PR: hardens `delete_asset` + ships repair migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)