### PR TITLE
feat(thesis): richer By-thesis view + symbol-addressed indicators

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from starlette.responses import FileResponse
 from app.config import settings as app_settings
 
 from app.database import async_session, engine
-from app.routers import annotations, assets, companion, data, groups, holdings, note, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, symbol_sources, tags, thesis
+from app.routers import annotations, assets, companion, data, groups, holdings, indicators, note, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, symbol_sources, tags, thesis
 from app.services.price_sync import sync_all_prices
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
@@ -305,6 +305,7 @@ app.include_router(tags.asset_tag_router)
 app.include_router(portfolio.router)
 app.include_router(prices.router)
 app.include_router(holdings.router)
+app.include_router(indicators.router)
 app.include_router(note.router)
 app.include_router(thesis.router)
 app.include_router(annotations.router)

--- a/backend/app/repositories/asset_repo.py
+++ b/backend/app/repositories/asset_repo.py
@@ -57,6 +57,20 @@ class AssetRepository:
         )
         return list(result.all())
 
+    async def list_id_symbol_pairs_by_symbols(self, symbols: list[str]) -> list[tuple[int, str]]:
+        """Return (id, symbol) pairs for the given symbols (tracked assets only).
+
+        Unknown symbols are silently omitted. Symbols are matched case-insensitively
+        (stored upper-cased, mirroring ``find_by_symbol``).
+        """
+        if not symbols:
+            return []
+        upper = [s.upper() for s in symbols]
+        result = await self.db.execute(
+            select(Asset.id, Asset.symbol).where(Asset.symbol.in_(upper))
+        )
+        return list(result.all())
+
     async def list_all(self) -> list[Asset]:
         result = await self.db.execute(select(Asset).order_by(Asset.symbol))
         return list(result.scalars().all())

