### PR TITLE
Backlog batch: cache key (#529), sig-fig compaction (#530), thesis members (#533), remove dialog + hard delete (#536)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
       - run: pnpm run build
+      - run: pnpm run test
       - run: pnpm audit --prod || true
 
   build-image:

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.asset import AssetCreate, AssetResponse, AssetUpdate
+from app.schemas.asset import AssetAttachments, AssetCreate, AssetResponse, AssetUpdate
 from app.services import asset_service
 
 router = APIRouter(prefix="/api/assets", tags=["assets"])
@@ -46,9 +46,35 @@ async def update_asset(asset_id: int, data: AssetUpdate, db: AsyncSession = Depe
     )
 
 
-@router.delete("/{symbol}", status_code=204, summary="Remove an asset from the default group")
-async def delete_asset(symbol: str, db: AsyncSession = Depends(get_db)):
-    """Remove the asset from the default group. The row is preserved so that
-    pseudo-ETF constituent relationships remain intact.
+@router.get(
+    "/{symbol}/attachments",
+    response_model=AssetAttachments,
+    summary="Summarise what is attached to an asset",
+)
+async def get_asset_attachments(symbol: str, db: AsyncSession = Depends(get_db)):
+    """Return the asset's group / pseudo-ETF / thesis memberships, tags, note and
+    annotation count. The remove dialog uses this to warn before leaving the asset
+    in zero groups, and to show what a hard delete would cascade into.
     """
-    await asset_service.delete_asset(db, symbol)
+    return await asset_service.get_attachments(db, symbol)
+
+
+@router.delete("/{symbol}", status_code=204, summary="Remove an asset (soft) or delete it entirely (hard)")
+async def delete_asset(
+    symbol: str,
+    hard: bool = Query(
+        default=False,
+        description="If true, permanently delete the asset row and cascade "
+        "(group + pseudo-ETF + thesis memberships, tags, note, annotations, prices). "
+        "Default false only removes it from the default group, preserving the row.",
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove the asset from the default group (soft, the row is preserved so
+    pseudo-ETF constituent relationships remain intact), or — with ``hard=true`` —
+    permanently delete the asset and everything attached to it.
+    """
+    if hard:
+        await asset_service.hard_delete_asset(db, symbol)
+    else:
+        await asset_service.delete_asset(db, symbol)

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -26,6 +26,20 @@ class TagBrief(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class AssetAttachments(BaseModel):
+    """What is attached to an asset, for the remove dialog to warn before an orphan
+    or a hard delete. ``groups`` drives the last-group warning; ``pseudo_etfs`` and
+    ``theses`` are the silent-mutation risks a hard delete would cascade into."""
+
+    symbol: str = Field(description="Ticker symbol")
+    groups: list[str] = Field(default=[], description="Names of groups containing this asset")
+    theses: list[str] = Field(default=[], description="Names of theses this asset is a member of")
+    pseudo_etfs: list[str] = Field(default=[], description="Names of pseudo-ETFs this asset is a constituent of")
+    tags: list[str] = Field(default=[], description="Tag names attached to this asset")
+    has_note: bool = Field(default=False, description="Whether the asset has a non-empty note")
+    annotation_count: int = Field(default=0, description="Number of chart annotations")
+
+
 class AssetResponse(BaseModel):
     id: int = Field(description="Internal asset ID")
     symbol: str = Field(description="Ticker symbol")

--- a/backend/app/schemas/thesis.py
+++ b/backend/app/schemas/thesis.py
@@ -4,14 +4,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from app.models.thesis import ThesisStatus
 from app.schemas._validators import validate_hex_color
-
-
-class ThesisAssetBrief(BaseModel):
-    id: int = Field(description="Asset ID")
-    symbol: str = Field(description="Ticker symbol")
-    name: str = Field(description="Display name")
-
-    model_config = {"from_attributes": True}
+from app.schemas.asset import AssetResponse
 
 
 class ThesisCreate(BaseModel):
@@ -57,7 +50,11 @@ class ThesisResponse(BaseModel):
     status: ThesisStatus = Field(description="Lifecycle status")
     opened_at: datetime.date = Field(description="Date the thesis was formed")
     created_at: datetime.datetime = Field(description="Creation timestamp")
-    assets: list[ThesisAssetBrief] = Field(default=[], description="Member assets")
+    assets: list[AssetResponse] = Field(
+        default=[],
+        description="Member assets as full rows (type/currency/tags), so callers can "
+        "render every member — including ones that are in no group.",
+    )
     aggregate_pct: float | None = Field(
         default=None,
         description="Equal-weight mean return of members since opened_at, in percent (null if no price data)",

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -1,9 +1,23 @@
 from fastapi import HTTPException
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Asset, AssetType
+from app.models import (
+    Annotation,
+    Asset,
+    AssetType,
+    Group,
+    Note,
+    PriceHistory,
+    PseudoETF,
+    group_assets,
+    pseudo_etf_constituents,
+    tag_assets,
+    thesis_assets,
+)
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
+from app.schemas.asset import AssetAttachments
 from app.services.currency_service import ensure_currency
 from app.services.entity_lookups import get_asset
 from app.services.yahoo import currency_from_suffix, yahoo_client
@@ -94,3 +108,65 @@ async def delete_asset(db: AsyncSession, symbol: str):
         )
     default_group.assets = [a for a in default_group.assets if a.id != asset.id]
     await group_repo.save(default_group)
+
+
+async def get_attachments(db: AsyncSession, symbol: str) -> AssetAttachments:
+    """Summarise what is attached to an asset so the remove dialog can warn the
+    user before an orphan (leaving zero groups) or a hard delete."""
+    asset = await get_asset(symbol, db)  # tags/theses eager-loaded (lazy="selectin")
+
+    group_names = (
+        await db.execute(
+            select(Group.name)
+            .join(group_assets, Group.id == group_assets.c.group_id)
+            .where(group_assets.c.asset_id == asset.id)
+            .order_by(Group.name)
+        )
+    ).scalars().all()
+    pseudo_names = (
+        await db.execute(
+            select(PseudoETF.name)
+            .join(pseudo_etf_constituents, PseudoETF.id == pseudo_etf_constituents.c.pseudo_etf_id)
+            .where(pseudo_etf_constituents.c.asset_id == asset.id)
+            .order_by(PseudoETF.name)
+        )
+    ).scalars().all()
+    note_content = (
+        await db.execute(select(Note.content).where(Note.asset_id == asset.id))
+    ).scalar_one_or_none()
+    annotation_count = (
+        await db.execute(select(func.count()).select_from(Annotation).where(Annotation.asset_id == asset.id))
+    ).scalar_one()
+
+    return AssetAttachments(
+        symbol=asset.symbol,
+        groups=list(group_names),
+        theses=sorted(t.name for t in asset.theses),
+        pseudo_etfs=list(pseudo_names),
+        tags=sorted(t.name for t in asset.tags),
+        has_note=bool(note_content and note_content.strip()),
+        annotation_count=annotation_count,
+    )
+
+
+async def hard_delete_asset(db: AsyncSession, symbol: str):
+    """Permanently delete the asset row and everything attached to it: group and
+    pseudo-ETF memberships, thesis memberships, tags, note, annotations, prices.
+
+    This is the explicit lifecycle choice offered in the remove dialog — distinct
+    from the soft ``delete_asset`` (default-group only). Every dependent row is
+    cleared explicitly rather than via ``ON DELETE CASCADE`` (which the SQLite test
+    DB doesn't enforce) or async ORM cascade (which would lazy-load during flush),
+    so the delete behaves identically on Postgres and SQLite.
+    """
+    asset = await get_asset(symbol, db)
+    aid = asset.id
+    # Detach the ORM object so its loaded tag/thesis collections don't make the
+    # unit-of-work re-issue (and mis-count) the association deletes we do by hand.
+    db.expunge(asset)
+    for table in (group_assets, pseudo_etf_constituents, tag_assets, thesis_assets):
+        await db.execute(delete(table).where(table.c.asset_id == aid))
+    for model in (PriceHistory, Annotation, Note):
+        await db.execute(delete(model).where(model.asset_id == aid))
+    await db.execute(delete(Asset).where(Asset.id == aid))
+    await db.commit()

--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -60,13 +60,13 @@ async def get_batch_sparklines(
 
 
 async def _compute_snapshots_for_rows(
-    db: AsyncSession, asset_rows, scope,
+    db: AsyncSession, asset_rows,
 ) -> dict[str, dict]:
     """Compute DB-backed indicator snapshots for (id, symbol) rows, with caching.
 
-    ``scope`` only disambiguates the cache key; the snapshot *values* depend purely
-    on (symbols, latest price date), so identical symbol sets across scopes compute
-    the same result.
+    The snapshot *values* depend purely on (symbols, latest price date), so the
+    cache is keyed by exactly that — identical symbol sets share entries across
+    callers (group pages and the symbol-addressed indicators endpoint alike).
     """
     if not asset_rows:
         return {}
@@ -76,9 +76,9 @@ async def _compute_snapshots_for_rows(
 
     price_repo = PriceRepository(db)
 
-    # Build cache key: symbols + latest price date + scope
+    # Build cache key: symbols + latest price date (scope-independent by design)
     latest_date = await price_repo.get_latest_date(asset_ids)
-    cache_key = (frozenset(id_to_symbol.values()), latest_date, scope)
+    cache_key = (frozenset(id_to_symbol.values()), latest_date)
 
     cached = _indicator_cache.get_value(cache_key)
     if cached is not None:
@@ -127,7 +127,7 @@ async def compute_and_cache_indicators(
     else:
         asset_rows = await _get_default_group_pairs(db)
 
-    return await _compute_snapshots_for_rows(db, asset_rows, group_id)
+    return await _compute_snapshots_for_rows(db, asset_rows)
 
 
 async def compute_indicators_for_symbols(
@@ -142,4 +142,4 @@ async def compute_indicators_for_symbols(
     if not symbols:
         return {}
     asset_rows = await AssetRepository(db).list_id_symbol_pairs_by_symbols(symbols)
-    return await _compute_snapshots_for_rows(db, asset_rows, None)
+    return await _compute_snapshots_for_rows(db, asset_rows)

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -119,6 +119,123 @@ async def test_delete_nonexistent_asset(client):
     assert resp.status_code == 404
 
 
+async def test_asset_attachments_summary(client, db):
+    """#536: the remove dialog reads this to warn before an orphan / hard delete."""
+    from app.models import Asset, AssetType, Note
+    from app.repositories.group_repo import GroupRepository
+
+    asset = Asset(symbol="COFF.L", name="Coffee", type=AssetType.STOCK, currency="USD")
+    db.add(asset)
+    await db.flush()
+    default_group = await GroupRepository(db).get_default()
+    assert default_group is not None
+    default_group.assets.append(asset)
+    db.add(Note(asset_id=asset.id, content="hold through El Niño"))
+    await db.commit()
+
+    tid = (await client.post("/api/theses", json={"name": "El Niño"})).json()["id"]
+    await client.post(f"/api/theses/{tid}/assets", json={"asset_ids": [asset.id]})
+
+    body = (await client.get("/api/assets/COFF.L/attachments")).json()
+    assert body["symbol"] == "COFF.L"
+    assert body["groups"] == ["Watchlist"]
+    assert body["theses"] == ["El Niño"]
+    assert body["has_note"] is True
+    assert body["annotation_count"] == 0
+    assert body["pseudo_etfs"] == []
+
+
+async def test_soft_delete_leaves_other_attachments(client, db):
+    """Soft delete only detaches from the default group — thesis membership and the
+    row survive (the exact orphan state #536 warns about)."""
+    from app.models import Asset, AssetType
+    from app.repositories.group_repo import GroupRepository
+
+    asset = Asset(symbol="COFF.L", name="Coffee", type=AssetType.STOCK, currency="USD")
+    db.add(asset)
+    await db.flush()
+    default_group = await GroupRepository(db).get_default()
+    assert default_group is not None
+    default_group.assets.append(asset)
+    await db.commit()
+    tid = (await client.post("/api/theses", json={"name": "El Niño"})).json()["id"]
+    await client.post(f"/api/theses/{tid}/assets", json={"asset_ids": [asset.id]})
+
+    assert (await client.delete("/api/assets/COFF.L")).status_code == 204
+
+    # Row + thesis membership preserved; only the group link is gone.
+    assert [a["symbol"] for a in (await client.get("/api/assets")).json()] == ["COFF.L"]
+    assert {a["symbol"] for a in (await client.get(f"/api/theses/{tid}")).json()["assets"]} == {"COFF.L"}
+    assert (await client.get("/api/assets/COFF.L/attachments")).json()["groups"] == []
+
+
+async def test_hard_delete_cascades(client, db):
+    """#536: hard delete removes the asset and every attachment — group / pseudo-ETF
+    / thesis links, tag, note, annotation, prices — while the group / thesis /
+    pseudo-ETF entities themselves survive."""
+    from datetime import date
+
+    from sqlalchemy import func, select
+
+    from app.models import (
+        Annotation,
+        Asset,
+        AssetType,
+        Note,
+        PriceHistory,
+        PseudoETF,
+        Tag,
+        group_assets,
+        pseudo_etf_constituents,
+        tag_assets,
+        thesis_assets,
+    )
+    from app.repositories.group_repo import GroupRepository
+    from tests.conftest import TestSession
+
+    asset = Asset(symbol="COFF.L", name="Coffee", type=AssetType.STOCK, currency="USD")
+    db.add(asset)
+    await db.flush()
+    aid = asset.id
+
+    default_group = await GroupRepository(db).get_default()
+    assert default_group is not None
+    default_group.assets.append(asset)
+    tag = Tag(name="softs", color="#3b82f6")
+    db.add(tag)
+    petf = PseudoETF(name="Softs Basket", base_date=date(2026, 1, 1))
+    petf.constituents.append(asset)
+    db.add(petf)
+    db.add(Note(asset_id=aid, content="thesis note"))
+    db.add(Annotation(asset_id=aid, date=date(2026, 1, 1), title="entry"))
+    db.add(PriceHistory(asset_id=aid, date=date(2026, 1, 1), open=1, high=1, low=1, close=1, volume=1))
+    await db.commit()
+
+    tid = (await client.post("/api/theses", json={"name": "El Niño"})).json()["id"]
+    await client.post(f"/api/theses/{tid}/assets", json={"asset_ids": [aid]})
+
+    assert (await client.delete("/api/assets/COFF.L?hard=true")).status_code == 204
+
+    # Verify with a fresh session so we read the committed state cleanly.
+    async with TestSession() as check:
+        async def count(selectable, where):
+            return (await check.execute(select(func.count()).select_from(selectable).where(where))).scalar_one()
+
+        assert await count(Asset, Asset.id == aid) == 0
+        for table in (group_assets, tag_assets, thesis_assets, pseudo_etf_constituents):
+            assert await count(table, table.c.asset_id == aid) == 0
+        for model in (Note, Annotation, PriceHistory):
+            assert await count(model, model.asset_id == aid) == 0
+        # Parent entities survive the cascade.
+        assert await count(PseudoETF, PseudoETF.id == petf.id) == 1
+        assert await count(Tag, Tag.id == tag.id) == 1
+    assert (await client.get(f"/api/theses/{tid}")).status_code == 200
+
+
+async def test_hard_delete_nonexistent_asset(client):
+    assert (await client.delete("/api/assets/NOPE?hard=true")).status_code == 404
+
+
 async def test_list_assets_returns_created(client):
     """``GET /api/assets`` returns every asset, ordered by symbol —
     including orphans not yet attached to any group."""

--- a/backend/tests/integration/test_theses.py
+++ b/backend/tests/integration/test_theses.py
@@ -123,6 +123,27 @@ async def test_add_and_remove_members(client):
     assert {a["symbol"] for a in resp.json()["assets"]} == {"ECAF.L"}
 
 
+async def test_members_returned_as_full_assets(client, db):
+    """#533: members come back as full asset rows (type/currency/tags), even when
+    the asset is in no group — so the theses page renders every member instead of
+    dropping groupless ones while still counting them in the aggregate."""
+    # Seed directly (NOT via the API), so the asset belongs to zero groups — the
+    # exact orphan state that used to vanish from the theses table.
+    orphan = await _seed_asset_with_closes(db, "ORPH.L", {date(2026, 3, 1): 100.0})
+    tid = (await client.post("/api/theses", json={"name": "Orphans"})).json()["id"]
+
+    resp = await client.post(f"/api/theses/{tid}/assets", json={"asset_ids": [orphan.id]})
+    assert resp.status_code == 200
+    members = resp.json()["assets"]
+    assert len(members) == 1
+    member = members[0]
+    assert member["symbol"] == "ORPH.L"
+    # Full AssetResponse shape, not the old id/symbol/name brief.
+    assert member["type"] == "stock"
+    assert member["currency"] == "USD"
+    assert member["tags"] == []
+
+
 async def test_asset_in_multiple_theses(client):
     coco = await create_asset_via_api(client, "COCO.L", "Cocoa")
     t1 = (await client.post("/api/theses", json={"name": "El Niño"})).json()["id"]

--- a/backend/tests/services/test_compute_group.py
+++ b/backend/tests/services/test_compute_group.py
@@ -232,3 +232,44 @@ class TestComputeIndicatorsForSymbols:
         assert result == {}
         # No DB work for an empty symbol set.
         mock_asset_repo_cls.return_value.list_id_symbol_pairs_by_symbols.assert_not_called()
+
+    @patch("app.services.compute.group.merge_fundamentals_from_cache")
+    @patch("app.services.compute.group.build_indicator_snapshot")
+    @patch("app.services.compute.group.compute_indicators")
+    @patch("app.services.compute.group.prices_to_df")
+    @patch("app.services.compute.group.PriceRepository")
+    @patch("app.services.compute.group.AssetRepository")
+    async def test_cache_shared_across_scopes(
+        self, mock_asset_repo_cls, mock_price_repo_cls, mock_prices_to_df,
+        mock_compute_ind, mock_build_snap, mock_merge_fund, db,
+    ):
+        """Regression for #529: the cache key is scope-independent, so a group
+        page (group_id) and the symbol-addressed endpoint (None) share the entry
+        when the symbol set + latest date match — no redundant recompute."""
+        _indicator_cache._data.clear()
+
+        row = _make_asset_row(1, "AAPL")
+        # Both entry points resolve the same symbol set to the same (id, symbol) row.
+        mock_asset_repo_cls.return_value.list_in_group_id_symbol_pairs = AsyncMock(return_value=[row])
+        mock_asset_repo_cls.return_value.list_id_symbol_pairs_by_symbols = AsyncMock(return_value=[row])
+
+        today = date.today()
+        prices = [_make_price(1, today - timedelta(days=i), 150.0 + i) for i in range(30)]
+        mock_price_repo_cls.return_value.list_by_assets_since = AsyncMock(return_value=prices)
+        mock_price_repo_cls.return_value.get_latest_date = AsyncMock(return_value=today)
+
+        mock_prices_to_df.return_value = MagicMock()
+        mock_compute_ind.return_value = MagicMock()
+        mock_build_snap.return_value = {"values": {"rsi": 55.0}}
+        mock_merge_fund.side_effect = _mock_merge_fundamentals({})
+
+        # Group call populates the cache.
+        await compute_and_cache_indicators(db, group_id=1)
+        calls_after_group = mock_compute_ind.call_count
+        assert calls_after_group > 0
+
+        # Symbol-addressed call for the same symbol set must hit that entry, not recompute.
+        await compute_indicators_for_symbols(db, ["AAPL"])
+        assert mock_compute_ind.call_count == calls_after_group
+
+        _indicator_cache._data.clear()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -45,6 +46,7 @@
     "shadcn": "^3.8.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vite:
         specifier: ^7.2.4
         version: 7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.10.12)(msw@2.12.9(@types/node@24.10.12)(typescript@5.9.3))(vite@7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2))
 
 packages:
 
@@ -1494,6 +1497,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
 
@@ -1616,8 +1622,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1728,6 +1740,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1806,6 +1847,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1888,6 +1933,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2146,6 +2195,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2241,6 +2293,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2264,6 +2319,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.2.1:
     resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
@@ -3133,6 +3192,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3217,6 +3280,9 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3511,6 +3577,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3532,9 +3601,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -3632,6 +3707,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -3639,6 +3717,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
@@ -3855,6 +3937,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3883,6 +4006,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -5323,6 +5451,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -5430,9 +5560,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -5577,6 +5714,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(msw@2.12.9(@types/node@24.10.12)(typescript@5.9.3))(vite@7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.9(@types/node@24.10.12)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -5666,6 +5845,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
@@ -5751,6 +5932,8 @@ snapshots:
   caniuse-lite@1.0.30001769: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6009,6 +6192,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -6169,6 +6354,10 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -6205,6 +6394,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.2.1(express@5.2.1):
     dependencies:
@@ -7163,6 +7354,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.3: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7263,6 +7456,8 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.3.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -7723,6 +7918,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7735,7 +7932,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -7838,12 +8039,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.23: {}
 
@@ -8053,6 +8258,33 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
+  vitest@4.1.10(@types/node@24.10.12)(msw@2.12.9(@types/node@24.10.12)(typescript@5.9.3))(vite@7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.12.9(@types/node@24.10.12)(typescript@5.9.3))(vite@7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@24.10.12)(jiti@2.6.1)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.12
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   which-boxed-primitive@1.1.1:
@@ -8103,6 +8335,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/frontend/src/components/assets/remove-asset-dialog.tsx
+++ b/frontend/src/components/assets/remove-asset-dialog.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react"
+import { AlertTriangle } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { useAssetAttachments, useHardDeleteAsset, useRemoveAssetFromGroup } from "@/lib/queries"
+import type { Asset, AssetAttachments } from "@/lib/api"
+
+interface RemoveAssetDialogProps {
+  asset: Asset | null
+  groupId: number
+  groupName: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/** The non-empty attachments a hard delete would cascade into. */
+function attachmentLines(a: AssetAttachments): { label: string; value: string }[] {
+  const lines: { label: string; value: string }[] = []
+  if (a.theses.length) lines.push({ label: "Theses", value: a.theses.join(", ") })
+  if (a.pseudo_etfs.length) lines.push({ label: "Pseudo-ETFs", value: a.pseudo_etfs.join(", ") })
+  if (a.tags.length) lines.push({ label: "Tags", value: a.tags.join(", ") })
+  if (a.has_note) lines.push({ label: "Note", value: "yes" })
+  if (a.annotation_count > 0) lines.push({ label: "Annotations", value: String(a.annotation_count) })
+  return lines
+}
+
+/**
+ * Confirms removing an asset from a group. When this is the asset's *last* group,
+ * it warns that the asset becomes an invisible orphan, lists what stays attached
+ * (theses / pseudo-ETFs / tags / note / annotations), and offers a hard delete —
+ * so the lifecycle decision is made with the attachments in view (see #536).
+ */
+export function RemoveAssetDialog({ asset, groupId, groupName, open, onOpenChange }: RemoveAssetDialogProps) {
+  const symbol = asset?.symbol ?? ""
+  const { data: attachments, isLoading } = useAssetAttachments(symbol, open && asset != null)
+  const [alsoDelete, setAlsoDelete] = useState(false)
+  const removeFromGroup = useRemoveAssetFromGroup()
+  const hardDelete = useHardDeleteAsset()
+
+  // Reset the hard-delete opt-in on every close, so a reopen starts unchecked.
+  const setOpen = (o: boolean) => {
+    if (!o) setAlsoDelete(false)
+    onOpenChange(o)
+  }
+
+  // Removing from this group orphans the asset when it's the only group it's in.
+  const willOrphan = attachments != null && attachments.groups.length <= 1
+  const pending = removeFromGroup.isPending || hardDelete.isPending
+  const lines = attachments ? attachmentLines(attachments) : []
+
+  const confirm = () => {
+    if (!asset) return
+    const done = () => setOpen(false)
+    if (alsoDelete) hardDelete.mutate(asset.symbol, { onSuccess: done })
+    else removeFromGroup.mutate({ groupId, assetId: asset.id }, { onSuccess: done })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Remove {symbol}?</DialogTitle>
+          <DialogDescription>
+            Remove <span className="font-medium text-foreground">{symbol}</span> from{" "}
+            <span className="font-medium text-foreground">{groupName}</span>.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && <p className="text-sm text-muted-foreground">Checking attachments…</p>}
+
+        {willOrphan && (
+          <div className="space-y-3">
+            <div className="flex gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+              <p>
+                <span className="font-medium">{symbol}</span> will no longer be in any group — it
+                becomes an invisible orphan, still tracked by its other attachments.
+              </p>
+            </div>
+            {lines.length > 0 && (
+              <div className="rounded-md border border-border p-3 text-sm">
+                <p className="mb-1 text-xs text-muted-foreground">Still attached to:</p>
+                <ul className="space-y-0.5">
+                  {lines.map((l) => (
+                    <li key={l.label}>
+                      <span className="text-muted-foreground">{l.label}:</span> {l.value}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <label htmlFor="also-delete-entirely" className="flex cursor-pointer items-start gap-2 text-sm">
+              <Checkbox
+                id="also-delete-entirely"
+                checked={alsoDelete}
+                onCheckedChange={(v) => setAlsoDelete(v === true)}
+                className="mt-0.5"
+              />
+              <span>
+                Also delete <span className="font-medium">{symbol}</span> entirely — removes it from
+                all groups, theses and pseudo-ETFs and deletes its note, tags and annotations. This
+                can’t be undone.
+              </span>
+            </label>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant={alsoDelete ? "destructive" : "default"}
+            onClick={confirm}
+            disabled={pending || isLoading}
+          >
+            {alsoDelete ? "Delete entirely" : "Remove"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/thesis/thesis-section-header.tsx
+++ b/frontend/src/components/thesis/thesis-section-header.tsx
@@ -80,7 +80,7 @@ export function ThesisSectionHeader({
         <ChangePct
           value={thesis.aggregate_pct}
           className="text-sm font-medium"
-          title="Equal-weight return of all members since the thesis opened (some may be in other groups or not shown)"
+          title="Equal-weight return of all members since the thesis opened"
         />
       )}
       {performance && performance.length > 1 && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   Annotation,
   AnnotationCreate,
   Asset,
+  AssetAttachments,
   AssetCreate,
   AssetDetail,
   AssetUpdate,
@@ -79,6 +80,11 @@ export const api = {
       request<Asset>("/assets", { method: "POST", body: JSON.stringify(data) }),
     update: (id: number, data: AssetUpdate) =>
       request<Asset>(`/assets/${id}`, { method: "PATCH", body: JSON.stringify(data) }),
+    attachments: (symbol: string) =>
+      request<AssetAttachments>(`/assets/${encodeURIComponent(symbol)}/attachments`),
+    // Hard delete: removes the row + all memberships/note/tags/annotations/prices.
+    hardDelete: (symbol: string) =>
+      request<void>(`/assets/${encodeURIComponent(symbol)}?hard=true`, { method: "DELETE" }),
   },
   prices: {
     detail: (symbol: string, period?: string) =>

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest"
+import { compactSigFig, formatCompactNumber, formatCompactPrice } from "./format"
+
+describe("compactSigFig", () => {
+  it("keeps ~3 significant figures so low-thousands prices stay distinct (NKT.CO case)", () => {
+    // The bug: 1,007 and 1,042 both collapsed to "1.0K" under fixed-1-decimal.
+    expect(compactSigFig(1007)).toBe("1.01K")
+    expect(compactSigFig(1042)).toBe("1.04K")
+    expect(compactSigFig(1090)).toBe("1.09K")
+    expect(compactSigFig(1122)).toBe("1.12K")
+  })
+
+  it("adapts decimals per magnitude band (2 → 1 → 0 integer digits)", () => {
+    expect(compactSigFig(1010)).toBe("1.01K") // 1.xxK → 2 decimals
+    expect(compactSigFig(72000)).toBe("72.0K") // xx.xK → 1 decimal
+    expect(compactSigFig(148500)).toBe("149K") //  xxxK → 0 decimals
+  })
+
+  it("retains trailing zeros for uniform width (no .0 stripping)", () => {
+    expect(compactSigFig(72000)).toBe("72.0K")
+    expect(compactSigFig(1400000)).toBe("1.40M")
+    expect(compactSigFig(2000000)).toBe("2.00M")
+    expect(compactSigFig(1000000000)).toBe("1.00B")
+  })
+
+  it("handles negatives", () => {
+    expect(compactSigFig(-1007)).toBe("-1.01K")
+    expect(compactSigFig(-1400000)).toBe("-1.40M")
+  })
+
+  it("crosses K/M/B boundaries and promotes on round-up", () => {
+    expect(compactSigFig(1000)).toBe("1.00K")
+    expect(compactSigFig(999000)).toBe("999K")
+    expect(compactSigFig(1000000)).toBe("1.00M")
+    // 999,700 rounds to "1000K" at 0 decimals → promote to the M band.
+    expect(compactSigFig(999700)).toBe("1.00M")
+    // 999,900,000 → "1000M" at the M band → promote to B.
+    expect(compactSigFig(999900000)).toBe("1.00B")
+  })
+})
+
+describe("formatCompactNumber", () => {
+  it("returns full integer precision below 1,000", () => {
+    expect(formatCompactNumber(990)).toBe("990")
+    expect(formatCompactNumber(500)).toBe("500")
+    expect(formatCompactNumber(0)).toBe("0")
+  })
+
+  it("abbreviates at/above 1,000 with sig figs", () => {
+    expect(formatCompactNumber(1007)).toBe("1.01K")
+    expect(formatCompactNumber(72000)).toBe("72.0K")
+    expect(formatCompactNumber(1400000)).toBe("1.40M")
+    expect(formatCompactNumber(-1042)).toBe("-1.04K")
+  })
+})
+
+describe("formatCompactPrice", () => {
+  it("keeps full currency precision below 1,000", () => {
+    expect(formatCompactPrice(990, "USD")).toBe("$990.00")
+    expect(formatCompactPrice(990, "KRW")).toBe("₩990") // zero-decimal currency
+  })
+
+  it("prefixes the currency symbol on the abbreviated form", () => {
+    expect(formatCompactPrice(1007, "USD")).toBe("$1.01K")
+    expect(formatCompactPrice(1400000, "USD")).toBe("$1.40M")
+    expect(formatCompactPrice(-1007, "USD")).toBe("$-1.01K")
+  })
+
+  it("handles currencies without a symbol (NKT.CO / DKK)", () => {
+    expect(formatCompactPrice(1122, "DKK")).toBe("DKK 1.12K")
+    expect(formatCompactPrice(72000, "DKK")).toBe("DKK 72.0K")
+  })
+})

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -75,26 +75,48 @@ export function formatAssetPrice(
   return isYieldIndex(asset.symbol) ? `${body}%` : body
 }
 
-export function formatCompactPrice(value: number, currency: string): string {
+/** Significant figures kept by the compact abbreviation. Tuning knob, not a user setting. */
+export const COMPACT_SIG_FIGS = 3
+
+// Suffix bands, largest first. Compact abbreviation only kicks in at |value| >= 1,000.
+const COMPACT_BANDS = [
+  { threshold: 1e9, divisor: 1e9, suffix: "B" },
+  { threshold: 1e6, divisor: 1e6, suffix: "M" },
+  { threshold: 1e3, divisor: 1e3, suffix: "K" },
+] as const
+
+/**
+ * Abbreviate `value` (|value| >= 1,000) to ~`sigFigs` significant figures with a
+ * K/M/B suffix — adaptive decimals per band (2 for `1.xxK`, 1 for `xx.xK`, 0 for
+ * `xxxK`). Trailing zeros are kept for uniform column width (`72.0K`, `1.40M`),
+ * unlike the old fixed-1-decimal formatter that stripped `.0` and collapsed
+ * distinct low-thousands prices (`1,007` and `1,042` both → `1.0K`).
+ */
+export function compactSigFig(value: number, sigFigs = COMPACT_SIG_FIGS): string {
   const abs = Math.abs(value)
-  const sym = currencySymbol(currency)
-  let scaled: string
-  if (abs >= 1e9) {
-    scaled = (value / 1e9).toFixed(1)
-    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
-    return `${sym}${scaled}B`
+  for (let i = 0; i < COMPACT_BANDS.length; i++) {
+    const { threshold, divisor, suffix } = COMPACT_BANDS[i]
+    if (abs < threshold) continue
+    const scaled = value / divisor
+    const intDigits = Math.floor(Math.abs(scaled)).toString().length
+    const decimals = Math.max(0, sigFigs - intDigits)
+    // Rounding can tip a value just under a band (e.g. 999,700 → "1000K"); when it
+    // rolls to 4 integer digits, promote to the next band up (→ "1.00M").
+    if (Math.abs(Number(scaled.toFixed(decimals))) >= 1000 && i > 0) {
+      const up = COMPACT_BANDS[i - 1]
+      const upScaled = value / up.divisor
+      const upDecimals = Math.max(0, sigFigs - Math.floor(Math.abs(upScaled)).toString().length)
+      return `${upScaled.toFixed(upDecimals)}${up.suffix}`
+    }
+    return `${scaled.toFixed(decimals)}${suffix}`
   }
-  if (abs >= 1e6) {
-    scaled = (value / 1e6).toFixed(1)
-    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
-    return `${sym}${scaled}M`
-  }
-  if (abs >= 1e3) {
-    scaled = (value / 1e3).toFixed(1)
-    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
-    return `${sym}${scaled}K`
-  }
-  return formatPrice(value, currency)
+  return value.toString()
+}
+
+export function formatCompactPrice(value: number, currency: string): string {
+  // Below 1,000 the abbreviation buys no width, so keep full currency precision.
+  if (Math.abs(value) < 1e3) return formatPrice(value, currency)
+  return `${currencySymbol(currency)}${compactSigFig(value)}`
 }
 
 export function formatAssetCompactPrice(value: number, asset: AssetFormatHints): string {
@@ -119,24 +141,9 @@ export function formatAssetPriceWithSettings(
 }
 
 export function formatCompactNumber(value: number): string {
-  const abs = Math.abs(value)
-  let scaled: string
-  if (abs >= 1e9) {
-    scaled = (value / 1e9).toFixed(1)
-    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
-    return `${scaled}B`
-  }
-  if (abs >= 1e6) {
-    scaled = (value / 1e6).toFixed(1)
-    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
-    return `${scaled}M`
-  }
-  if (abs >= 1e3) {
-    scaled = (value / 1e3).toFixed(1)
-    if (scaled.endsWith(".0")) scaled = scaled.slice(0, -2)
-    return `${scaled}K`
-  }
-  return value.toFixed(0)
+  // Same sig-fig rule as prices, for volume / chart axis / indicator cards.
+  if (Math.abs(value) < 1e3) return value.toFixed(0)
+  return compactSigFig(value)
 }
 
 export function changeColor(pct: number | null | undefined): string {

--- a/frontend/src/lib/queries/assets.ts
+++ b/frontend/src/lib/queries/assets.ts
@@ -1,9 +1,34 @@
-import { useQuery, keepPreviousData } from "@tanstack/react-query"
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { api, type AssetCreate, type AssetUpdate, type SymbolSearchResult } from "../api"
 import { keys, STALE_1MIN, STALE_5MIN, useInvalidatingMutation } from "./shared"
 
 export function useAssets() {
   return useQuery({ queryKey: keys.assets, queryFn: api.assets.list, staleTime: STALE_5MIN })
+}
+
+/** What is attached to an asset (groups/theses/pseudo-ETFs/tags/note/annotations).
+ *  Enabled-gated so it only fetches when the remove dialog is actually open. */
+export function useAssetAttachments(symbol: string, enabled: boolean) {
+  return useQuery({
+    queryKey: keys.assetAttachments(symbol),
+    queryFn: () => api.assets.attachments(symbol),
+    enabled: enabled && symbol.length > 0,
+    staleTime: STALE_1MIN,
+  })
+}
+
+/** Permanently delete an asset and everything attached to it. Invalidates every
+ *  view a membership could have appeared in (groups, listings, theses, pseudo-ETFs). */
+export function useHardDeleteAsset() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (symbol: string) => api.assets.hardDelete(symbol),
+    onSuccess: () => {
+      for (const key of [keys.groups, keys.assets, keys.theses, keys.pseudoEtfs]) {
+        qc.invalidateQueries({ queryKey: key })
+      }
+    },
+  })
 }
 
 export function useCreateAsset() {

--- a/frontend/src/lib/queries/index.ts
+++ b/frontend/src/lib/queries/index.ts
@@ -1,6 +1,6 @@
 export { keys, STALE_1MIN, STALE_5MIN, STALE_24H, useInvalidatingMutation } from "./shared"
 export { usePortfolioIndex, usePortfolioPerformers } from "./portfolio"
-export { useAssets, useCreateAsset, useUpdateAsset, useLocalSearch, useYahooSearch } from "./assets"
+export { useAssets, useCreateAsset, useUpdateAsset, useAssetAttachments, useHardDeleteAsset, useLocalSearch, useYahooSearch } from "./assets"
 export { useAssetDetail, useAssetWindow, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
 export { useEarnings } from "./earnings"
 export { useTags, useCreateTag, useAttachTag, useDetachTag } from "./tags"

--- a/frontend/src/lib/queries/shared.ts
+++ b/frontend/src/lib/queries/shared.ts
@@ -23,6 +23,7 @@ export const keys = {
   portfolioIndex: (period?: string) => ["portfolio-index", period] as const,
   portfolioPerformers: (period?: string) => ["portfolio-performers", period] as const,
   assets: ["assets"] as const,
+  assetAttachments: (symbol: string) => ["asset-attachments", symbol] as const,
   assetDetail: (symbol: string, period?: string) => ["asset-detail", symbol, period] as const,
   etfHoldings: (symbol: string) => ["etf-holdings", symbol] as const,
   holdingsIndicators: (symbol: string) => ["holdings-indicators", symbol] as const,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -36,6 +36,17 @@ export interface Asset {
   tags: TagBrief[]
 }
 
+/** What is attached to an asset — drives the remove dialog's orphan warning + hard-delete confirm. */
+export interface AssetAttachments {
+  symbol: string
+  groups: string[]
+  theses: string[]
+  pseudo_etfs: string[]
+  tags: string[]
+  has_note: boolean
+  annotation_count: number
+}
+
 export interface AssetCreate {
   symbol: string
   name?: string

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -121,12 +121,6 @@ export interface Note {
 
 export type ThesisStatus = "watching" | "live" | "played_out"
 
-export interface ThesisAssetBrief {
-  id: number
-  symbol: string
-  name: string
-}
-
 export interface Thesis {
   id: number
   name: string
@@ -136,7 +130,8 @@ export interface Thesis {
   status: ThesisStatus
   opened_at: string
   created_at: string
-  assets: ThesisAssetBrief[]
+  // Full member rows (backend returns AssetResponse), so groupless members render too.
+  assets: Asset[]
   aggregate_pct: number | null
 }
 

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -13,9 +13,10 @@ import { SegmentedControl } from "@/components/ui/segmented-control"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AddSymbolDialog } from "@/components/assets/add-symbol-dialog"
+import { RemoveAssetDialog } from "@/components/assets/remove-asset-dialog"
 import { AssetCard } from "@/components/assets/asset-card"
 import { TagFilterPopover } from "@/components/tags/tag-filter-popover"
-import { useGroup, useGroups, useGroupSparklines, useGroupIndicators, useRemoveAssetFromGroup, useUpdateGroup, useTags, useTheses, usePrefetchAssetDetail, usePrefetchOtherGroups } from "@/lib/queries"
+import { useGroup, useGroups, useGroupSparklines, useGroupIndicators, useUpdateGroup, useTags, useTheses, usePrefetchAssetDetail, usePrefetchOtherGroups } from "@/lib/queries"
 import { useQuotes } from "@/lib/quote-stream"
 import { buildSortOptions, getScannableDescriptors } from "@/lib/indicator-registry"
 import { useSettings, type AssetTypeFilter, type GroupSortBy, type GroupViewMode, type SortDir } from "@/lib/settings"
@@ -39,7 +40,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
   const { data: allTags } = useTags()
   const { data: theses } = useTheses()
   const { data: allGroups } = useGroups()
-  const removeFromGroup = useRemoveAssetFromGroup()
+  const [removeTarget, setRemoveTarget] = useState<Asset | null>(null)
   const [selectedTags, setSelectedTags] = useState<number[]>([])
   const [sparklinePeriod, setSparklinePeriod] = useState("3mo")
   const { settings, updateSettings } = useSettings()
@@ -177,8 +178,8 @@ export function GroupPage({ groupId }: { groupId: number }) {
 
   const handleRemove = useCallback((symbol: string) => {
     const asset = allAssets?.find((a) => a.symbol === symbol)
-    if (asset) removeFromGroup.mutate({ groupId, assetId: asset.id })
-  }, [allAssets, removeFromGroup, groupId])
+    if (asset) setRemoveTarget(asset)
+  }, [allAssets])
 
   const toggleTag = (id: number) =>
     setSelectedTags((prev) =>
@@ -409,6 +410,16 @@ export function GroupPage({ groupId }: { groupId: number }) {
         </div>
       )}
       </div>
+
+      <RemoveAssetDialog
+        asset={removeTarget}
+        groupId={groupId}
+        groupName={group?.name ?? "this group"}
+        open={removeTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) setRemoveTarget(null)
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/theses/index.tsx
+++ b/frontend/src/pages/theses/index.tsx
@@ -1,11 +1,10 @@
 import { useMemo, useState } from "react"
 import { ChevronsDownUp, ChevronsUpDown, Pencil } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { useTheses, useThesesPerformance, useGroups, useIndicators } from "@/lib/queries"
+import { useTheses, useThesesPerformance, useIndicators } from "@/lib/queries"
 import { useQuotes } from "@/lib/quote-stream"
 import { useSettings } from "@/lib/settings"
-import type { Asset, Thesis, ThesisPerformancePoint } from "@/lib/api"
-import { buildAssetsById } from "@/lib/assets"
+import type { Thesis, ThesisPerformancePoint } from "@/lib/api"
 import { GroupTable } from "@/components/group-table"
 import { ThesisSectionHeader } from "@/components/thesis/thesis-section-header"
 import { ThesisMemberContextMenuContent } from "@/components/thesis/thesis-member-context-menu"
@@ -15,17 +14,12 @@ import { EditThesisDialog } from "@/components/thesis/edit-thesis-dialog"
 export function ThesesPage() {
   const { data: theses, isLoading } = useTheses()
   const { data: performance } = useThesesPerformance()
-  const { data: groups } = useGroups()
   const quotes = useQuotes()
   const { settings } = useSettings()
 
   const [expanded, setExpanded] = useState<Set<number>>(new Set())
   const [showPlayedOut, setShowPlayedOut] = useState(false)
   const [editThesis, setEditThesis] = useState<Thesis | null>(null)
-
-  // Thesis members only carry id/symbol/name; resolve them to full Asset objects
-  // (sourced from every group) so we can render the rich GroupTable rows.
-  const assetsById = useMemo(() => buildAssetsById(groups ?? []), [groups])
 
   const perfById = useMemo(() => {
     const map = new Map<number, ThesisPerformancePoint[]>()
@@ -50,26 +44,15 @@ export function ThesesPage() {
     })
   }, [allTheses, showPlayedOut])
 
-  const membersByThesis = useMemo(() => {
-    const map = new Map<number, Asset[]>()
-    for (const t of allTheses) {
-      map.set(
-        t.id,
-        t.assets.map((m) => assetsById.get(m.id)).filter((a): a is Asset => a != null),
-      )
-    }
-    return map
-  }, [allTheses, assetsById])
-
   // Fetch indicators only for the members of expanded theses (lazy on expand).
   const expandedSymbols = useMemo(() => {
     const syms = new Set<string>()
     for (const t of visible) {
       if (!expanded.has(t.id)) continue
-      for (const a of membersByThesis.get(t.id) ?? []) syms.add(a.symbol)
+      for (const a of t.assets) syms.add(a.symbol)
     }
     return [...syms]
-  }, [visible, expanded, membersByThesis])
+  }, [visible, expanded])
   const { data: indicators } = useIndicators(expandedSymbols)
 
   const toggle = (id: number) =>
@@ -132,8 +115,7 @@ export function ThesesPage() {
         <div className="space-y-3">
           {visible.map((thesis) => {
             const isOpen = expanded.has(thesis.id)
-            const members = membersByThesis.get(thesis.id) ?? []
-            const unresolved = thesis.assets.length - members.length
+            const members = thesis.assets
             return (
               <section key={thesis.id} className="rounded-md border border-border p-2">
                 <ThesisSectionHeader
@@ -177,12 +159,7 @@ export function ThesesPage() {
                       />
                     ) : (
                       <p className="px-2 py-3 text-sm text-muted-foreground">
-                        No members in any group yet.
-                      </p>
-                    )}
-                    {unresolved > 0 && (
-                      <p className="px-2 text-xs text-muted-foreground">
-                        +{unresolved} member{unresolved === 1 ? "" : "s"} not in any group
+                        No members yet.
                       </p>
                     )}
                   </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,15 @@
 import path from "path"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig } from "vitest/config"
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
   build: {
     chunkSizeWarningLimit: 600,
     rollupOptions: {


### PR DESCRIPTION
Batch of four backlog issues, one commit each. Verified in-container: backend `pytest` (673 passed), frontend `pnpm lint` + `pnpm build` + `pnpm test` (10 passed) all green.

Closes #529
Closes #530
Closes #533
Closes #536

---

### `perf(backend)` #529 — drop redundant `scope` from the indicator cache key
Snapshot values depend purely on `(symbols, latest_price_date)`; `group_id` was only a key disambiguator that fragmented the cache across groups with the same symbol set. Key is now `(frozenset(symbols), latest_date)`, so group pages and the symbol-addressed `/api/indicators` endpoint share entries. Added a cross-scope cache-sharing regression test.

### `feat(frontend)` #530 — significant-figure compact number formatting
Fixed-1-decimal compaction collapsed distinct low-thousands prices (NKT.CO `1,007` and `1,042` both → `1.0K`). Now ~3 sig figs with adaptive decimals per band (`1.01K` / `72.0K` / `149K` / `1.40M`), trailing zeros kept for column uniformity, sub-1,000 unchanged. Routed both `formatCompactPrice` and `formatCompactNumber` through one `compactSigFig` helper.
**Note:** this issue asked for unit tests but the frontend had **no test harness** — this PR stands up **vitest** (dev dep + `pnpm test` script + `test-frontend` CI step) and adds `format.test.ts`.

### `fix(thesis)` #533 — return thesis members as full assets so groupless ones render
The theses page reconstructed members from `useGroups()`, silently dropping any member in no group while still counting it in the headline aggregate. `ThesisResponse.assets` now carries full `AssetResponse` rows (type/currency/tags — `Asset.tags` is already `lazy="selectin"`, so no extra eager-load), and the page renders `thesis.assets` directly. Removes the reconstruction and the "+N not in any group" workaround.

### `feat(assets)` #536 — remove dialog: last-group warning + hard delete with cascade
Removing an asset from its only group fired instantly and silently, leaving an invisible orphan that kept skewing live thesis aggregates (the COFF.L/COCO.L incident). Now:
- **`GET /api/assets/{symbol}/attachments`** — group / thesis / pseudo-ETF / tag / note / annotation summary.
- **`DELETE /api/assets/{symbol}?hard=true`** — full cascade delete. Associations are cleared **explicitly** so it behaves identically on Postgres and SQLite (which doesn't enforce `ON DELETE CASCADE`) with no async ORM-cascade lazy-load. Soft delete (default-group only) is unchanged.
- **`RemoveAssetDialog`** — on a last-group removal, warns, lists what stays attached, and offers an opt-in "delete entirely". `group-page` remove now opens this dialog instead of mutating immediately.

---

**Out of scope / deliberately not done:** `#536`'s "orphan visibility" (`Unassigned` section) and a `migrate OLD NEW` primitive — both noted as separate follow-ups in the issue.

An untracked `scripts/` dir in the working tree is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
