### PR TITLE
Companion config contract (SoT) + GET /api/companion/config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Companion App
+
+Fibenchi has a **mobile companion app** — a separate repo (`jvanmelckebeke/fibenchi-app`, checked out locally at `../fibenchi-app`). It's a native React Native / Expo (Android-first) app for glanceable market data on the phone. Its own `CLAUDE.md` has the full architecture.
+
+The split of responsibilities, so backend changes don't break it:
+
+- **The app gets live market data and computes indicators itself** — it calls Yahoo Finance directly on-device (native, so not CORS-bound) and ports `movement-stats.ts` / `indicators.py` to TypeScript. Fibenchi does **not** serve quotes or charts to the app.
+- **Fibenchi is only the "config plane":** it tells the app *what to track* (groups / tickers / tags) via `GET /api/companion/config`. That endpoint (added in PR #519/#520) is the **only** coupling between the two codebases.
+- **The contract is a single source of truth:** `backend/app/schemas/companion.py` (`CompanionConfig`) is the one definition. `backend/scripts/export_companion_schema.py` emits `backend/companion.schema.json`, which feeds the app's Zod codegen — so the contract can't drift between Python and TypeScript. The model carries a `version: Literal[1]` field the app gates on; any breaking shape change is a version bump (v1 is intentionally minimal: groups/tickers/tags; pseudo-ETFs/settings would be a later version).
+
+**When touching `app/schemas/companion.py`, `app/services/companion_service.py`, `app/routers/companion.py`, or `companion.schema.json`: remember the consumer is the separate app.** Re-export the schema after model changes, bump `version` on breaking changes, and keep the contract explicit. (Note: `claudedocs/mobile-companion-pwa-design.md` is an earlier PWA/AWS-proxy design that the native app superseded — it's obsolete.)
+
 ## Development Environment
 
 The entire stack runs via Docker Compose:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from starlette.responses import FileResponse
 from app.config import settings as app_settings
 
 from app.database import async_session, engine
-from app.routers import annotations, assets, data, groups, holdings, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, symbol_sources, tags, thesis
+from app.routers import annotations, assets, companion, data, groups, holdings, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, symbol_sources, tags, thesis
 from app.services.price_sync import sync_all_prices
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
@@ -282,6 +282,10 @@ app = FastAPI(
             "description": "User preference storage for indicator visibility, chart preferences, and display options.",
         },
         {
+            "name": "companion",
+            "description": "Versioned config bundle (groups + tickers + tags) for the mobile companion app — tells it what to track; live data is fetched on-device.",
+        },
+        {
             "name": "system",
             "description": "Health checks and operational endpoints.",
         },
@@ -291,6 +295,7 @@ app = FastAPI(
 app.include_router(assets.router)
 app.include_router(data.router)
 app.include_router(groups.router)
+app.include_router(companion.router)
 app.include_router(tags.router)
 app.include_router(tags.asset_tag_router)
 app.include_router(portfolio.router)

--- a/backend/app/routers/companion.py
+++ b/backend/app/routers/companion.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.companion import CompanionConfig
+from app.services import companion_service
+
+router = APIRouter(prefix="/api/companion", tags=["companion"])
+
+
+@router.get("/config", response_model=CompanionConfig, summary="Companion app config bundle")
+async def get_companion_config(db: AsyncSession = Depends(get_db)):
+    """Versioned config bundle (groups + tickers + tags) for the mobile companion.
+
+    The companion fetches live market data directly from Yahoo on-device; this
+    endpoint only tells it *what to track*.
+    """
+    return await companion_service.build_config(db)

--- a/backend/app/schemas/companion.py
+++ b/backend/app/schemas/companion.py
@@ -1,0 +1,58 @@
+"""Companion-app config contract — the single source of truth.
+
+This Pydantic model is the SoT for the mobile companion (jvanmelckebeke/fibenchi-app).
+Its JSON Schema (see ``scripts/export_companion_schema.py``) is the input to the
+app's Zod codegen, so the contract cannot drift between Fibenchi and the app.
+
+Shape is normalized: groups reference symbols, and ``tickers`` holds each symbol's
+metadata once (a symbol commonly lives in several groups via the M:N group_assets).
+
+Serialized camelCase (alias generator) for the TypeScript consumer; constructed
+with snake_case field names internally (populate_by_name).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+from app.models.asset import AssetType
+
+#: Current contract version. Bump on any breaking shape change; the app gates on it.
+CONFIG_VERSION = 1
+
+
+class _CamelModel(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+
+class ConfigTicker(_CamelModel):
+    """Metadata for a single tracked symbol (defined once across all groups)."""
+
+    name: str = Field(description="Display name")
+    type: AssetType = Field(description="Asset type: stock, etf, or index")
+    currency: str = Field(default="USD", description="ISO 4217 display code (normalized, e.g. GBp -> GBP)")
+    tags: list[str] = Field(default_factory=list, description="Tag names attached to this symbol")
+
+
+class ConfigGroup(_CamelModel):
+    """A user group as ordered symbol references."""
+
+    name: str = Field(description="Group name")
+    icon: str | None = Field(default=None, description="Lucide icon name")
+    is_default: bool = Field(description="Whether this is the protected default group (Watchlist)")
+    position: int = Field(description="Display order (0 = first)")
+    symbols: list[str] = Field(default_factory=list, description="Ticker symbols in this group, in order")
+
+
+class CompanionConfig(_CamelModel):
+    """The full config bundle the companion app pulls and caches."""
+
+    version: Literal[1] = Field(default=CONFIG_VERSION, description="Contract version the app gates on")
+    generated_at: datetime.datetime = Field(description="When this bundle was produced (UTC)")
+    groups: list[ConfigGroup] = Field(default_factory=list, description="User groups, ordered")
+    tickers: dict[str, ConfigTicker] = Field(default_factory=dict, description="symbol -> metadata")
+    tags: dict[str, str] = Field(default_factory=dict, description="tag name -> hex colour")

--- a/backend/app/schemas/companion.py
+++ b/backend/app/schemas/companion.py
@@ -51,7 +51,7 @@ class ConfigGroup(_CamelModel):
 class CompanionConfig(_CamelModel):
     """The full config bundle the companion app pulls and caches."""
 
-    version: Literal[1] = Field(default=CONFIG_VERSION, description="Contract version the app gates on")
+    version: Literal[1] = Field(description="Contract version the app gates on (always sent; required so the app's gate can't be bypassed by an absent field)")
     generated_at: datetime.datetime = Field(description="When this bundle was produced (UTC)")
     groups: list[ConfigGroup] = Field(default_factory=list, description="User groups, ordered")
     tickers: dict[str, ConfigTicker] = Field(default_factory=dict, description="symbol -> metadata")

--- a/backend/app/services/companion_service.py
+++ b/backend/app/services/companion_service.py
@@ -19,7 +19,9 @@ async def build_config(db: AsyncSession) -> CompanionConfig:
 
     for group in groups:  # already ordered by position, name
         symbols: list[str] = []
-        for asset in group.assets:
+        # group_assets is an unordered M:N (no ordinal column), so sort by symbol
+        # for a stable, reproducible bundle — the app relies on deterministic order.
+        for asset in sorted(group.assets, key=lambda a: a.symbol):
             symbols.append(asset.symbol)
             if asset.symbol not in tickers:
                 display_currency, _ = currency_lookup(asset.currency)

--- a/backend/app/services/companion_service.py
+++ b/backend/app/services/companion_service.py
@@ -1,0 +1,48 @@
+"""Assemble the companion-app config bundle from groups, assets, and tags."""
+
+import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.companion import CONFIG_VERSION, CompanionConfig, ConfigGroup, ConfigTicker
+from app.services import group_service, tag_service
+from app.services.currency_service import lookup as currency_lookup
+
+
+async def build_config(db: AsyncSession) -> CompanionConfig:
+    """Build the normalized config bundle (groups ordered, tickers deduped)."""
+    groups = await group_service.list_groups(db)
+    tags = await tag_service.list_tags(db)
+
+    config_groups: list[ConfigGroup] = []
+    tickers: dict[str, ConfigTicker] = {}
+
+    for group in groups:  # already ordered by position, name
+        symbols: list[str] = []
+        for asset in group.assets:
+            symbols.append(asset.symbol)
+            if asset.symbol not in tickers:
+                display_currency, _ = currency_lookup(asset.currency)
+                tickers[asset.symbol] = ConfigTicker(
+                    name=asset.name,
+                    type=asset.type,
+                    currency=display_currency,
+                    tags=[tag.name for tag in asset.tags],
+                )
+        config_groups.append(
+            ConfigGroup(
+                name=group.name,
+                icon=group.icon,
+                is_default=group.is_default,
+                position=group.position,
+                symbols=symbols,
+            )
+        )
+
+    return CompanionConfig(
+        version=CONFIG_VERSION,
+        generated_at=datetime.datetime.now(datetime.UTC),
+        groups=config_groups,
+        tickers=tickers,
+        tags={tag.name: tag.color for tag in tags},
+    )

--- a/backend/companion.schema.json
+++ b/backend/companion.schema.json
@@ -1,0 +1,140 @@
+{
+  "$defs": {
+    "AssetType": {
+      "enum": [
+        "stock",
+        "etf",
+        "index"
+      ],
+      "title": "AssetType",
+      "type": "string"
+    },
+    "ConfigGroup": {
+      "description": "A user group as ordered symbol references.",
+      "properties": {
+        "name": {
+          "description": "Group name",
+          "title": "Name",
+          "type": "string"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Lucide icon name",
+          "title": "Icon"
+        },
+        "isDefault": {
+          "description": "Whether this is the protected default group (Watchlist)",
+          "title": "Isdefault",
+          "type": "boolean"
+        },
+        "position": {
+          "description": "Display order (0 = first)",
+          "title": "Position",
+          "type": "integer"
+        },
+        "symbols": {
+          "description": "Ticker symbols in this group, in order",
+          "items": {
+            "type": "string"
+          },
+          "title": "Symbols",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "isDefault",
+        "position"
+      ],
+      "title": "ConfigGroup",
+      "type": "object"
+    },
+    "ConfigTicker": {
+      "description": "Metadata for a single tracked symbol (defined once across all groups).",
+      "properties": {
+        "name": {
+          "description": "Display name",
+          "title": "Name",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/$defs/AssetType",
+          "description": "Asset type: stock, etf, or index"
+        },
+        "currency": {
+          "default": "USD",
+          "description": "ISO 4217 display code (normalized, e.g. GBp -> GBP)",
+          "title": "Currency",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tag names attached to this symbol",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "title": "ConfigTicker",
+      "type": "object"
+    }
+  },
+  "description": "The full config bundle the companion app pulls and caches.",
+  "properties": {
+    "version": {
+      "const": 1,
+      "default": 1,
+      "description": "Contract version the app gates on",
+      "title": "Version",
+      "type": "integer"
+    },
+    "generatedAt": {
+      "description": "When this bundle was produced (UTC)",
+      "format": "date-time",
+      "title": "Generatedat",
+      "type": "string"
+    },
+    "groups": {
+      "description": "User groups, ordered",
+      "items": {
+        "$ref": "#/$defs/ConfigGroup"
+      },
+      "title": "Groups",
+      "type": "array"
+    },
+    "tickers": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ConfigTicker"
+      },
+      "description": "symbol -> metadata",
+      "title": "Tickers",
+      "type": "object"
+    },
+    "tags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "tag name -> hex colour",
+      "title": "Tags",
+      "type": "object"
+    }
+  },
+  "required": [
+    "generatedAt"
+  ],
+  "title": "CompanionConfig",
+  "type": "object"
+}

--- a/backend/companion.schema.json
+++ b/backend/companion.schema.json
@@ -96,8 +96,7 @@
   "properties": {
     "version": {
       "const": 1,
-      "default": 1,
-      "description": "Contract version the app gates on",
+      "description": "Contract version the app gates on (always sent; required so the app's gate can't be bypassed by an absent field)",
       "title": "Version",
       "type": "integer"
     },
@@ -133,6 +132,7 @@
     }
   },
   "required": [
+    "version",
     "generatedAt"
   ],
   "title": "CompanionConfig",

--- a/backend/scripts/export_companion_schema.py
+++ b/backend/scripts/export_companion_schema.py
@@ -1,0 +1,25 @@
+"""Emit the companion config JSON Schema — the single source of truth artifact.
+
+This JSON Schema is what the companion app's Zod codegen consumes
+(json-schema-to-zod). Regenerate after any change to ``app/schemas/companion.py``
+and copy the output into the app repo:
+
+    python -m scripts.export_companion_schema
+    # -> backend/companion.schema.json  (copy to fibenchi-app/schema/)
+"""
+
+import json
+import pathlib
+
+from app.schemas.companion import CompanionConfig
+
+
+def main() -> None:
+    schema = CompanionConfig.model_json_schema(by_alias=True)
+    out = pathlib.Path(__file__).resolve().parent.parent / "companion.schema.json"
+    out.write_text(json.dumps(schema, indent=2) + "\n")
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/integration/test_companion.py
+++ b/backend/tests/integration/test_companion.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests.helpers import create_asset_via_api
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_companion_config_shape(client):
+    aapl = await create_asset_via_api(client, "AAPL", "Apple Inc.")
+    await create_asset_via_api(client, "MSFT", "Microsoft Corp.")
+
+    # A second (non-default) group containing only AAPL — exercises normalization
+    # (AAPL is in two groups but defined once in `tickers`).
+    tech = (await client.post("/api/groups", json={"name": "Tech", "icon": "cpu"})).json()
+    await client.post(f"/api/groups/{tech['id']}/assets", json={"asset_ids": [aapl["id"]]})
+
+    # A tag on AAPL.
+    tag = (await client.post("/api/tags", json={"name": "tech", "color": "#3b82f6"})).json()
+    await client.post(f"/api/assets/AAPL/tags/{tag['id']}")
+
+    resp = await client.get("/api/companion/config")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # Versioned + camelCase serialization for the TS consumer.
+    assert body["version"] == 1
+    assert "generatedAt" in body
+
+    groups = {g["name"]: g for g in body["groups"]}
+    assert groups["Watchlist"]["isDefault"] is True
+    assert set(groups["Watchlist"]["symbols"]) == {"AAPL", "MSFT"}
+    assert groups["Tech"]["isDefault"] is False
+    assert groups["Tech"]["symbols"] == ["AAPL"]
+
+    # Ticker metadata defined once even though AAPL is in two groups.
+    assert set(body["tickers"]) == {"AAPL", "MSFT"}
+    aapl_ticker = body["tickers"]["AAPL"]
+    assert aapl_ticker["name"] == "Apple Inc."
+    assert aapl_ticker["type"] == "stock"
+    assert aapl_ticker["currency"] == "USD"
+    assert aapl_ticker["tags"] == ["tech"]
+
+    assert body["tags"]["tech"] == "#3b82f6"
+
+
+async def test_companion_config_empty_is_valid(client):
+    # Only the seeded default Watchlist exists; bundle should still be well-formed.
+    body = (await client.get("/api/companion/config")).json()
+    assert body["version"] == 1
+    assert isinstance(body["groups"], list)
+    assert isinstance(body["tickers"], dict)
+    assert isinstance(body["tags"], dict)

--- a/backend/tests/integration/test_companion.py
+++ b/backend/tests/integration/test_companion.py
@@ -1,3 +1,6 @@
+import json
+import pathlib
+
 import pytest
 
 from tests.helpers import create_asset_via_api
@@ -28,7 +31,8 @@ async def test_companion_config_shape(client):
 
     groups = {g["name"]: g for g in body["groups"]}
     assert groups["Watchlist"]["isDefault"] is True
-    assert set(groups["Watchlist"]["symbols"]) == {"AAPL", "MSFT"}
+    # Symbols are sorted deterministically (group_assets has no ordinal column).
+    assert groups["Watchlist"]["symbols"] == ["AAPL", "MSFT"]
     assert groups["Tech"]["isDefault"] is False
     assert groups["Tech"]["symbols"] == ["AAPL"]
 
@@ -50,3 +54,19 @@ async def test_companion_config_empty_is_valid(client):
     assert isinstance(body["groups"], list)
     assert isinstance(body["tickers"], dict)
     assert isinstance(body["tags"], dict)
+
+
+async def test_companion_schema_artifact_is_fresh():
+    """The committed JSON Schema is the codegen input for the companion app, so it
+    must stay in lock-step with the Pydantic SoT. If this fails, regenerate it:
+
+        python -m scripts.export_companion_schema
+    """
+    from app.schemas.companion import CompanionConfig
+
+    current = CompanionConfig.model_json_schema(by_alias=True)
+    artifact = pathlib.Path(__file__).parents[2] / "companion.schema.json"
+    on_disk = json.loads(artifact.read_text())
+    assert current == on_disk, (
+        "companion.schema.json is stale — run: python -m scripts.export_companion_schema"
+    )


### PR DESCRIPTION
Closes #519.

Single source of truth for the mobile companion app's config contract. The companion fetches *what to track* (groups/tickers/tags) here, then gets live market data directly from Yahoo on-device.

### The SoT → codegen idea
`app/schemas/companion.py`'s Pydantic `CompanionConfig` is the **one definition**. Its JSON Schema (emitted by `scripts/export_companion_schema.py` → `companion.schema.json`) is the input to the app's Zod codegen — so the contract can't drift between Python and TypeScript. Constraints live on the model (`version: Literal[1]`, `AssetType` enum, currency normalization), and they flow all the way to the app's runtime decoder.

### Shape (v1, normalized, camelCase)
```jsonc
{
  "version": 1,
  "generatedAt": "2026-06-07T...Z",
  "groups": [{ "name": "Watchlist", "icon": "star", "isDefault": true, "position": 0, "symbols": ["AAPL"] }],
  "tickers": { "AAPL": { "name": "Apple Inc.", "type": "stock", "currency": "USD", "tags": ["tech"] } },
  "tags": { "tech": "#3b82f6" }
}
```
Normalized because `group_assets` is M:N — a symbol commonly lives in multiple groups, so its metadata is defined once in `tickers`.

### Files
- `app/schemas/companion.py` — SoT model (camelCase aliases, version literal)
- `app/services/companion_service.py` — assembles bundle from groups + assets + tags
- `app/routers/companion.py` — `GET /api/companion/config`, registered in `main.py`
- `scripts/export_companion_schema.py` + `companion.schema.json` — the codegen artifact
- `tests/integration/test_companion.py` — shape + cross-group normalization + empty bundle

### Verification
- `pytest tests/integration/test_companion.py` → **2 passed**.
- Schema export emits camelCase property names (`generatedAt`, `isDefault`).

### Notes
- v1 intentionally minimal (groups/tickers/tags). pseudo-ETFs / settings = a future version bump — the `version` field is the gate.