### PR TITLE
feat: asset movement stats + precise analysis window (#515, #517)

### DIFF
--- a/frontend/src/components/earnings-countdown.tsx
+++ b/frontend/src/components/earnings-countdown.tsx
@@ -3,6 +3,7 @@ import { useEarnings } from "@/lib/queries"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
+import { formatDateLong } from "@/lib/format"
 
 const DIAL_SIZE = 96
 const STROKE = 6
@@ -16,14 +17,6 @@ function daysUntil(dateStr: string): number {
   const now = new Date()
   now.setHours(0, 0, 0, 0)
   return Math.round((target.getTime() - now.getTime()) / 86_400_000)
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr + "T00:00:00").toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  })
 }
 
 function getColor(days: number): { stroke: string; text: string } {
@@ -104,7 +97,7 @@ export function EarningsCountdown({ symbol }: { symbol: string }) {
         <div className="space-y-1">
           <p className="text-sm font-semibold text-amber-500">Post-Earnings</p>
           <p className="text-xs text-muted-foreground">
-            Reported {formatDate(reportedDate)} — price action may be noisy
+            Reported {formatDateLong(reportedDate)} — price action may be noisy
           </p>
         </div>
       </div>
@@ -148,7 +141,7 @@ export function EarningsCountdown({ symbol }: { symbol: string }) {
       </div>
       <div className="space-y-1">
         <p className="text-sm font-medium text-muted-foreground">Earnings Countdown</p>
-        <p className="text-sm">{formatDate(date)}</p>
+        <p className="text-sm">{formatDateLong(date)}</p>
         {isEstimate && <Badge variant="outline" className="text-[10px]">Estimated</Badge>}
       </div>
     </div>

--- a/frontend/src/components/period-selector.tsx
+++ b/frontend/src/components/period-selector.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button"
-
-const DEFAULT_PERIODS = ["1mo", "3mo", "6mo", "1y", "2y", "5y"] as const
+import { STANDARD_PERIODS } from "@/lib/asset-window"
 
 interface PeriodSelectorProps {
   value: string
@@ -11,7 +10,7 @@ interface PeriodSelectorProps {
 export function PeriodSelector({
   value,
   onChange,
-  periods = DEFAULT_PERIODS,
+  periods = STANDARD_PERIODS,
 }: PeriodSelectorProps) {
   return (
     <div className="flex gap-1">

--- a/frontend/src/components/window-selector.tsx
+++ b/frontend/src/components/window-selector.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react"
+import { CalendarDays } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { STANDARD_PERIODS, relativeStart, ytdStart, todayISO, type AssetWindow } from "@/lib/asset-window"
+
+const RELATIVE_PRESETS: { label: string; days: number }[] = [
+  { label: "1W", days: 7 },
+  { label: "2W", days: 14 },
+  { label: "3W", days: 21 },
+]
+
+function formatShort(iso: string): string {
+  return new Date(iso + "T00:00:00").toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}
+
+interface WindowSelectorProps {
+  value: AssetWindow
+  onChange: (window: AssetWindow) => void
+}
+
+export function WindowSelector({ value, onChange }: WindowSelectorProps) {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState("")
+  const isCustom = value.kind === "since"
+
+  const applySince = (start: string) => {
+    if (!start) return
+    onChange({ kind: "since", start })
+    setOpen(false)
+  }
+
+  return (
+    <div className="flex gap-1">
+      {STANDARD_PERIODS.map((p) => (
+        <Button
+          key={p}
+          variant={value.kind === "period" && value.period === p ? "default" : "ghost"}
+          size="sm"
+          onClick={() => onChange({ kind: "period", period: p })}
+          className="text-xs"
+        >
+          {p}
+        </Button>
+      ))}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant={isCustom ? "default" : "ghost"} size="sm" className="text-xs gap-1.5">
+            <CalendarDays className="h-3.5 w-3.5" />
+            {isCustom ? formatShort(value.start) : "Custom"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-56 space-y-3">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-1.5">Recent</p>
+            <div className="flex flex-wrap gap-1">
+              {RELATIVE_PRESETS.map((r) => (
+                <Button
+                  key={r.label}
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  onClick={() => applySince(relativeStart(r.days))}
+                >
+                  {r.label}
+                </Button>
+              ))}
+              <Button variant="outline" size="sm" className="text-xs" onClick={() => applySince(ytdStart())}>
+                YTD
+              </Button>
+            </div>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-1.5">Since a date</p>
+            <div className="flex gap-1.5">
+              <Input
+                type="date"
+                max={todayISO()}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                className="h-8 text-xs"
+              />
+              <Button size="sm" className="text-xs" disabled={!draft} onClick={() => applySince(draft)}>
+                Apply
+              </Button>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/frontend/src/components/window-selector.tsx
+++ b/frontend/src/components/window-selector.tsx
@@ -4,16 +4,13 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { STANDARD_PERIODS, relativeStart, ytdStart, todayISO, type AssetWindow } from "@/lib/asset-window"
+import { formatDateShort } from "@/lib/format"
 
 const RELATIVE_PRESETS: { label: string; days: number }[] = [
   { label: "1W", days: 7 },
   { label: "2W", days: 14 },
   { label: "3W", days: 21 },
 ]
-
-function formatShort(iso: string): string {
-  return new Date(iso + "T00:00:00").toLocaleDateString(undefined, { month: "short", day: "numeric" })
-}
 
 interface WindowSelectorProps {
   value: AssetWindow
@@ -22,7 +19,7 @@ interface WindowSelectorProps {
 
 export function WindowSelector({ value, onChange }: WindowSelectorProps) {
   const [open, setOpen] = useState(false)
-  const [draft, setDraft] = useState("")
+  const [draft, setDraft] = useState(value.kind === "since" ? value.start : "")
   const isCustom = value.kind === "since"
 
   const applySince = (start: string) => {
@@ -48,7 +45,7 @@ export function WindowSelector({ value, onChange }: WindowSelectorProps) {
         <PopoverTrigger asChild>
           <Button variant={isCustom ? "default" : "ghost"} size="sm" className="text-xs gap-1.5">
             <CalendarDays className="h-3.5 w-3.5" />
-            {isCustom ? formatShort(value.start) : "Custom"}
+            {isCustom ? formatDateShort(value.start) : "Custom"}
           </Button>
         </PopoverTrigger>
         <PopoverContent align="end" className="w-56 space-y-3">

--- a/frontend/src/lib/asset-window.ts
+++ b/frontend/src/lib/asset-window.ts
@@ -1,0 +1,98 @@
+/**
+ * Asset-detail analysis window.
+ *
+ * A window always ends at the latest available data and is fully described by a
+ * start. It is either one of the backend's fixed periods, or an explicit start
+ * date ("since"). Custom windows are served frontend-only: we fetch the smallest
+ * fixed period that *covers* the start, then slice the result to the exact day —
+ * no backend arbitrary-range endpoint required.
+ */
+
+/** Calendar-day span of each fixed backend period. Mirrors backend `PERIOD_DAYS`. */
+export const PERIOD_DAYS: Record<string, number> = {
+  "1mo": 30,
+  "3mo": 90,
+  "6mo": 180,
+  "1y": 365,
+  "2y": 730,
+  "5y": 1825,
+}
+
+/** Fixed periods understood by the backend, smallest → largest. */
+export const STANDARD_PERIODS = ["1mo", "3mo", "6mo", "1y", "2y", "5y"] as const
+
+const LARGEST_PERIOD = STANDARD_PERIODS[STANDARD_PERIODS.length - 1]
+
+export type AssetWindow =
+  | { kind: "period"; period: string }
+  | { kind: "since"; start: string } // ISO yyyy-mm-dd
+
+export interface ResolvedWindow {
+  /** Backend period to actually fetch (guaranteed to cover the window). */
+  fetchPeriod: string
+  /** ISO date to slice the fetched series at, or null to use the whole period. */
+  startDate: string | null
+  /** Human label for the active window. */
+  label: string
+}
+
+/** Format a Date as a local-time ISO date (avoids the UTC shift of toISOString). */
+function toISODate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+/** Today as a local ISO date. */
+export function todayISO(): string {
+  return toISODate(new Date())
+}
+
+/** ISO date `days` calendar days before today (local). */
+export function relativeStart(days: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() - days)
+  return toISODate(d)
+}
+
+/** ISO date for Jan 1 of the current year. */
+export function ytdStart(): string {
+  return `${new Date().getFullYear()}-01-01`
+}
+
+/** Smallest fixed period whose span covers `days`; clamps to the largest. */
+export function coveringPeriod(days: number): string {
+  for (const p of STANDARD_PERIODS) {
+    if (PERIOD_DAYS[p] >= days) return p
+  }
+  return LARGEST_PERIOD
+}
+
+function daysSince(isoStart: string): number {
+  const start = new Date(isoStart + "T00:00:00")
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  return Math.ceil((now.getTime() - start.getTime()) / 86_400_000)
+}
+
+function formatSinceLabel(isoStart: string): string {
+  const d = new Date(isoStart + "T00:00:00").toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+  return `since ${d}`
+}
+
+export function resolveWindow(window: AssetWindow): ResolvedWindow {
+  if (window.kind === "period") {
+    return { fetchPeriod: window.period, startDate: null, label: window.period }
+  }
+  return {
+    fetchPeriod: coveringPeriod(daysSince(window.start)),
+    startDate: window.start,
+    label: formatSinceLabel(window.start),
+  }
+}

--- a/frontend/src/lib/asset-window.ts
+++ b/frontend/src/lib/asset-window.ts
@@ -8,6 +8,8 @@
  * no backend arbitrary-range endpoint required.
  */
 
+import { formatDateLong } from "./format"
+
 /** Calendar-day span of each fixed backend period. Mirrors backend `PERIOD_DAYS`. */
 export const PERIOD_DAYS: Record<string, number> = {
   "1mo": 30,
@@ -78,12 +80,7 @@ function daysSince(isoStart: string): number {
 }
 
 function formatSinceLabel(isoStart: string): string {
-  const d = new Date(isoStart + "T00:00:00").toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  })
-  return `since ${d}`
+  return `since ${formatDateLong(isoStart)}`
 }
 
 export function resolveWindow(window: AssetWindow): ResolvedWindow {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -121,6 +121,23 @@ export function formatChangePct(v: number | null): { text: string | null; classN
   }
 }
 
+/** Format an ISO date (`yyyy-mm-dd`) in the user's locale, e.g. "Feb 1, 2026". */
+export function formatDateLong(iso: string): string {
+  return new Date(iso + "T00:00:00").toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+/** Format an ISO date (`yyyy-mm-dd`) without the year, e.g. "Feb 1". */
+export function formatDateShort(iso: string): string {
+  return new Date(iso + "T00:00:00").toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })
+}
+
 export function buildYahooQuoteUrl(symbol: string): string {
   return `https://finance.yahoo.com/quote/${encodeURIComponent(symbol)}/`
 }

--- a/frontend/src/lib/movement-stats.ts
+++ b/frontend/src/lib/movement-stats.ts
@@ -1,0 +1,102 @@
+import type { Price } from "@/lib/types"
+
+interface DailyExtreme {
+  /** Close-to-close percentage change for the day. */
+  pct: number
+  /** ISO date of the day the move occurred. */
+  date: string
+}
+
+interface Drawdown {
+  /** Peak-to-trough decline as a (negative) percentage. */
+  pct: number
+  /** ISO date of the running peak the decline measured from. */
+  peakDate: string
+  /** ISO date of the trough (the lowest close after that peak). */
+  troughDate: string
+}
+
+export interface MovementStats {
+  /** Total return from the first close in the window to the latest close, as a percentage. */
+  periodReturnPct: number
+  /** First close in the window (baseline for the period return). */
+  startClose: number
+  /** Latest close in the window. */
+  endClose: number
+  /** Largest single-day gain (close-to-close). Null only when there are no day-over-day transitions. */
+  maxDailyGain: DailyExtreme | null
+  /** Largest single-day loss (close-to-close); `pct` is negative for a genuine loss. */
+  maxDailyLoss: DailyExtreme | null
+  /** Largest peak-to-trough decline over the window. Null when the close never fell below a running peak. */
+  maxDrawdown: Drawdown | null
+  /** Count of days that closed higher than the previous close. */
+  upDays: number
+  /** Count of days that closed lower than the previous close. */
+  downDays: number
+  /** Number of day-over-day transitions considered (prices.length - 1). */
+  tradingDays: number
+}
+
+/**
+ * Derive period movement and downside metrics from an OHLCV series.
+ *
+ * Pure and side-effect-free — operates only on the passed `prices` (assumed
+ * ascending by date, as returned by the asset-detail endpoint). Returns null
+ * when there is too little data (< 2 points) or the baseline close is invalid.
+ *
+ * Note: "max daily move" (single-day, close-to-close) and "max drawdown"
+ * (path-dependent peak-to-trough) are distinct metrics; both are reported.
+ */
+export function computeMovementStats(prices: Price[]): MovementStats | null {
+  if (prices.length < 2) return null
+
+  const first = prices[0]
+  const last = prices[prices.length - 1]
+  if (first.close <= 0) return null
+
+  let maxDailyGain: DailyExtreme | null = null
+  let maxDailyLoss: DailyExtreme | null = null
+  let upDays = 0
+  let downDays = 0
+
+  // Running-peak drawdown: track the highest close seen so far and the largest
+  // decline measured from it.
+  let peak = first.close
+  let peakDate = first.date
+  let maxDrawdown: Drawdown | null = null
+
+  for (let i = 1; i < prices.length; i++) {
+    const prev = prices[i - 1].close
+    const { close: cur, date } = prices[i]
+
+    if (prev > 0) {
+      const dayPct = (cur / prev - 1) * 100
+      if (dayPct > 0) upDays++
+      else if (dayPct < 0) downDays++
+      if (maxDailyGain === null || dayPct > maxDailyGain.pct) maxDailyGain = { pct: dayPct, date }
+      if (maxDailyLoss === null || dayPct < maxDailyLoss.pct) maxDailyLoss = { pct: dayPct, date }
+    }
+
+    if (cur > peak) {
+      peak = cur
+      peakDate = date
+    } else if (peak > 0) {
+      const ddPct = (cur / peak - 1) * 100
+      if (maxDrawdown === null || ddPct < maxDrawdown.pct) {
+        maxDrawdown = { pct: ddPct, peakDate, troughDate: date }
+      }
+    }
+  }
+
+  return {
+    periodReturnPct: (last.close / first.close - 1) * 100,
+    startClose: first.close,
+    endClose: last.close,
+    maxDailyGain,
+    maxDailyLoss,
+    maxDrawdown,
+    upDays,
+    downDays,
+    tradingDays: prices.length - 1,
+  }
+}

--- a/frontend/src/lib/queries/index.ts
+++ b/frontend/src/lib/queries/index.ts
@@ -1,7 +1,7 @@
 export { keys, STALE_1MIN, STALE_5MIN, STALE_24H, useInvalidatingMutation } from "./shared"
 export { usePortfolioIndex, usePortfolioPerformers } from "./portfolio"
 export { useAssets, useCreateAsset, useUpdateAsset, useLocalSearch, useYahooSearch } from "./assets"
-export { useAssetDetail, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
+export { useAssetDetail, useAssetWindow, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
 export { useEarnings } from "./earnings"
 export { useTags, useCreateTag, useAttachTag, useDetachTag } from "./tags"
 export { useGroups, useCreateGroup, useUpdateGroup, useDeleteGroup, useReorderGroups, useAddAssetsToGroup, useRemoveAssetFromGroup, useGroup, useGroupSparklines, useGroupIndicators, usePrefetchOtherGroups } from "./groups"

--- a/frontend/src/lib/queries/prices.ts
+++ b/frontend/src/lib/queries/prices.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
-import { useCallback } from "react"
+import { useCallback, useMemo } from "react"
 import { api } from "../api"
+import { resolveWindow, type AssetWindow } from "../asset-window"
 import { keys, STALE_5MIN, STALE_24H, useInvalidatingMutation } from "./shared"
 
 export function useAssetDetail(symbol: string, period?: string, opts?: { enabled?: boolean }) {
@@ -11,6 +12,30 @@ export function useAssetDetail(symbol: string, period?: string, opts?: { enabled
     staleTime: STALE_5MIN, // 5 min — daily OHLCV data, SSE handles live quotes
     placeholderData: keepPreviousData,
   })
+}
+
+function sliceFrom<T extends { date: string }>(
+  rows: T[] | undefined,
+  startDate: string | null,
+): T[] | undefined {
+  if (!rows || !startDate) return rows
+  return rows.filter((r) => r.date >= startDate) // ISO dates compare lexicographically
+}
+
+/**
+ * Fetch asset detail for an analysis window. Resolves the window to a covering
+ * fixed period (so the underlying `useAssetDetail` cache is shared with the
+ * chart), then slices prices + indicators to the window's exact start.
+ */
+export function useAssetWindow(symbol: string, window: AssetWindow, opts?: { enabled?: boolean }) {
+  const { fetchPeriod, startDate, label } = resolveWindow(window)
+  const query = useAssetDetail(symbol, fetchPeriod, opts)
+  const prices = useMemo(() => sliceFrom(query.data?.prices, startDate), [query.data?.prices, startDate])
+  const indicators = useMemo(
+    () => sliceFrom(query.data?.indicators, startDate),
+    [query.data?.indicators, startDate],
+  )
+  return { ...query, prices, indicators, fetchPeriod, windowLabel: label }
 }
 
 export function useEtfHoldings(symbol: string, enabled: boolean) {

--- a/frontend/src/lib/queries/prices.ts
+++ b/frontend/src/lib/queries/prices.ts
@@ -26,16 +26,23 @@ function sliceFrom<T extends { date: string }>(
  * Fetch asset detail for an analysis window. Resolves the window to a covering
  * fixed period (so the underlying `useAssetDetail` cache is shared with the
  * chart), then slices prices + indicators to the window's exact start.
+ *
+ * Consumers should read the sliced `prices` / `indicators` returned here — NOT
+ * `data.prices` (which is the unsliced full-period payload). `windowEmpty` is
+ * true when the fetch returned data but nothing falls inside the window (e.g.
+ * a "since" date with no trading days yet), so callers can distinguish that
+ * from "the asset has no data at all".
  */
-export function useAssetWindow(symbol: string, window: AssetWindow, opts?: { enabled?: boolean }) {
-  const { fetchPeriod, startDate, label } = resolveWindow(window)
+export function useAssetWindow(symbol: string, assetWindow: AssetWindow, opts?: { enabled?: boolean }) {
+  const { fetchPeriod, startDate, label } = resolveWindow(assetWindow)
   const query = useAssetDetail(symbol, fetchPeriod, opts)
   const prices = useMemo(() => sliceFrom(query.data?.prices, startDate), [query.data?.prices, startDate])
   const indicators = useMemo(
     () => sliceFrom(query.data?.indicators, startDate),
     [query.data?.indicators, startDate],
   )
-  return { ...query, prices, indicators, fetchPeriod, windowLabel: label }
+  const windowEmpty = !!query.data?.prices?.length && !prices?.length
+  return { ...query, prices, indicators, fetchPeriod, windowLabel: label, windowEmpty }
 }
 
 export function useEtfHoldings(symbol: string, enabled: boolean) {

--- a/frontend/src/pages/asset-detail/chart-section.tsx
+++ b/frontend/src/pages/asset-detail/chart-section.tsx
@@ -77,7 +77,8 @@ function HistoricalChartSection({
   currency?: string
   assetType?: AssetType
 }) {
-  const { prices, indicators, isLoading: detailLoading, isFetching: detailFetching } = useAssetWindow(symbol, assetWindow)
+  const { prices, indicators, windowEmpty, isLoading: detailLoading, isFetching: detailFetching } =
+    useAssetWindow(symbol, assetWindow)
   const { data: annotations } = useAnnotations(symbol)
 
   if (detailLoading) {
@@ -87,7 +88,9 @@ function HistoricalChartSection({
   if (!prices?.length) {
     return (
       <div className="h-[520px] flex items-center justify-center text-muted-foreground">
-        No price data. Click Refresh to fetch.
+        {windowEmpty
+          ? "No data in this window — try a wider range."
+          : "No price data. Click Refresh to fetch."}
       </div>
     )
   }

--- a/frontend/src/pages/asset-detail/chart-section.tsx
+++ b/frontend/src/pages/asset-detail/chart-section.tsx
@@ -1,15 +1,16 @@
 import { PriceChart } from "@/components/price-chart"
 import { ChartSkeleton } from "@/components/chart-skeleton"
 import { IntradayChart } from "@/components/intraday-chart"
-import { useAssetDetail, useAnnotations } from "@/lib/queries"
+import { useAssetWindow, useAnnotations } from "@/lib/queries"
 import { useIntraday, useQuote } from "@/lib/quote-stream"
+import type { AssetWindow } from "@/lib/asset-window"
 import type { Placement } from "@/lib/indicator-registry"
 import type { AssetType } from "@/lib/api"
 import type { ChartMode } from "./header"
 
 export function ChartSection({
   symbol,
-  period,
+  assetWindow,
   indicatorVisibility,
   chartType,
   currency,
@@ -17,7 +18,7 @@ export function ChartSection({
   mode,
 }: {
   symbol: string
-  period: string
+  assetWindow: AssetWindow
   indicatorVisibility: Record<string, Placement[]>
   chartType: "candle" | "line"
   currency?: string
@@ -30,7 +31,7 @@ export function ChartSection({
   return (
     <HistoricalChartSection
       symbol={symbol}
-      period={period}
+      assetWindow={assetWindow}
       indicatorVisibility={indicatorVisibility}
       chartType={chartType}
       currency={currency}
@@ -63,22 +64,20 @@ function LiveChartSection({ symbol }: { symbol: string }) {
 
 function HistoricalChartSection({
   symbol,
-  period,
+  assetWindow,
   indicatorVisibility,
   chartType,
   currency,
   assetType,
 }: {
   symbol: string
-  period: string
+  assetWindow: AssetWindow
   indicatorVisibility: Record<string, Placement[]>
   chartType: "candle" | "line"
   currency?: string
   assetType?: AssetType
 }) {
-  const { data: detail, isLoading: detailLoading, isFetching: detailFetching } = useAssetDetail(symbol, period)
-  const prices = detail?.prices
-  const indicators = detail?.indicators
+  const { prices, indicators, isLoading: detailLoading, isFetching: detailFetching } = useAssetWindow(symbol, assetWindow)
   const { data: annotations } = useAnnotations(symbol)
 
   if (detailLoading) {

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -8,7 +8,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { PeriodSelector } from "@/components/period-selector"
+import { WindowSelector } from "@/components/window-selector"
+import { resolveWindow, type AssetWindow } from "@/lib/asset-window"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { resolveIcon } from "@/lib/icon-utils"
 import { buildYahooFinanceUrl, buildYahooQuoteUrl, formatAssetPrice, formatAssetCompactPrice, formatChangePct } from "@/lib/format"
@@ -25,8 +26,8 @@ export function Header({
   name,
   currency,
   type,
-  period,
-  setPeriod,
+  assetWindow,
+  setAssetWindow,
   isTracked,
   assetId,
   mode,
@@ -36,8 +37,8 @@ export function Header({
   name?: string
   currency: string
   type: AssetType
-  period: string
-  setPeriod: (p: string) => void
+  assetWindow: AssetWindow
+  setAssetWindow: (w: AssetWindow) => void
   isTracked: boolean
   assetId?: number
   mode: ChartMode
@@ -149,12 +150,12 @@ export function Header({
         </Tabs>
         {mode === "historical" && (
           <>
-            <PeriodSelector value={period} onChange={setPeriod} />
+            <WindowSelector value={assetWindow} onChange={setAssetWindow} />
             {isTracked && (
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => refresh.mutate(period)}
+                onClick={() => refresh.mutate(resolveWindow(assetWindow).fetchPeriod)}
                 disabled={refresh.isPending}
               >
                 <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${refresh.isPending ? "animate-spin" : ""}`} />

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -5,13 +5,14 @@ import { ConnectedAnnotations } from "@/components/connected-annotations"
 import { TagInput } from "@/components/tag-input"
 import {
   useAssets,
-  useAssetDetail,
+  useAssetWindow,
   useAnnotations,
   useCreateAnnotation,
   useDeleteAnnotation,
   useThesis,
   useUpdateThesis,
 } from "@/lib/queries"
+import type { AssetWindow } from "@/lib/asset-window"
 import { useSettings } from "@/lib/settings"
 import { useQuote } from "@/lib/quote-stream"
 import { StatsPanel } from "@/components/stats-panel"
@@ -25,11 +26,16 @@ import { HoldingsSection } from "./holdings-section"
 export function AssetDetailPage() {
   const { symbol } = useParams<{ symbol: string }>()
   const { settings } = useSettings()
-  const [period, setPeriod] = useState<string>(settings.chart_default_period)
+  const [assetWindow, setAssetWindow] = useState<AssetWindow>({
+    kind: "period",
+    period: settings.chart_default_period,
+  })
   const [mode, setMode] = useState<ChartMode>("historical")
   const { data: assets } = useAssets()
   const asset = assets?.find((a) => a.symbol === symbol?.toUpperCase())
-  const { data: detail } = useAssetDetail(symbol ?? "", period, { enabled: !!symbol && mode !== "live" })
+  const { prices, indicators, windowLabel } = useAssetWindow(symbol ?? "", assetWindow, {
+    enabled: !!symbol && mode !== "live",
+  })
   const quote = useQuote(symbol?.toUpperCase() ?? "")
   const isTracked = !!asset
   const isEtf = asset?.type === "etf"
@@ -38,28 +44,28 @@ export function AssetDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} type={asset?.type ?? "stock"} period={period} setPeriod={setPeriod} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
+      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} type={asset?.type ?? "stock"} assetWindow={assetWindow} setAssetWindow={setAssetWindow} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
       <ChartSection
         symbol={symbol}
-        period={period}
+        assetWindow={assetWindow}
         indicatorVisibility={settings.indicator_visibility}
         chartType={settings.chart_type}
         currency={asset?.currency}
         assetType={asset?.type}
         mode={mode}
       />
-      {mode === "historical" && detail?.prices && detail.prices.length > 1 && (
+      {mode === "historical" && prices && prices.length > 1 && (
         <MovementStats
-          prices={detail.prices}
-          period={period}
+          prices={prices}
+          label={windowLabel}
           symbol={symbol}
           currency={asset?.currency ?? "USD"}
           assetType={asset?.type ?? "stock"}
         />
       )}
-      {mode === "historical" && detail?.indicators && detail.indicators.length > 0 && (
+      {mode === "historical" && indicators && indicators.length > 0 && (
         <StatsPanel
-          indicators={detail.indicators}
+          indicators={indicators}
           indicatorVisibility={settings.indicator_visibility}
           currency={asset?.currency}
           quote={quote}

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -17,6 +17,7 @@ import { useQuote } from "@/lib/quote-stream"
 import { StatsPanel } from "@/components/stats-panel"
 import { Header, type ChartMode } from "./header"
 import { ChartSection } from "./chart-section"
+import { MovementStats } from "./movement-stats"
 import { EarningsCountdown } from "@/components/earnings-countdown"
 import { HoldingsSection } from "./holdings-section"
 
@@ -47,6 +48,15 @@ export function AssetDetailPage() {
         assetType={asset?.type}
         mode={mode}
       />
+      {mode === "historical" && detail?.prices && detail.prices.length > 1 && (
+        <MovementStats
+          prices={detail.prices}
+          period={period}
+          symbol={symbol}
+          currency={asset?.currency ?? "USD"}
+          assetType={asset?.type ?? "stock"}
+        />
+      )}
       {mode === "historical" && detail?.indicators && detail.indicators.length > 0 && (
         <StatsPanel
           indicators={detail.indicators}

--- a/frontend/src/pages/asset-detail/movement-stats.tsx
+++ b/frontend/src/pages/asset-detail/movement-stats.tsx
@@ -1,16 +1,7 @@
 import { useMemo } from "react"
 import { computeMovementStats } from "@/lib/movement-stats"
-import { formatChangePct, changeColor, formatAssetPrice } from "@/lib/format"
+import { formatChangePct, changeColor, formatAssetPrice, formatDateLong } from "@/lib/format"
 import type { Price, AssetType } from "@/lib/types"
-
-/** Matches the date formatting used by the sibling EarningsCountdown panel. */
-function formatDate(dateStr: string): string {
-  return new Date(dateStr + "T00:00:00").toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  })
-}
 
 interface MovementStatsProps {
   prices: Price[]
@@ -45,7 +36,7 @@ export function MovementStats({ prices, label, symbol, currency, assetType }: Mo
           valueClass={stats.maxDrawdown ? "text-red-500" : "text-muted-foreground"}
           sub={
             stats.maxDrawdown
-              ? `${formatDate(stats.maxDrawdown.peakDate)} → ${formatDate(stats.maxDrawdown.troughDate)}`
+              ? `${formatDateLong(stats.maxDrawdown.peakDate)} → ${formatDateLong(stats.maxDrawdown.troughDate)}`
               : "no decline"
           }
         />
@@ -53,13 +44,13 @@ export function MovementStats({ prices, label, symbol, currency, assetType }: Mo
           label="Max daily gain"
           valueText={stats.maxDailyGain ? formatChangePct(stats.maxDailyGain.pct).text : "—"}
           valueClass={changeColor(stats.maxDailyGain?.pct)}
-          sub={stats.maxDailyGain ? formatDate(stats.maxDailyGain.date) : undefined}
+          sub={stats.maxDailyGain ? formatDateLong(stats.maxDailyGain.date) : undefined}
         />
         <StatTile
           label="Max daily loss"
           valueText={stats.maxDailyLoss ? formatChangePct(stats.maxDailyLoss.pct).text : "—"}
           valueClass={changeColor(stats.maxDailyLoss?.pct)}
-          sub={stats.maxDailyLoss ? formatDate(stats.maxDailyLoss.date) : undefined}
+          sub={stats.maxDailyLoss ? formatDateLong(stats.maxDailyLoss.date) : undefined}
         />
         <StatTile
           label="Up / down days"

--- a/frontend/src/pages/asset-detail/movement-stats.tsx
+++ b/frontend/src/pages/asset-detail/movement-stats.tsx
@@ -14,13 +14,13 @@ function formatDate(dateStr: string): string {
 
 interface MovementStatsProps {
   prices: Price[]
-  period: string
+  label: string
   symbol: string
   currency: string
   assetType: AssetType
 }
 
-export function MovementStats({ prices, period, symbol, currency, assetType }: MovementStatsProps) {
+export function MovementStats({ prices, label, symbol, currency, assetType }: MovementStatsProps) {
   const stats = useMemo(() => computeMovementStats(prices), [prices])
   if (!stats) return null
 
@@ -30,7 +30,7 @@ export function MovementStats({ prices, period, symbol, currency, assetType }: M
   return (
     <div className="rounded-lg border bg-card text-card-foreground px-4 py-3">
       <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-        Movement · {period}
+        Movement · {label}
       </h3>
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         <StatTile

--- a/frontend/src/pages/asset-detail/movement-stats.tsx
+++ b/frontend/src/pages/asset-detail/movement-stats.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from "react"
+import { computeMovementStats } from "@/lib/movement-stats"
+import { formatChangePct, changeColor, formatAssetPrice } from "@/lib/format"
+import type { Price, AssetType } from "@/lib/types"
+
+/** Matches the date formatting used by the sibling EarningsCountdown panel. */
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+interface MovementStatsProps {
+  prices: Price[]
+  period: string
+  symbol: string
+  currency: string
+  assetType: AssetType
+}
+
+export function MovementStats({ prices, period, symbol, currency, assetType }: MovementStatsProps) {
+  const stats = useMemo(() => computeMovementStats(prices), [prices])
+  if (!stats) return null
+
+  const hints = { type: assetType, symbol, currency }
+  const ret = formatChangePct(stats.periodReturnPct)
+
+  return (
+    <div className="rounded-lg border bg-card text-card-foreground px-4 py-3">
+      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+        Movement · {period}
+      </h3>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <StatTile
+          label="Period return"
+          valueText={ret.text}
+          valueClass={ret.className}
+          sub={`${formatAssetPrice(stats.startClose, hints)} → ${formatAssetPrice(stats.endClose, hints)}`}
+        />
+        <StatTile
+          label="Max drawdown"
+          valueText={stats.maxDrawdown ? formatChangePct(stats.maxDrawdown.pct).text : "0.00%"}
+          valueClass={stats.maxDrawdown ? "text-red-500" : "text-muted-foreground"}
+          sub={
+            stats.maxDrawdown
+              ? `${formatDate(stats.maxDrawdown.peakDate)} → ${formatDate(stats.maxDrawdown.troughDate)}`
+              : "no decline"
+          }
+        />
+        <StatTile
+          label="Max daily gain"
+          valueText={stats.maxDailyGain ? formatChangePct(stats.maxDailyGain.pct).text : "—"}
+          valueClass={changeColor(stats.maxDailyGain?.pct)}
+          sub={stats.maxDailyGain ? formatDate(stats.maxDailyGain.date) : undefined}
+        />
+        <StatTile
+          label="Max daily loss"
+          valueText={stats.maxDailyLoss ? formatChangePct(stats.maxDailyLoss.pct).text : "—"}
+          valueClass={changeColor(stats.maxDailyLoss?.pct)}
+          sub={stats.maxDailyLoss ? formatDate(stats.maxDailyLoss.date) : undefined}
+        />
+        <StatTile
+          label="Up / down days"
+          valueText={`${stats.upDays} / ${stats.downDays}`}
+          valueClass="text-foreground"
+          sub={`${stats.tradingDays} sessions`}
+        />
+      </div>
+    </div>
+  )
+}
+
+function StatTile({
+  label,
+  valueText,
+  valueClass,
+  sub,
+}: {
+  label: string
+  valueText: string | null
+  valueClass: string
+  sub?: string
+}) {
+  return (
+    <div className="rounded-md bg-muted/40 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</div>
+      <div className={`text-lg font-semibold tabular-nums ${valueClass}`}>{valueText ?? "—"}</div>
+      {sub && <div className="text-[11px] text-muted-foreground tabular-nums mt-0.5 truncate">{sub}</div>}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #515. Closes #517. Closes #518. Part of the Homescreen v2 epic (#512).

## What

Two tightly-coupled additions to the asset-detail page:

1. **Movement / risk stats panel** (#515) — period return, max drawdown (peak→trough with span), max single-day gain/loss (with dates), up/down day counts.
2. **Precise analysis window** (#517) — a window control replacing the fixed period buttons: week-granular presets (1W/2W/3W), the existing month/year presets, YTD, and a **"since <date>"** picker. The chart **and** the stats panel share this one window.

## How

- `computeMovementStats(prices)` — pure helper over the OHLCV array.
- `asset-window.ts` — a window is fully described by a start date. A custom "since" window resolves to the **smallest fixed period that covers it** (for the fetch, so the `useAssetDetail` cache stays shared with the chart) plus the exact start date (for slicing).
- `useAssetWindow` wraps `useAssetDetail` and slices `prices` + `indicators` to the window start. Standard presets slice nothing → behave exactly as before.
- `WindowSelector` — presets + a popover (1W/2W/3W, YTD, date picker).

**Frontend-only.** No backend change, no new endpoint, no migration. Verified `get_detail` trims to the display period and the covering-period start is always ≤ the window start, so in-window indicators are fully warmed.

## Trade-offs

- Windows are capped at the largest preset (5y); custom ranges over-fetch to the nearest preset (negligible). A true backend arbitrary-range endpoint was deliberately **not** built (deferred unless >5y is ever needed).
- "max single-day move" and "max drawdown" are kept as distinct metrics (single-day vs path-dependent), per #515.

## Testing

- `npx eslint` clean on all touched files
- `pnpm run build` (`tsc -b` + vite) passes in the frontend container

> ⚠️ **No frontend unit tests.** The repo has no JS test runner (no vitest/jest; CLAUDE.md gates the frontend on lint + build only). `computeMovementStats` and `resolveWindow`/`coveringPeriod` are pure and structured to be trivially testable once a runner exists — recommend a follow-up issue to add vitest. Until then this is **manually verified only**, not test-covered.

## Out of scope (deferred)

Trailing-stop *simulation* — this panel + window are the data foundation a later trailing-stop feature builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
