### PR TITLE
feat(thesis): thesis grouping in the table view — colour-edged list, keep-together toggle, sections

### DIFF
--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -22,7 +22,9 @@ class AppSettingsData(BaseModel):
     group_sort_dir: Literal["asc", "desc"] | None = None
     group_table_columns: dict[str, bool] | None = None
     group_table_column_widths: dict[str, float] | None = None
-    group_by_thesis: bool | None = None
+    # 3-way thesis grouping for the table view. Old clients may still send the
+    # boolean `group_by_thesis`; it is preserved via extra="allow".
+    thesis_grouping: Literal["none", "sections", "inline"] | None = None
     chart_default_period: str | None = None
     chart_type: Literal["candle", "line"] | None = None
     theme: Literal["dark", "light", "system"] | None = None

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -22,9 +22,12 @@ class AppSettingsData(BaseModel):
     group_sort_dir: Literal["asc", "desc"] | None = None
     group_table_columns: dict[str, bool] | None = None
     group_table_column_widths: dict[str, float] | None = None
-    # 3-way thesis grouping for the table view. Old clients may still send the
-    # boolean `group_by_thesis`; it is preserved via extra="allow".
-    thesis_grouping: Literal["none", "sections", "inline"] | None = None
+    # Thesis layout for the table view, plus whether the list view clusters a
+    # thesis's members together when sorting. Legacy keys (`group_by_thesis`, the
+    # old "none"/"inline" thesis_grouping values) are tolerated via extra="allow"
+    # and normalized client-side.
+    thesis_grouping: Literal["list", "sections"] | None = None
+    thesis_cluster: bool | None = None
     chart_default_period: str | None = None
     chart_type: Literal["candle", "line"] | None = None
     theme: Literal["dark", "light", "system"] | None = None

--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -38,9 +38,16 @@ interface GroupTableProps {
   moreOpen?: boolean
   /** Controlled toggle handler for the "more" footer. */
   onToggleMore?: () => void
+  /**
+   * Per-symbol left-border accent colour (thesis colour) for the "inline" thesis
+   * grouping mode. Rows without an entry render no accent.
+   */
+  accentColors?: Record<string, string>
+  /** Per-symbol tooltip for the accent bar (the thesis name[s]). */
+  accentTitles?: Record<string, string>
 }
 