--- a/backend/app/routers/indicators.py
+++ b/backend/app/routers/indicators.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.price import IndicatorSnapshotBase
+from app.services.compute.group import compute_indicators_for_symbols
+
+router = APIRouter(prefix="/api/indicators", tags=["indicators"])
+
+
+@router.get(
+    "",
+    response_model=dict[str, IndicatorSnapshotBase],
+    summary="Batch indicators for arbitrary tracked symbols",
+)
+async def batch_indicators(
+    symbols: list[str] = Query(default=[], description="Tracked ticker symbols"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Latest indicator snapshot per symbol, keyed by symbol.
+
+    DB-backed and addressable by symbol set (not by group) — lets the By-thesis
+    view fill indicator columns for members that live in other groups. Untracked
+    symbols are omitted from the response.
+    """
+    return await compute_indicators_for_symbols(db, symbols)

--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -59,18 +59,15 @@ async def get_batch_sparklines(
     return out
 
 
-async def compute_and_cache_indicators(
-    db: AsyncSession, group_id: int | None = None,
+async def _compute_snapshots_for_rows(
+    db: AsyncSession, asset_rows, scope,
 ) -> dict[str, dict]:
-    """Compute indicator snapshots for assets in a group, with caching.
+    """Compute DB-backed indicator snapshots for (id, symbol) rows, with caching.
 
-    If group_id is None, uses the default group.
+    ``scope`` only disambiguates the cache key; the snapshot *values* depend purely
+    on (symbols, latest price date), so identical symbol sets across scopes compute
+    the same result.
     """
-    if group_id is not None:
-        asset_rows = await AssetRepository(db).list_in_group_id_symbol_pairs(group_id)
-    else:
-        asset_rows = await _get_default_group_pairs(db)
-
     if not asset_rows:
         return {}
 
@@ -79,9 +76,9 @@ async def compute_and_cache_indicators(
 
     price_repo = PriceRepository(db)
 
-    # Build cache key: symbols + latest price date + group context
+    # Build cache key: symbols + latest price date + scope
     latest_date = await price_repo.get_latest_date(asset_ids)
-    cache_key = (frozenset(id_to_symbol.values()), latest_date, group_id)
+    cache_key = (frozenset(id_to_symbol.values()), latest_date, scope)
 
     cached = _indicator_cache.get_value(cache_key)
     if cached is not None:
@@ -116,3 +113,33 @@ async def compute_and_cache_indicators(
     _indicator_cache.set_value(cache_key, out)
 
     return out
+
+
+async def compute_and_cache_indicators(
+    db: AsyncSession, group_id: int | None = None,
+) -> dict[str, dict]:
+    """Compute indicator snapshots for assets in a group, with caching.
+
+    If group_id is None, uses the default group.
+    """
+    if group_id is not None:
+        asset_rows = await AssetRepository(db).list_in_group_id_symbol_pairs(group_id)
+    else:
+        asset_rows = await _get_default_group_pairs(db)
+
+    return await _compute_snapshots_for_rows(db, asset_rows, group_id)
+
+
+async def compute_indicators_for_symbols(
+    db: AsyncSession, symbols: list[str],
+) -> dict[str, dict]:
+    """Compute indicator snapshots for specific tracked symbols (DB-backed).
+
+    Mirrors the per-group snapshot shape but is addressable by symbol set rather
+    than by group — used to fill indicator columns for thesis members that live in
+    other groups. Unknown/untracked symbols are omitted (no DB price history).
+    """
+    if not symbols:
+        return {}
+    asset_rows = await AssetRepository(db).list_id_symbol_pairs_by_symbols(symbols)
+    return await _compute_snapshots_for_rows(db, asset_rows, None)

--- a/backend/tests/services/test_compute_group.py
+++ b/backend/tests/services/test_compute_group.py
@@ -8,6 +8,7 @@ import pytest
 from app.services.compute.group import (
     _indicator_cache,
     compute_and_cache_indicators,
+    compute_indicators_for_symbols,
     get_batch_sparklines,
 )
 
@@ -185,3 +186,49 @@ class TestComputeAndCacheIndicators:
         assert mock_compute_ind.call_count == call_count_1  # No additional calls
 
         _indicator_cache._data.clear()
+
+
+class TestComputeIndicatorsForSymbols:
+    @patch("app.services.compute.group.merge_fundamentals_from_cache")
+    @patch("app.services.compute.group.build_indicator_snapshot")
+    @patch("app.services.compute.group.compute_indicators")
+    @patch("app.services.compute.group.prices_to_df")
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_computes_snapshots_for_symbols(
+        self, mock_asset_repo_cls, mock_price_repo_cls, mock_prices_to_df,
+        mock_compute_ind, mock_build_snap, mock_merge_fund, db,
+    ):
+        _indicator_cache._data.clear()
+
+        # Only the tracked symbol resolves to a row; "GHOST" is dropped by the repo.
+        rows = [_make_asset_row(1, "AAPL")]
+        mock_asset_repo_cls.return_value.list_id_symbol_pairs_by_symbols = AsyncMock(return_value=rows)
+
+        today = date.today()
+        prices = [_make_price(1, today - timedelta(days=i), 150.0 + i) for i in range(30)]
+        mock_price_repo_cls.return_value.list_by_assets_since = AsyncMock(return_value=prices)
+        mock_price_repo_cls.return_value.get_latest_date = AsyncMock(return_value=today)
+
+        mock_prices_to_df.return_value = MagicMock()
+        mock_compute_ind.return_value = MagicMock()
+        mock_build_snap.return_value = {"values": {"rsi": 55.0}}
+        mock_merge_fund.side_effect = _mock_merge_fundamentals({})
+
+        result = await compute_indicators_for_symbols(db, ["AAPL", "GHOST"])
+
+        assert set(result) == {"AAPL"}
+        assert result["AAPL"]["values"]["rsi"] == 55.0
+        mock_asset_repo_cls.return_value.list_id_symbol_pairs_by_symbols.assert_awaited_once_with(
+            ["AAPL", "GHOST"]
+        )
+
+        _indicator_cache._data.clear()
+
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_empty_symbols_short_circuits(self, mock_asset_repo_cls, db):
+        result = await compute_indicators_for_symbols(db, [])
+
+        assert result == {}
+        # No DB work for an empty symbol set.
+        mock_asset_repo_cls.return_value.list_id_symbol_pairs_by_symbols.assert_not_called()

--- a/frontend/src/components/edit-thesis-dialog.tsx
+++ b/frontend/src/components/edit-thesis-dialog.tsx
@@ -19,9 +19,8 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useUpdateThesis, useDeleteThesis } from "@/lib/queries"
+import { THESIS_PRESET_COLORS } from "@/lib/thesis-colors"
 import type { Thesis, ThesisStatus } from "@/lib/api"
-
-const PRESET_COLORS = ["#3b82f6", "#ef4444", "#22c55e", "#f59e0b", "#8b5cf6", "#ec4899", "#06b6d4", "#f97316"]
 
 const STATUSES: { value: ThesisStatus; label: string }[] = [
   { value: "watching", label: "Watching" },
@@ -97,8 +96,8 @@ function EditThesisForm({ thesis, onClose }: { thesis: Thesis; onClose: () => vo
         </div>
         <div className="space-y-2">
           <Label>Colour</Label>
-          <div className="flex gap-1.5">
-            {PRESET_COLORS.map((c) => (
+          <div className="flex flex-wrap gap-1.5">
+            {THESIS_PRESET_COLORS.map((c) => (
               <button
                 key={c}
                 type="button"

--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useState } from "react"
-import { ChevronsUpDown, ChevronsDownUp } from "lucide-react"
+import { useCallback, useMemo, useState, type ReactNode } from "react"
+import { ChevronsUpDown, ChevronsDownUp, ChevronRight, ChevronDown } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
 import type { GroupSortBy, SortDir } from "@/lib/settings"
@@ -26,10 +26,25 @@ interface GroupTableProps {
   sortBy?: GroupSortBy
   sortDir?: SortDir
   onSort?: (key: GroupSortBy) => void
+  /**
+   * Secondary rows appended below the main rows behind a collapsible in-table
+   * footer toggle (e.g. thesis members that live in other groups). Rendered with
+   * the same columns — no second header.
+   */
+  moreAssets?: Asset[]
+  /** Label for the "more" footer toggle (e.g. "+2 more in hotlist, Watchlist"). */
+  moreLabel?: ReactNode
+  /** Controlled open state for the "more" footer. Falls back to internal state. */
+  moreOpen?: boolean
+  /** Controlled toggle handler for the "more" footer. */
+  onToggleMore?: () => void
 }
 
-export function GroupTable({ groupId, assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort }: GroupTableProps) {
+export function GroupTable({ groupId, assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort, moreAssets, moreLabel, moreOpen, onToggleMore }: GroupTableProps) {
   const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(new Set())
+  const [internalMoreOpen, setInternalMoreOpen] = useState(false)
+  const moreOpenState = moreOpen ?? internalMoreOpen
+  const toggleMore = onToggleMore ?? (() => setInternalMoreOpen((o) => !o))
   const { settings, updateSettings } = useSettings()
   const columnSettings = settings.group_table_columns
   const responsiveHidden = useResponsiveHidden()
@@ -65,6 +80,26 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
   const visibleBaseCount =
     BASE_COLUMN_DEFS.filter((c) => isColumnVisible(columnSettings, c.key)).length
   const totalColSpan = 1 + 1 + visibleBaseCount + visibleIndicatorFields.length
+
+  const hasMore = !!moreAssets && moreAssets.length > 0
+
+  const renderRow = (asset: Asset, keyPrefix = "") => (
+    <TableRow
+      key={`${keyPrefix}${asset.id}`}
+      groupId={groupId}
+      asset={asset}
+      quote={quotes[asset.symbol]}
+      indicator={indicators?.[asset.symbol]}
+      expanded={expandedSymbols.has(asset.symbol)}
+      onToggle={toggleExpand}
+      onDelete={onDelete}
+      onHover={onHover ?? noop}
+      compactMode={compactMode}
+      columnSettings={columnSettings}
+      visibleIndicatorFields={visibleIndicatorFields}
+      totalColSpan={totalColSpan}
+    />
+  )
 
   return (
     <div className="rounded-md border border-border overflow-x-auto">
@@ -154,23 +189,25 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
           </tr>
         </thead>
         <tbody>
-          {assets.map((asset) => (
-            <TableRow
-              key={asset.id}
-              groupId={groupId}
-              asset={asset}
-              quote={quotes[asset.symbol]}
-              indicator={indicators?.[asset.symbol]}
-              expanded={expandedSymbols.has(asset.symbol)}
-              onToggle={toggleExpand}
-              onDelete={onDelete}
-              onHover={onHover ?? noop}
-              compactMode={compactMode}
-              columnSettings={columnSettings}
-              visibleIndicatorFields={visibleIndicatorFields}
-              totalColSpan={totalColSpan}
-            />
-          ))}
+          {assets.map((asset) => renderRow(asset))}
+          {hasMore && (
+            <>
+              <tr className="border-b border-border bg-muted/20">
+                <td colSpan={totalColSpan} className="px-2 py-1.5">
+                  <button
+                    type="button"
+                    onClick={toggleMore}
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    aria-expanded={moreOpenState}
+                  >
+                    {moreOpenState ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                    {moreLabel}
+                  </button>
+                </td>
+              </tr>
+              {moreOpenState && moreAssets!.map((asset) => renderRow(asset, "more-"))}
+            </>
+          )}
         </tbody>
       </table>
     </div>

--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -193,14 +193,14 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
           {hasMore && (
             <>
               <tr className="border-b border-border bg-muted/20">
-                <td colSpan={totalColSpan} className="px-2 py-1.5">
+                <td colSpan={totalColSpan} className="p-0">
                   <button
                     type="button"
                     onClick={toggleMore}
-                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    className="flex w-full items-center gap-1 px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-muted/30 hover:text-foreground transition-colors"
                     aria-expanded={moreOpenState}
                   >
-                    {moreOpenState ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                    {moreOpenState ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
                     {moreLabel}
                   </button>
                 </td>

--- a/frontend/src/components/new-thesis-dialog.tsx
+++ b/frontend/src/components/new-thesis-dialog.tsx
@@ -18,9 +18,8 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useCreateThesis } from "@/lib/queries"
+import { THESIS_PRESET_COLORS, DEFAULT_THESIS_COLOR } from "@/lib/thesis-colors"
 import type { Thesis, ThesisStatus } from "@/lib/api"
-
-const PRESET_COLORS = ["#3b82f6", "#ef4444", "#22c55e", "#f59e0b", "#8b5cf6", "#ec4899", "#06b6d4", "#f97316"]
 
 const STATUSES: { value: ThesisStatus; label: string }[] = [
   { value: "watching", label: "Watching" },
@@ -71,7 +70,7 @@ function NewThesisForm({
 }) {
   const createThesis = useCreateThesis()
   const [name, setName] = useState(initialName ?? "")
-  const [color, setColor] = useState(PRESET_COLORS[0])
+  const [color, setColor] = useState(DEFAULT_THESIS_COLOR)
   const [status, setStatus] = useState<ThesisStatus>("watching")
   const [openedAt, setOpenedAt] = useState(todayISO())
   const [description, setDescription] = useState("")
@@ -114,8 +113,8 @@ function NewThesisForm({
         </div>
         <div className="space-y-2">
           <Label>Colour</Label>
-          <div className="flex gap-1.5">
-            {PRESET_COLORS.map((c) => (
+          <div className="flex flex-wrap gap-1.5">
+            {THESIS_PRESET_COLORS.map((c) => (
               <button
                 key={c}
                 type="button"

--- a/frontend/src/components/thesis-grouped-table.tsx
+++ b/frontend/src/components/thesis-grouped-table.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react"
-import { ChevronDown, ChevronRight, Pencil, Plus } from "lucide-react"
+import { Pencil, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Asset, Group, IndicatorSummary, Quote, Thesis, ThesisStatus } from "@/lib/api"
 import type { GroupSortBy, SortDir } from "@/lib/settings"
 import { formatChangePct, formatDateLong } from "@/lib/format"
+import { useIndicators } from "@/lib/queries"
 import { GroupTable } from "@/components/group-table"
 import { NewThesisDialog } from "@/components/new-thesis-dialog"
 import { EditThesisDialog } from "@/components/edit-thesis-dialog"
@@ -42,9 +43,10 @@ export function ThesisGroupedTable({
   groupId, assets, theses, allGroups, quotes, indicators,
   onDelete, compactMode, onHover, sortBy, sortDir, onSort,
 }: ThesisGroupedTableProps) {
-  const [revealed, setRevealed] = useState<Set<number>>(new Set())
   const [newThesisOpen, setNewThesisOpen] = useState(false)
   const [editThesis, setEditThesis] = useState<Thesis | null>(null)
+  // Which theses have their "+N more" fold expanded (drives the lazy indicator fetch).
+  const [revealed, setRevealed] = useState<Set<number>>(new Set())
 
   const toggleReveal = (id: number) =>
     setRevealed((prev) => {
@@ -53,6 +55,19 @@ export function ThesisGroupedTable({
       else next.add(id)
       return next
     })
+
+  // Full Asset objects keyed by id, sourced from every group. Lets the "elsewhere"
+  // fold render the same rich GroupTable rows (price/change/indicators) as the
+  // in-group section — thesis members only carry id/symbol/name.
+  const assetsById = useMemo(() => {
+    const map = new Map<number, Asset>()
+    for (const g of allGroups) {
+      for (const a of g.assets) {
+        if (!map.has(a.id)) map.set(a.id, a)
+      }
+    }
+    return map
+  }, [allGroups])
 
   // Which other groups (by name) contain each asset — for the "+N more in [group]" fold.
   const otherGroupNamesById = useMemo(() => {
@@ -93,8 +108,32 @@ export function ThesisGroupedTable({
     return { sections, ungrouped }
   }, [theses, assets, currentGroupIds])
 
+  // Symbols of elsewhere-members for theses whose fold is open. Fetched lazily so
+  // expanding a fold (not just rendering the view) is what triggers the request.
+  const expandedElsewhereSymbols = useMemo(() => {
+    const syms = new Set<string>()
+    for (const { thesis, elsewhere } of sections) {
+      if (!revealed.has(thesis.id)) continue
+      for (const m of elsewhere) {
+        const a = assetsById.get(m.id)
+        if (a) syms.add(a.symbol)
+      }
+    }
+    return [...syms]
+  }, [sections, revealed, assetsById])
+
+  const { data: elsewhereIndicators } = useIndicators(expandedElsewhereSymbols)
+
+  // The per-group batch (`indicators`) only covers in-group assets; merge in the
+  // symbol-addressed snapshots so elsewhere rows get RSI/MACD/ATR/… too. Overlapping
+  // symbols carry identical values, so precedence is irrelevant.
+  const mergedIndicators = useMemo(
+    () => ({ ...(elsewhereIndicators ?? {}), ...(indicators ?? {}) }),
+    [elsewhereIndicators, indicators],
+  )
+
   const passthrough = {
-    groupId, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort,
+    groupId, quotes, indicators: mergedIndicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort,
   }
 
   return (
@@ -112,11 +151,19 @@ export function ThesisGroupedTable({
       </div>
 
       {sections.map(({ thesis, inGroup, elsewhere }) => {
-        const isOpen = revealed.has(thesis.id)
         const elsewhereGroups = [
           ...new Set(elsewhere.flatMap((m) => otherGroupNamesById.get(m.id) ?? [])),
         ]
         const agg = formatChangePct(thesis.aggregate_pct)
+        const elsewhereAssets = elsewhere
+          .map((m) => assetsById.get(m.id))
+          .filter((a): a is Asset => a != null)
+        const moreLabel = (
+          <>
+            +{elsewhereAssets.length} more
+            {elsewhereGroups.length > 0 && <> in {elsewhereGroups.join(", ")}</>}
+          </>
+        )
         return (
           <section key={thesis.id} className="space-y-2">
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -135,9 +182,6 @@ export function ThesisGroupedTable({
                   {agg.text}
                 </span>
               )}
-              <span className="text-xs text-muted-foreground">
-                {inGroup.length} here
-              </span>
               <button
                 type="button"
                 onClick={() => setEditThesis(thesis)}
@@ -149,37 +193,14 @@ export function ThesisGroupedTable({
               </button>
             </div>
 
-            <GroupTable assets={inGroup} {...passthrough} />
-
-            {elsewhere.length > 0 && (
-              <div className="text-xs">
-                <button
-                  type="button"
-                  onClick={() => toggleReveal(thesis.id)}
-                  className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  {isOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-                  +{elsewhere.length} more
-                  {elsewhereGroups.length > 0 && <> in {elsewhereGroups.join(", ")}</>}
-                </button>
-                {isOpen && (
-                  <ul className="mt-1 ml-4 space-y-0.5">
-                    {elsewhere.map((m) => {
-                      const where = otherGroupNamesById.get(m.id) ?? []
-                      return (
-                        <li key={m.id} className="text-muted-foreground">
-                          <span className="font-medium text-foreground">{m.symbol}</span>
-                          {" — "}{m.name}
-                          {where.length > 0 && (
-                            <span className="text-muted-foreground"> · in {where.join(", ")}</span>
-                          )}
-                        </li>
-                      )
-                    })}
-                  </ul>
-                )}
-              </div>
-            )}
+            <GroupTable
+              assets={inGroup}
+              moreAssets={elsewhereAssets}
+              moreLabel={moreLabel}
+              moreOpen={revealed.has(thesis.id)}
+              onToggleMore={() => toggleReveal(thesis.id)}
+              {...passthrough}
+            />
           </section>
         )
       })}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -137,6 +137,14 @@ export const api = {
     indicators: (id: number) =>
       request<Record<string, IndicatorSummary>>(`/groups/${id}/indicators`),
   },
+  indicators: {
+    /** Batch indicator snapshots for arbitrary tracked symbols, keyed by symbol. */
+    batch: (symbols: string[]) => {
+      const params = new URLSearchParams()
+      for (const s of symbols) params.append("symbols", s)
+      return request<Record<string, IndicatorSummary>>(`/indicators?${params.toString()}`)
+    },
+  },
   note: {
     get: (symbol: string) => request<Note>(`/assets/${symbol}/note`),
     update: (symbol: string, content: string) =>

--- a/frontend/src/lib/queries/groups.ts
+++ b/frontend/src/lib/queries/groups.ts
@@ -101,6 +101,18 @@ export function useGroupIndicators(id: number) {
   })
 }
 
+/** Indicator snapshots for an arbitrary set of tracked symbols, keyed by symbol.
+ * Used to fill indicator columns for thesis members living in other groups —
+ * the per-group batch only covers the current group. */
+export function useIndicators(symbols: string[], enabled = true) {
+  return useQuery({
+    queryKey: keys.indicators(symbols),
+    queryFn: () => api.indicators.batch(symbols),
+    enabled: enabled && symbols.length > 0,
+    staleTime: STALE_5MIN,
+  })
+}
+
 /** Prefetch the metadata, sparklines and indicators for every group except
  * ``activeGroupId`` so switching groups feels instant. The active group's
  * data is already being fetched by the page that called this hook. */

--- a/frontend/src/lib/queries/index.ts
+++ b/frontend/src/lib/queries/index.ts
@@ -4,7 +4,7 @@ export { useAssets, useCreateAsset, useUpdateAsset, useLocalSearch, useYahooSear
 export { useAssetDetail, useAssetWindow, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
 export { useEarnings } from "./earnings"
 export { useTags, useCreateTag, useAttachTag, useDetachTag } from "./tags"
-export { useGroups, useCreateGroup, useUpdateGroup, useDeleteGroup, useReorderGroups, useAddAssetsToGroup, useRemoveAssetFromGroup, useGroup, useGroupSparklines, useGroupIndicators, usePrefetchOtherGroups } from "./groups"
+export { useGroups, useCreateGroup, useUpdateGroup, useDeleteGroup, useReorderGroups, useAddAssetsToGroup, useRemoveAssetFromGroup, useGroup, useGroupSparklines, useGroupIndicators, useIndicators, usePrefetchOtherGroups } from "./groups"
 export { useNote, useUpdateNote, useAnnotations, useCreateAnnotation, useDeleteAnnotation } from "./notes"
 export { useTheses, useThesis, useCreateThesis, useUpdateThesis, useDeleteThesis, useAddThesisAssets, useRemoveThesisAsset, useAddAssetToThesis, useRemoveAssetFromThesis } from "./theses"
 export { usePseudoEtfs, usePseudoEtf, useCreatePseudoEtf, useUpdatePseudoEtf, useDeletePseudoEtf, useAddPseudoEtfConstituents, useRemovePseudoEtfConstituent, usePseudoEtfPerformance, usePseudoEtfConstituentsIndicators, usePseudoEtfNote, useUpdatePseudoEtfNote, usePseudoEtfAnnotations, useCreatePseudoEtfAnnotation, useDeletePseudoEtfAnnotation } from "./pseudo-etfs"

--- a/frontend/src/lib/queries/shared.ts
+++ b/frontend/src/lib/queries/shared.ts
@@ -31,6 +31,8 @@ export const keys = {
   group: (id: number) => ["groups", id] as const,
   groupSparklines: (id: number, period?: string) => ["group-sparklines", id, period] as const,
   groupIndicators: (id: number) => ["group-indicators", id] as const,
+  // Sorted+joined so the key is order-independent (same symbol set → one cache entry).
+  indicators: (symbols: readonly string[]) => ["indicators", [...symbols].sort().join(",")] as const,
   note: (symbol: string) => ["note", symbol] as const,
   theses: ["theses"] as const,
   thesis: (id: number) => ["theses", id] as const,

--- a/frontend/src/lib/thesis-colors.ts
+++ b/frontend/src/lib/thesis-colors.ts
@@ -1,0 +1,28 @@
+// Preset colours for thesis dots, shared by the new/edit thesis dialogs so the
+// palette can't drift between them. Tailwind 500-level hues, rainbow-ordered for
+// a pleasant picker. All eight original presets are retained (existing theses
+// keep matching a swatch).
+export const THESIS_PRESET_COLORS = [
+  "#ef4444", // red
+  "#f97316", // orange
+  "#f59e0b", // amber
+  "#eab308", // yellow
+  "#84cc16", // lime
+  "#22c55e", // green
+  "#10b981", // emerald
+  "#14b8a6", // teal
+  "#06b6d4", // cyan
+  "#0ea5e9", // sky
+  "#3b82f6", // blue
+  "#6366f1", // indigo
+  "#8b5cf6", // violet
+  "#a855f7", // purple
+  "#d946ef", // fuchsia
+  "#ec4899", // pink
+  "#f43f5e", // rose
+  "#64748b", // slate
+  "#78716c", // stone
+]
+
+// Default colour for a freshly created thesis (preserves the prior blue default).
+export const DEFAULT_THESIS_COLOR = "#3b82f6"


### PR DESCRIPTION
Improvements to the By-thesis table, plus the fix for empty indicator columns in the "+N more" rows.

## UI polish
- **Drop the "N here" label** from each thesis header (redundant with the table below it).
- **More colours** — palette expanded 8 → 19, extracted to a shared `lib/thesis-colors.ts` (was duplicated verbatim in the new/edit dialogs); swatch row now wraps. All 8 original presets retained, so existing theses keep matching a swatch.
- **In-table expander** — the `+N more in <groups>` toggle now lives *inside* the thesis table as a footer-style row. Expanding continues the **same** table (one header) instead of rendering a second table with its own column header.

## Empty RSI/MACD/ATR/… in elsewhere rows — fixed
The per-group batch (`GET /groups/{id}/indicators`) only computes indicators for assets *in that group*, so thesis members living in other groups rendered with blank indicator cells (price/change still showed, from the global SSE quote stream). Indicator values are computed **per symbol** — `group_id` is only a cache key — so the clean fix is to make indicators addressable by symbol set:

- **New endpoint:** `GET /api/indicators?symbols=A&symbols=B` → `dict[str, IndicatorSnapshotBase]`. DB-backed, tracked symbols only; untracked symbols are omitted.
- **Backend:** extracted `_compute_snapshots_for_rows` core from `compute_and_cache_indicators`; added `compute_indicators_for_symbols` + `AssetRepository.list_id_symbol_pairs_by_symbols`. The group endpoint is now a thin caller of the shared core.
- **Frontend:** `useIndicators(symbols)` fetched **lazily** — only when a fold is expanded — and merged into the indicator map handed to the elsewhere rows.

### Trade-offs / notes
- Brief `—` → fill-in on first expand (expected for lazy load).
- An elsewhere member that belongs to **no** group can't be rendered as a row (no `Asset` data) — excluded from the count + rows. In practice assets live in at least the default Watchlist group.
- **Pre-existing pyright nits** (not a CI gate; CI runs pytest/lint/build): `get_batch_sparklines` in `compute/group.py:48-49` has `Row`-vs-`tuple` attribute-access warnings, mirrored by the three `list_*_id_symbol_pairs` repo methods (`tuple[int,str]` annotation vs real SQLAlchemy `Row`). Untouched by this PR; happy to clean up the repo annotations separately if wanted.

## Verification
- Backend: **658 tests pass** (added 2 for `compute_indicators_for_symbols`).
- Frontend: **lint + build clean**.
- Endpoint live-tested: empty → `{}`; real symbols return full snapshots (RSI/SMA/BB/MACD/ATR/ADX/…).

Targeting `dev` per CLAUDE.md (backend endpoint + service refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)