-export function GroupTable({ groupId, assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort, moreAssets, moreLabel, moreOpen, onToggleMore }: GroupTableProps) {
+export function GroupTable({ groupId, assets, quotes, indicators, onDelete, compactMode, onHover, sortBy, sortDir, onSort, moreAssets, moreLabel, moreOpen, onToggleMore, accentColors, accentTitles }: GroupTableProps) {
   const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(new Set())
   const [internalMoreOpen, setInternalMoreOpen] = useState(false)
   const moreOpenState = moreOpen ?? internalMoreOpen
@@ -98,6 +105,8 @@ export function GroupTable({ groupId, assets, quotes, indicators, onDelete, comp
       columnSettings={columnSettings}
       visibleIndicatorFields={visibleIndicatorFields}
       totalColSpan={totalColSpan}
+      accent={accentColors?.[asset.symbol]}
+      accentTitle={accentTitles?.[asset.symbol]}
     />
   )
 

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -70,6 +70,8 @@ export const TableRow = memo(function TableRow({
   columnSettings,
   visibleIndicatorFields,
   totalColSpan,
+  accent,
+  accentTitle,
 }: {
   groupId: number
   asset: Asset
@@ -83,6 +85,10 @@ export const TableRow = memo(function TableRow({
   columnSettings: Record<string, boolean>
   visibleIndicatorFields: string[]
   totalColSpan: number
+  /** Left-border accent colour (thesis colour) for the "inline" thesis grouping. */
+  accent?: string
+  /** Tooltip for the accent bar — the thesis name(s) this row belongs to. */
+  accentTitle?: string
 }) {
   // Use live SSE quote when available, fall back to DB-cached indicator values
   const livePrice = quote?.price ?? null
@@ -120,7 +126,11 @@ export const TableRow = memo(function TableRow({
           onClick={handleToggle}
           onMouseEnter={handleHover}
         >
-          <td className={`${py} pl-2`}>
+          <td
+            className={`${py} pl-2`}
+            style={accent ? { boxShadow: `inset 3px 0 0 0 ${accent}` } : undefined}
+            title={accent ? accentTitle : undefined}
+          >
             {expanded ? (
               <ChevronDown className="h-4 w-4 text-muted-foreground" />
             ) : (

--- a/frontend/src/components/ui/segmented-control.tsx
+++ b/frontend/src/components/ui/segmented-control.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react"
 interface Option<T extends string> {
   value: T
   label: ReactNode
+  /** Tooltip / accessible label — useful when `label` is an icon only. */
+  title?: string
 }
 
 interface SegmentedControlProps<T extends string> {
@@ -22,6 +24,8 @@ export function SegmentedControl<T extends string>({
         <button
           key={opt.value}
           onClick={() => onChange(opt.value)}
+          title={opt.title}
+          aria-label={opt.title}
           className={`px-2.5 py-1 text-xs font-medium transition-colors ${
             value === opt.value
               ? "bg-primary text-primary-foreground"

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -8,6 +8,8 @@ export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"
 export type GroupViewMode = "card" | "table" | "scanner" | "live"
 export type YahooLinkMode = "chart" | "quote"
+/** How the table view organizes rows by thesis. */
+export type ThesisGrouping = "none" | "sections" | "inline"
 
 export interface AppSettings {
   /** Per-indicator placement visibility matrix. Missing key = use descriptor defaults. */
@@ -20,7 +22,7 @@ export interface AppSettings {
   group_sort_dir: SortDir
   group_table_columns: Record<string, boolean>
   group_table_column_widths: Record<string, number>
-  group_by_thesis: boolean
+  thesis_grouping: ThesisGrouping
   chart_default_period: string
   chart_type: "candle" | "line"
   theme: "dark" | "light" | "system"
@@ -56,6 +58,22 @@ function migrateOldVisibility(
   return result
 }
 
+/**
+ * Migrate the old boolean `group_by_thesis` toggle to the 3-way `thesis_grouping`
+ * selector: `true` → sectioned grouping, `false`/absent → no grouping. Only fills
+ * `thesis_grouping` when it isn't already set, so an explicit choice (including the
+ * new "inline" color-coded mode) is never clobbered by a stale boolean.
+ */
+type LegacySettings = Partial<AppSettings> & { group_by_thesis?: boolean }
+
+function withThesisGrouping(s: LegacySettings): LegacySettings {
+  if (s.thesis_grouping == null && "group_by_thesis" in s) {
+    const { group_by_thesis, ...rest } = s
+    return { ...rest, thesis_grouping: group_by_thesis ? "sections" : "none" }
+  }
+  return s
+}
+
 // eslint-disable-next-line react-refresh/only-export-components
 export const DEFAULT_SETTINGS: AppSettings = {
   indicator_visibility: {},
@@ -67,7 +85,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   group_sort_dir: "asc",
   group_table_columns: {},
   group_table_column_widths: {},
-  group_by_thesis: false,
+  thesis_grouping: "none",
   chart_default_period: "1y",
   chart_type: "candle",
   theme: "system",
@@ -98,9 +116,10 @@ function loadFromStorage(): AppSettings {
         delete parsed.group_indicator_visibility
         delete parsed.detail_indicator_visibility
         // Persist migrated settings
-        localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...DEFAULT_SETTINGS, ...parsed }))
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...DEFAULT_SETTINGS, ...withThesisGrouping(parsed) }))
       }
-      return { ...DEFAULT_SETTINGS, ...parsed }
+      // Migrate before merging defaults — the "none" default would otherwise mask the old flag.
+      return { ...DEFAULT_SETTINGS, ...withThesisGrouping(parsed) }
     }
   } catch {
     // ignore corrupt storage
@@ -131,9 +150,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       .then((body) => {
         if (cancelled) return
         if (body?.data && Object.keys(body.data).length > 0) {
+          const remoteData = withThesisGrouping(body.data as Partial<AppSettings>)
           setSettings((prev) => {
             const localTs = prev._updated_at
-            const remoteTs = (body.data as Partial<AppSettings>)._updated_at
+            const remoteTs = remoteData._updated_at
             // Only let backend overwrite if it has a newer (or equal) timestamp,
             // or if local has no timestamp yet (first sync)
             if (localTs && remoteTs && remoteTs < localTs) {
@@ -141,7 +161,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
               api.settings.update(prev as unknown as Record<string, unknown>).catch(() => {})
               return prev
             }
-            const merged = { ...prev, ...body.data }
+            const merged = { ...prev, ...remoteData }
             saveToStorage(merged)
             return merged
           })

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -8,8 +8,8 @@ export type SortDir = "asc" | "desc"
 export type MacdStyle = "classic" | "divergence"
 export type GroupViewMode = "card" | "table" | "scanner" | "live"
 export type YahooLinkMode = "chart" | "quote"
-/** How the table view organizes rows by thesis. */
-export type ThesisGrouping = "none" | "sections" | "inline"
+/** Thesis layout in the table view: a flat (colour-edged) list or per-thesis sections. */
+export type ThesisGrouping = "list" | "sections"
 
 export interface AppSettings {
   /** Per-indicator placement visibility matrix. Missing key = use descriptor defaults. */
@@ -23,6 +23,8 @@ export interface AppSettings {
   group_table_columns: Record<string, boolean>
   group_table_column_widths: Record<string, number>
   thesis_grouping: ThesisGrouping
+  /** In list view, keep a thesis's members together when sorting (average-and-interleave). */
+  thesis_cluster: boolean
   chart_default_period: string
   chart_type: "candle" | "line"
   theme: "dark" | "light" | "system"
@@ -64,14 +66,25 @@ function migrateOldVisibility(
  * `thesis_grouping` when it isn't already set, so an explicit choice (including the
  * new "inline" color-coded mode) is never clobbered by a stale boolean.
  */
-type LegacySettings = Partial<AppSettings> & { group_by_thesis?: boolean }
-
-function withThesisGrouping(s: LegacySettings): LegacySettings {
-  if (s.thesis_grouping == null && "group_by_thesis" in s) {
-    const { group_by_thesis, ...rest } = s
-    return { ...rest, thesis_grouping: group_by_thesis ? "sections" : "none" }
+/**
+ * Normalize legacy thesis settings into the current shape
+ * ({ thesis_grouping: "list" | "sections", thesis_cluster }):
+ *   - boolean `group_by_thesis`: true → sections, false → list
+ *   - old 3-way `thesis_grouping`: "none" → list, "inline" → list + cluster, "sections" → sections
+ * Only fills what it can derive; DEFAULT_SETTINGS backfills the rest, and a value
+ * already in the new shape is left untouched.
+ */
+function migrateThesisSettings(s: Record<string, unknown>): Partial<AppSettings> {
+  const out: Record<string, unknown> = { ...s }
+  const tg = out.thesis_grouping
+  if (tg === "none" || tg === "inline") {
+    out.thesis_cluster = tg === "inline"
+    out.thesis_grouping = "list"
+  } else if (tg == null && "group_by_thesis" in out) {
+    out.thesis_grouping = out.group_by_thesis ? "sections" : "list"
   }
-  return s
+  delete out.group_by_thesis
+  return out as Partial<AppSettings>
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -85,7 +98,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   group_sort_dir: "asc",
   group_table_columns: {},
   group_table_column_widths: {},
-  thesis_grouping: "none",
+  thesis_grouping: "list",
+  thesis_cluster: false,
   chart_default_period: "1y",
   chart_type: "candle",
   theme: "system",
@@ -116,10 +130,10 @@ function loadFromStorage(): AppSettings {
         delete parsed.group_indicator_visibility
         delete parsed.detail_indicator_visibility
         // Persist migrated settings
-        localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...DEFAULT_SETTINGS, ...withThesisGrouping(parsed) }))
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...DEFAULT_SETTINGS, ...migrateThesisSettings(parsed) }))
       }
-      // Migrate before merging defaults — the "none" default would otherwise mask the old flag.
-      return { ...DEFAULT_SETTINGS, ...withThesisGrouping(parsed) }
+      // Migrate before merging defaults so legacy thesis values aren't masked.
+      return { ...DEFAULT_SETTINGS, ...migrateThesisSettings(parsed) }
     }
   } catch {
     // ignore corrupt storage
@@ -150,7 +164,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       .then((body) => {
         if (cancelled) return
         if (body?.data && Object.keys(body.data).length > 0) {
-          const remoteData = withThesisGrouping(body.data as Partial<AppSettings>)
+          const remoteData = migrateThesisSettings(body.data)
           setSettings((prev) => {
             const localTs = prev._updated_at
             const remoteTs = remoteData._updated_at

--- a/frontend/src/lib/use-group-filter.ts
+++ b/frontend/src/lib/use-group-filter.ts
@@ -3,10 +3,41 @@ import type { Asset, Quote, IndicatorSummary } from "@/lib/api"
 import type { AssetTypeFilter, GroupSortBy, SortDir } from "@/lib/settings"
 import { getNumericValue } from "@/lib/indicator-registry"
 
-function compareNullable(a: number | null, b: number | null): number {
+/** A row's value for a given sort field: number for metrics, string for "name". */
+export type SortValue = number | string | null
+
+/**
+ * Resolve the sortable value for an asset under `sortBy`, using the same sources
+ * the table renders from: live SSE quote for price/change, indicator snapshot for
+ * everything else. Shared so derived orderings (e.g. thesis-block averages) can't
+ * drift from the row sort.
+ */
+export function getSortValue(
+  asset: Asset,
+  sortBy: GroupSortBy,
+  quotes: Record<string, Quote>,
+  indicators?: Record<string, IndicatorSummary>,
+): SortValue {
+  switch (sortBy) {
+    case "name":
+      return asset.symbol
+    case "price":
+      return quotes[asset.symbol]?.price ?? null
+    case "change_pct":
+      return quotes[asset.symbol]?.change_percent ?? null
+    default:
+      return getNumericValue(indicators?.[asset.symbol]?.values, sortBy)
+  }
+}
+
+/** Ascending comparator for {@link SortValue}: nulls last, strings via locale. */
+export function compareSortValues(a: SortValue, b: SortValue): number {
   if (a == null && b == null) return 0
   if (a == null) return 1
   if (b == null) return -1
+  if (typeof a === "string" || typeof b === "string") {
+    return String(a).localeCompare(String(b))
+  }
   return a - b
 }
 
@@ -37,31 +68,10 @@ export function useFilteredSortedAssets(
     }
 
     const sorted = [...filtered].sort((a, b) => {
-      let cmp = 0
-      switch (sortBy) {
-        case "name":
-          cmp = a.symbol.localeCompare(b.symbol)
-          break
-        case "price":
-          cmp = compareNullable(
-            quotes[a.symbol]?.price ?? null,
-            quotes[b.symbol]?.price ?? null,
-          )
-          break
-        case "change_pct":
-          cmp = compareNullable(
-            quotes[a.symbol]?.change_percent ?? null,
-            quotes[b.symbol]?.change_percent ?? null,
-          )
-          break
-        default:
-          // Indicator-based sorting: sortBy is the field name (e.g. "rsi", "macd")
-          cmp = compareNullable(
-            getNumericValue(indicators?.[a.symbol]?.values, sortBy),
-            getNumericValue(indicators?.[b.symbol]?.values, sortBy),
-          )
-          break
-      }
+      const cmp = compareSortValues(
+        getSortValue(a, sortBy, quotes, indicators),
+        getSortValue(b, sortBy, quotes, indicators),
+      )
       return sortDir === "asc" ? cmp : -cmp
     })
 

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, useMemo, useTransition } from "react"
-import { Activity, ArrowDownAZ, ArrowUpAZ, Layers, LayoutGrid, List, Palette, Pencil, ScanLine, Star, Table, TrendingUp } from "lucide-react"
+import { Activity, ArrowDownAZ, ArrowUpAZ, Layers, LayoutGrid, List, Magnet, Pencil, ScanLine, Star, Table, TrendingUp } from "lucide-react"
 import { resolveIcon } from "@/lib/icon-utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -43,6 +43,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
   const { settings, updateSettings } = useSettings()
   const thesisGrouping = settings.thesis_grouping
+  const thesisCluster = settings.thesis_cluster
   const [isPending, startTransition] = useTransition()
   // settings.group_view_mode = immediate (drives SegmentedControl highlight)
   // viewMode = deferred via useTransition (drives content rendering)
@@ -79,14 +80,14 @@ export function GroupPage({ groupId }: { groupId: number }) {
     indicators: batchIndicators,
   })
 
-  // "inline" thesis grouping: one flat table, but each thesis's members are pulled
-  // together into a block and ordered *within* the block by the active sort. Each
-  // block is then placed in the global order by the AVERAGE of its members' sort
-  // metric, interleaved with ungrouped assets (each its own size-1 unit). Members'
-  // left borders are coloured with the thesis colour — no section headers.
-  const { inlineAssets, accentColors, accentTitles } = useMemo(() => {
-    if (thesisGrouping !== "inline" || !theses || theses.length === 0 || !assets) {
-      return { inlineAssets: assets, accentColors: undefined, accentTitles: undefined }
+  // List view always paints each row's left border with its thesis colour. When the
+  // "keep together" toggle is on, members are additionally clustered: each thesis's
+  // rows are pulled into a block ordered *within* by the active sort, and the block is
+  // placed in the global order by the AVERAGE of its members' metric, interleaved with
+  // ungrouped assets (each a size-1 unit). Off → plain sort, just colour-edged.
+  const { listAssets, accentColors, accentTitles } = useMemo(() => {
+    if (thesisGrouping !== "list" || !theses || theses.length === 0 || !assets) {
+      return { listAssets: assets, accentColors: undefined, accentTitles: undefined }
     }
     // asset id -> theses containing it, in the API's order (alphabetical by name)
     const thesesByAssetId = new Map<number, Thesis[]>()
@@ -98,10 +99,22 @@ export function GroupPage({ groupId }: { groupId: number }) {
       }
     }
 
+    // Colour edges + tooltips are shown whether or not clustering is on.
     const colors: Record<string, string> = {}
     const titles: Record<string, string> = {}
+    for (const a of assets) {
+      const ts = thesesByAssetId.get(a.id)
+      if (ts && ts.length > 0) {
+        colors[a.symbol] = ts[0].color
+        titles[a.symbol] = ts.map((t) => t.name).join(", ")
+      }
+    }
 
-    // A unit is one sortable row of the global order: a thesis block (many rows) or
+    if (!thesisCluster) {
+      return { listAssets: assets, accentColors: colors, accentTitles: titles }
+    }
+
+    // A unit is one sortable entry of the global order: a thesis block (many rows) or
     // a lone ungrouped asset (one row). `numVals` accumulates members' numeric metric
     // for the block average. Units are created in first-appearance order (stable ties).
     type Unit = { key: SortValue; rows: Asset[]; numVals: number[] }
@@ -115,8 +128,6 @@ export function GroupPage({ groupId }: { groupId: number }) {
         units.push({ key: val, rows: [a], numVals: [] })
         continue
       }
-      colors[a.symbol] = ts[0].color
-      titles[a.symbol] = ts.map((t) => t.name).join(", ")
       let block = blockByThesisId.get(ts[0].id)
       if (!block) {
         block = { key: null, rows: [], numVals: [] }
@@ -145,8 +156,8 @@ export function GroupPage({ groupId }: { groupId: number }) {
       .sort((x, y) => dir * compareSortValues(x.key, y.key))
       .flatMap((u) => u.rows)
 
-    return { inlineAssets: ordered, accentColors: colors, accentTitles: titles }
-  }, [thesisGrouping, theses, assets, sortBy, sortDir, quotes, batchIndicators])
+    return { listAssets: ordered, accentColors: colors, accentTitles: titles }
+  }, [thesisGrouping, thesisCluster, theses, assets, sortBy, sortDir, quotes, batchIndicators])
 
   const setTypeFilter = (v: AssetTypeFilter) =>
     updateSettings({ group_type_filter: v })
@@ -264,15 +275,28 @@ export function GroupPage({ groupId }: { groupId: number }) {
             onChange={setViewMode}
           />
           {viewMode === "table" && (
-            <SegmentedControl
-              options={[
-                { value: "none", label: <List className="h-3.5 w-3.5" />, title: "No thesis grouping" },
-                { value: "sections", label: <Layers className="h-3.5 w-3.5" />, title: "Group by thesis — sections" },
-                { value: "inline", label: <Palette className="h-3.5 w-3.5" />, title: "Group by thesis — colour-coded rows" },
-              ]}
-              value={thesisGrouping}
-              onChange={(v) => updateSettings({ thesis_grouping: v })}
-            />
+            <div className="flex items-center gap-1.5">
+              <SegmentedControl
+                options={[
+                  { value: "list", label: <List className="h-3.5 w-3.5" />, title: "List — colour-edged by thesis" },
+                  { value: "sections", label: <Layers className="h-3.5 w-3.5" />, title: "Group by thesis — sections" },
+                ]}
+                value={thesisGrouping}
+                onChange={(v) => updateSettings({ thesis_grouping: v })}
+              />
+              {thesisGrouping === "list" && (
+                <Button
+                  variant={thesisCluster ? "default" : "outline"}
+                  size="sm"
+                  className="h-7 gap-1.5 text-xs"
+                  onClick={() => updateSettings({ thesis_cluster: !thesisCluster })}
+                  title="Keep each thesis's members together when sorting"
+                >
+                  <Magnet className="h-3.5 w-3.5" />
+                  Keep together
+                </Button>
+              )}
+            </div>
           )}
           {allTags && allTags.length > 0 && (
             <TagFilterPopover
@@ -326,7 +350,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
           ) : (
             <GroupTable
               groupId={groupId}
-              assets={inlineAssets ?? assets}
+              assets={listAssets ?? assets}
               quotes={quotes}
               indicators={batchIndicators}
               onDelete={handleRemove}

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -290,10 +290,10 @@ export function GroupPage({ groupId }: { groupId: number }) {
                   size="sm"
                   className="h-7 gap-1.5 text-xs"
                   onClick={() => updateSettings({ thesis_cluster: !thesisCluster })}
-                  title="Keep each thesis's members together when sorting"
+                  title="Sort each thesis's members together as one block"
                 >
                   <Magnet className="h-3.5 w-3.5" />
-                  Keep together
+                  Sort together
                 </Button>
               )}
             </div>

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, useMemo, useTransition } from "react"
-import { Activity, ArrowDownAZ, ArrowUpAZ, Layers, LayoutGrid, Pencil, ScanLine, Star, Table, TrendingUp } from "lucide-react"
+import { Activity, ArrowDownAZ, ArrowUpAZ, Layers, LayoutGrid, List, Palette, Pencil, ScanLine, Star, Table, TrendingUp } from "lucide-react"
 import { resolveIcon } from "@/lib/icon-utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -19,7 +19,8 @@ import { useGroup, useGroups, useGroupSparklines, useGroupIndicators, useRemoveA
 import { useQuotes } from "@/lib/quote-stream"
 import { buildSortOptions, getScannableDescriptors } from "@/lib/indicator-registry"
 import { useSettings, type AssetTypeFilter, type GroupSortBy, type GroupViewMode, type SortDir } from "@/lib/settings"
-import { useFilteredSortedAssets } from "@/lib/use-group-filter"
+import { useFilteredSortedAssets, getSortValue, compareSortValues, type SortValue } from "@/lib/use-group-filter"
+import type { Asset, Thesis } from "@/lib/api"
 import { GroupTable } from "@/components/group-table"
 import { ThesisGroupedTable } from "@/components/thesis-grouped-table"
 import { CrosshairTimeSyncProvider } from "@/components/chart/crosshair-time-sync"
@@ -41,7 +42,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
   const { settings, updateSettings } = useSettings()
-  const groupByThesis = settings.group_by_thesis
+  const thesisGrouping = settings.thesis_grouping
   const [isPending, startTransition] = useTransition()
   // settings.group_view_mode = immediate (drives SegmentedControl highlight)
   // viewMode = deferred via useTransition (drives content rendering)
@@ -77,6 +78,75 @@ export function GroupPage({ groupId }: { groupId: number }) {
     quotes,
     indicators: batchIndicators,
   })
+
+  // "inline" thesis grouping: one flat table, but each thesis's members are pulled
+  // together into a block and ordered *within* the block by the active sort. Each
+  // block is then placed in the global order by the AVERAGE of its members' sort
+  // metric, interleaved with ungrouped assets (each its own size-1 unit). Members'
+  // left borders are coloured with the thesis colour — no section headers.
+  const { inlineAssets, accentColors, accentTitles } = useMemo(() => {
+    if (thesisGrouping !== "inline" || !theses || theses.length === 0 || !assets) {
+      return { inlineAssets: assets, accentColors: undefined, accentTitles: undefined }
+    }
+    // asset id -> theses containing it, in the API's order (alphabetical by name)
+    const thesesByAssetId = new Map<number, Thesis[]>()
+    for (const t of theses) {
+      for (const m of t.assets) {
+        const list = thesesByAssetId.get(m.id)
+        if (list) list.push(t)
+        else thesesByAssetId.set(m.id, [t])
+      }
+    }
+
+    const colors: Record<string, string> = {}
+    const titles: Record<string, string> = {}
+
+    // A unit is one sortable row of the global order: a thesis block (many rows) or
+    // a lone ungrouped asset (one row). `numVals` accumulates members' numeric metric
+    // for the block average. Units are created in first-appearance order (stable ties).
+    type Unit = { key: SortValue; rows: Asset[]; numVals: number[] }
+    const units: Unit[] = []
+    const blockByThesisId = new Map<number, Unit>()
+
+    for (const a of assets) {
+      const val = getSortValue(a, sortBy, quotes, batchIndicators)
+      const ts = thesesByAssetId.get(a.id)
+      if (!ts || ts.length === 0) {
+        units.push({ key: val, rows: [a], numVals: [] })
+        continue
+      }
+      colors[a.symbol] = ts[0].color
+      titles[a.symbol] = ts.map((t) => t.name).join(", ")
+      let block = blockByThesisId.get(ts[0].id)
+      if (!block) {
+        block = { key: null, rows: [], numVals: [] }
+        blockByThesisId.set(ts[0].id, block)
+        units.push(block)
+      }
+      block.rows.push(a) // assets are pre-sorted, so within-block order is the active sort
+      if (typeof val === "number") block.numVals.push(val)
+    }
+
+    // Block key = average of members' metric (numeric sorts); for the "name" sort the
+    // average is meaningless, so the leading member (in the current direction) stands in.
+    for (const block of blockByThesisId.values()) {
+      block.key =
+        sortBy === "name"
+          ? block.rows.length
+            ? getSortValue(block.rows[0], sortBy, quotes, batchIndicators)
+            : null
+          : block.numVals.length
+            ? block.numVals.reduce((s, v) => s + v, 0) / block.numVals.length
+            : null
+    }
+
+    const dir = sortDir === "asc" ? 1 : -1
+    const ordered = [...units]
+      .sort((x, y) => dir * compareSortValues(x.key, y.key))
+      .flatMap((u) => u.rows)
+
+    return { inlineAssets: ordered, accentColors: colors, accentTitles: titles }
+  }, [thesisGrouping, theses, assets, sortBy, sortDir, quotes, batchIndicators])
 
   const setTypeFilter = (v: AssetTypeFilter) =>
     updateSettings({ group_type_filter: v })
@@ -194,16 +264,15 @@ export function GroupPage({ groupId }: { groupId: number }) {
             onChange={setViewMode}
           />
           {viewMode === "table" && (
-            <Button
-              variant={groupByThesis ? "default" : "outline"}
-              size="sm"
-              className="h-7 gap-1.5 text-xs"
-              onClick={() => updateSettings({ group_by_thesis: !groupByThesis })}
-              title="Group rows by thesis"
-            >
-              <Layers className="h-3.5 w-3.5" />
-              By thesis
-            </Button>
+            <SegmentedControl
+              options={[
+                { value: "none", label: <List className="h-3.5 w-3.5" />, title: "No thesis grouping" },
+                { value: "sections", label: <Layers className="h-3.5 w-3.5" />, title: "Group by thesis — sections" },
+                { value: "inline", label: <Palette className="h-3.5 w-3.5" />, title: "Group by thesis — colour-coded rows" },
+              ]}
+              value={thesisGrouping}
+              onChange={(v) => updateSettings({ thesis_grouping: v })}
+            />
           )}
           {allTags && allTags.length > 0 && (
             <TagFilterPopover
@@ -239,7 +308,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
         </CrosshairTimeSyncProvider>
       ) : viewMode === "table" && assets && assets.length > 0 ? (
         <CrosshairTimeSyncProvider enabled={true}>
-          {groupByThesis ? (
+          {thesisGrouping === "sections" ? (
             <ThesisGroupedTable
               groupId={groupId}
               assets={assets}
@@ -257,7 +326,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
           ) : (
             <GroupTable
               groupId={groupId}
-              assets={assets}
+              assets={inlineAssets ?? assets}
               quotes={quotes}
               indicators={batchIndicators}
               onDelete={handleRemove}
@@ -266,6 +335,8 @@ export function GroupPage({ groupId }: { groupId: number }) {
               sortBy={sortBy}
               sortDir={sortDir}
               onSort={handleSort}
+              accentColors={accentColors}
+              accentTitles={accentTitles}
             />
           )}
         </CrosshairTimeSyncProvider>


### PR DESCRIPTION
Adds thesis organisation to the group **table** view, split into two orthogonal axes: *coloring* (always on in list) and *clustering* (a toggle). (Evolved from an initial 3-way none/sections/inline control — see commits.)

## Controls
- **View** segmented control: **List** (`List` icon) | **Sections** (`Layers` icon).
- **List** always paints each row's left border in its thesis colour (tooltip names the thesis, or all of them for a multi-thesis ticker).
- **Keep together** toggle (`Magnet`, List view only): off = plain sort, just colour-edged; on = members clustered.

## Sections
Unchanged `ThesisGroupedTable` — per-thesis headers + the "+N more in [groups]" fold for members that live in other groups.

## "Keep together" clustering — average & interleave
- **Within a block:** the active column sort.
- **Block position:** the **average** of its members' sort metric, treated as one sortable value.
- **Ungrouped assets:** each a size-1 unit, interleaved with blocks by its own value.
- **Direction** applies to both block order and within-block.

So an ungrouped ticker at −2% sorts *above* a thesis block averaging −1%, members ascending inside:

```
A.DE  -2.0%   ← ungrouped
NEX   -3.0%   ┐
PRY   -1.0%   ├ Cables block (avg -1.0%)
NKT   +1.0%   ┘
OKLO  -0.5%   ┐ Nuclear block (avg 0.0%)
RR    +0.5%   ┘
```

The block average reuses the **same** value the row renders (live SSE quote → DB fallback): the accessor (`getSortValue` / `compareSortValues`) was extracted from `useFilteredSortedAssets` and shared, so the average can't drift from the row sort. `name` sort can't be averaged, so a block slots at its leading member. Blocks re-position intraday as quotes move — consistent with how the flat table already reorders under a change%/price sort.

## Settings / compatibility
- `group_by_thesis: bool` → `thesis_grouping: "list" | "sections"` + new `thesis_cluster: bool`.
- `migrateThesisSettings` folds every legacy value forward (boolean true→sections/false→list; old `"none"`→list, `"inline"`→list+cluster, `"sections"`→sections) in **both** the localStorage-load and backend-merge paths.
- Backend `AppSettingsData` mirrors the new fields; legacy keys still tolerated via `extra="allow"`.
- `SegmentedControl` gained per-option `title`/`aria-label` for the icon-only options.

## Verification
- Frontend `pnpm lint` + `pnpm build`: clean.
- Migration table checked for all legacy shapes; backend schema accepts new shape, rejects dropped `inline`, tolerates legacy `group_by_thesis`; `pytest -k settings` → 14 passed.
- Clustering order verified against a simulation of the algorithm (trace above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)