### PR TITLE
chore(backend): add ruff (lint + import sort) with a CI gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
           cache-dependency-glob: backend/requirements*.txt
 
       - run: uv pip install --system -r requirements-dev.txt
+      - run: ruff check .
       - run: pytest
       - run: uv pip install --system pip-audit
       - run: pip-audit -r requirements.txt

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -3,17 +3,18 @@ import sys
 from logging.config import fileConfig
 from pathlib import Path
 
-from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
 
 # Ensure the backend root (/app) is on sys.path so `app.*` imports resolve
 # when alembic is invoked as a CLI command.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from app.database import Base  # noqa: E402
-from app.config import settings  # noqa: E402
 import app.models  # noqa: E402,F401 — register all models with Base.metadata
+from app.config import settings  # noqa: E402
+from app.database import Base  # noqa: E402
 
 config = context.config
 config.set_main_option("sqlalchemy.url", settings.database_url)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,8 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
-from pathlib import Path
-
 from datetime import date
+from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -13,14 +12,32 @@ from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
 from app.config import settings as app_settings
-
 from app.database import async_session, engine
-from app.routers import annotations, assets, companion, data, groups, holdings, indicators, note, portfolio, prices, pseudo_etfs, pseudo_etf_analysis, quotes, search, settings as settings_router, symbol_sources, tags, thesis
-from app.services.price_sync import sync_all_prices
+from app.routers import (
+    annotations,
+    assets,
+    companion,
+    data,
+    groups,
+    holdings,
+    indicators,
+    note,
+    portfolio,
+    prices,
+    pseudo_etf_analysis,
+    pseudo_etfs,
+    quotes,
+    search,
+    symbol_sources,
+    tags,
+    thesis,
+)
+from app.routers import settings as settings_router
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
+from app.services.intraday import cleanup_old_intraday, fetch_and_store_intraday
 from app.services.price_providers import init_price_provider
-from app.services.intraday import fetch_and_store_intraday, cleanup_old_intraday
+from app.services.price_sync import sync_all_prices
 from app.services.symbol_sync_service import sync_all_enabled as sync_all_symbol_sources
 
 logger = logging.getLogger(__name__)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,13 +1,13 @@
-from app.models.asset import Asset, AssetType  # noqa: F401
-from app.models.group import Group, group_assets  # noqa: F401
-from app.models.price import PriceHistory  # noqa: F401
 from app.models.annotation import Annotation  # noqa: F401
+from app.models.asset import Asset, AssetType  # noqa: F401
+from app.models.currency import Currency  # noqa: F401
+from app.models.group import Group, group_assets  # noqa: F401
+from app.models.intraday import IntradayPrice  # noqa: F401
 from app.models.note import Note  # noqa: F401
+from app.models.price import PriceHistory  # noqa: F401
+from app.models.pseudo_etf import PseudoETF, PseudoEtfAnnotation, PseudoEtfNote, pseudo_etf_constituents  # noqa: F401
+from app.models.symbol_directory import SymbolDirectory  # noqa: F401
+from app.models.symbol_source import SymbolSource  # noqa: F401
 from app.models.tag import Tag, tag_assets  # noqa: F401
 from app.models.thesis import Thesis, ThesisStatus, thesis_assets  # noqa: F401
-from app.models.pseudo_etf import PseudoETF, PseudoEtfAnnotation, PseudoEtfNote, pseudo_etf_constituents  # noqa: F401
 from app.models.user_settings import UserSettings  # noqa: F401
-from app.models.symbol_source import SymbolSource  # noqa: F401
-from app.models.symbol_directory import SymbolDirectory  # noqa: F401
-from app.models.currency import Currency  # noqa: F401
-from app.models.intraday import IntradayPrice  # noqa: F401

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -31,8 +31,8 @@ class Asset(Base):
 
 
 # Avoid circular import issues - these are resolved at runtime
-from app.models.price import PriceHistory  # noqa: E402, F401
 from app.models.annotation import Annotation  # noqa: E402, F401
 from app.models.note import Note  # noqa: E402, F401
+from app.models.price import PriceHistory  # noqa: E402, F401
 from app.models.tag import Tag, tag_assets  # noqa: E402, F401
 from app.models.thesis import Thesis, thesis_assets  # noqa: E402, F401

--- a/backend/app/models/symbol_source.py
+++ b/backend/app/models/symbol_source.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Integer, JSON, String, func
+from sqlalchemy import JSON, Boolean, DateTime, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,12 +1,12 @@
-from app.repositories.asset_repo import AssetRepository
-from app.repositories.price_repo import PriceRepository
 from app.repositories.annotation_repo import AnnotationRepository
-from app.repositories.note_repo import NoteRepository
-from app.repositories.tag_repo import TagRepository
-from app.repositories.thesis_repo import ThesisRepository
+from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
+from app.repositories.note_repo import NoteRepository
+from app.repositories.price_repo import PriceRepository
 from app.repositories.pseudo_etf_repo import PseudoEtfRepository
 from app.repositories.settings_repo import SettingsRepository
+from app.repositories.tag_repo import TagRepository
+from app.repositories.thesis_repo import ThesisRepository
 
 __all__ = [
     "AssetRepository",

--- a/backend/app/repositories/price_repo.py
+++ b/backend/app/repositories/price_repo.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 import pandas as pd
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import PriceHistory

--- a/backend/app/routers/annotations.py
+++ b/backend/app/routers/annotations.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.services.entity_lookups import get_asset
 from app.schemas.annotation import AnnotationCreate, AnnotationResponse
 from app.services import annotation_service
+from app.services.entity_lookups import get_asset
 
 router = APIRouter(prefix="/api/assets/{symbol}/annotations", tags=["annotations"])
 

--- a/backend/app/routers/note.py
+++ b/backend/app/routers/note.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.services.entity_lookups import get_asset
 from app.schemas.note import NoteResponse, NoteUpdate
 from app.services import note_service
+from app.services.entity_lookups import get_asset
 
 router = APIRouter(prefix="/api/assets/{symbol}/note", tags=["note"])
 

--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -3,11 +3,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.constants import PeriodType
 from app.database import get_db
-from app.services.entity_lookups import find_asset, get_asset
 from app.schemas.earnings import EarningsResponse
 from app.schemas.price import AssetDetailResponse, IndicatorResponse, PriceResponse, RefreshResponse
 from app.services import price_service
 from app.services.earnings_cache import get_earnings
+from app.services.entity_lookups import find_asset, get_asset
 
 router = APIRouter(prefix="/api/assets/{symbol}", tags=["prices"])
 

--- a/backend/app/routers/pseudo_etf_analysis.py
+++ b/backend/app/routers/pseudo_etf_analysis.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.services.entity_lookups import get_pseudo_etf
-from app.schemas.pseudo_etf import PerformanceBreakdownPoint, ConstituentIndicatorResponse
-from app.services.compute.pseudo_etf import calculate_performance
+from app.schemas.pseudo_etf import ConstituentIndicatorResponse, PerformanceBreakdownPoint
 from app.services.compute.indicators import compute_batch_indicator_snapshots
+from app.services.compute.pseudo_etf import calculate_performance
+from app.services.entity_lookups import get_pseudo_etf
 from app.services.fundamentals_cache import merge_fundamentals_into_batch
 
 router = APIRouter(prefix="/api/pseudo-etfs", tags=["pseudo-etfs"])

--- a/backend/app/routers/pseudo_etfs.py
+++ b/backend/app/routers/pseudo_etfs.py
@@ -2,14 +2,14 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.pseudo_etf import (
-    PseudoETFCreate,
-    PseudoETFUpdate,
-    PseudoETFAddConstituents,
-    PseudoETFResponse,
-)
-from app.schemas.note import NoteResponse, NoteUpdate
 from app.schemas.annotation import AnnotationCreate, AnnotationResponse
+from app.schemas.note import NoteResponse, NoteUpdate
+from app.schemas.pseudo_etf import (
+    PseudoETFAddConstituents,
+    PseudoETFCreate,
+    PseudoETFResponse,
+    PseudoETFUpdate,
+)
 from app.services import pseudo_etf_service
 
 router = APIRouter(prefix="/api/pseudo-etfs", tags=["pseudo-etfs"])

--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -474,12 +474,12 @@ def _compute_deltas(result: pd.DataFrame, window: int = 20) -> None:
       - {field}_delta_sigma = |Δ| expressed in rolling σ units, only when
         the absolute delta exceeds mean + 2σ of the rolling window (else NaN).
     """
-    for field in _get_delta_fields():
-        if field not in result.columns:
+    for field_name in _get_delta_fields():
+        if field_name not in result.columns:
             continue
-        series = result[field]
+        series = result[field_name]
         delta = series.diff()
-        result[f"{field}_delta"] = delta
+        result[f"{field_name}_delta"] = delta
 
         abs_delta = delta.abs()
         rolling_mean = abs_delta.rolling(window=window, min_periods=window).mean()
@@ -487,7 +487,7 @@ def _compute_deltas(result: pd.DataFrame, window: int = 20) -> None:
 
         sigma = (abs_delta - rolling_mean) / rolling_std
         # Only keep sigma when |Δ| exceeds the 2σ threshold
-        result[f"{field}_delta_sigma"] = sigma.where(
+        result[f"{field_name}_delta_sigma"] = sigma.where(
             abs_delta > rolling_mean + 2 * rolling_std
         )
 

--- a/backend/app/services/compute/pseudo_etf.py
+++ b/backend/app/services/compute/pseudo_etf.py
@@ -25,7 +25,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.price_repo import PriceRepository
 
-
 QUARTER_MONTHS = {1, 4, 7, 10}
 
 

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -2,10 +2,9 @@
 
 from datetime import date, datetime, timedelta
 
+import pandas as pd
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-
-import pandas as pd
 
 from app.constants import PERIOD_DAYS, WARMUP_DAYS
 from app.models import Asset, PriceHistory

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -2,7 +2,8 @@
 
 from datetime import datetime, timezone
 
-from sqlalchemy import or_, select, func as sa_func
+from sqlalchemy import func as sa_func
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.symbol_directory import SymbolDirectory

--- a/backend/app/services/symbol_sync_service.py
+++ b/backend/app/services/symbol_sync_service.py
@@ -1,7 +1,7 @@
 """Sync service — orchestrates provider execution and symbol_directory upserts."""
 
 import logging
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert

--- a/backend/app/services/yahoo/client.py
+++ b/backend/app/services/yahoo/client.py
@@ -34,6 +34,8 @@ from app.services.yahoo._validation import _ValidationMixin
 from app.services.yahoo.rate_limit import (
     CrumbRejected,
     YahooThrottle,
+)
+from app.services.yahoo.rate_limit import (
     yahoo_throttle as _shared_throttle,
 )
 from app.utils import TTLCache

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,15 @@
+# Ruff config for the backend. Intentionally lenient to start: catch the real
+# footguns (unused imports, undefined names, import order) with near-zero style
+# noise. Broaden `select` over time; a type checker (pyright/mypy) is a separate
+# follow-up for the None-access / return-type class of issues ruff can't see.
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+extend-exclude = ["alembic/versions"]
+
+[tool.ruff.lint]
+# F = pyflakes (unused imports, undefined names, f-string bugs, …), I = isort.
+select = ["F", "I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["app", "tests"]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest==8.3.5
 pytest-asyncio==0.25.3
 httpx==0.28.1
 aiosqlite==0.21.0
+ruff==0.15.21

--- a/backend/scripts/probe_yahoo_session_reuse.py
+++ b/backend/scripts/probe_yahoo_session_reuse.py
@@ -44,6 +44,7 @@ def show(after_label: str):
 async def main():
     global _label
     from yahooquery import Ticker
+
     from app.services.yahoo.client import YahooClient
     from app.services.yahoo.rate_limit import YahooThrottle
 

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -5,7 +5,6 @@ import pytest
 
 from app.services import asset_service
 
-
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 

--- a/backend/tests/integration/test_data.py
+++ b/backend/tests/integration/test_data.py
@@ -1,7 +1,8 @@
 """Tests for GET /api/data batch query endpoint."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from tests.helpers import make_yahoo_df, seed_asset_with_prices
 

--- a/backend/tests/integration/test_groups.py
+++ b/backend/tests/integration/test_groups.py
@@ -1,7 +1,8 @@
 """Tests for group endpoints — CRUD and batch (sparklines, indicators)."""
 
-import pytest
 from datetime import date, timedelta
+
+import pytest
 
 from app.models import Asset, AssetType, PriceHistory
 from app.repositories.group_repo import GroupRepository

--- a/backend/tests/integration/test_holdings.py
+++ b/backend/tests/integration/test_holdings.py
@@ -1,7 +1,8 @@
 """Tests for the holdings router (ETF holdings + holding indicators)."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock, MagicMock
 
 from app.services.compute.indicators import bb_position
 from app.services.yahoo import yahoo_client

--- a/backend/tests/integration/test_note_annotations.py
+++ b/backend/tests/integration/test_note_annotations.py
@@ -2,7 +2,6 @@ import pytest
 
 from tests.helpers import create_asset_via_api
 
-
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 

--- a/backend/tests/integration/test_prices.py
+++ b/backend/tests/integration/test_prices.py
@@ -1,8 +1,9 @@
 """Tests for the prices router (GET /prices, GET /indicators, POST /refresh)."""
 
-import pytest
 from datetime import date, timedelta
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from tests.helpers import make_yahoo_df, seed_asset_with_prices
 

--- a/backend/tests/integration/test_pseudo_etf.py
+++ b/backend/tests/integration/test_pseudo_etf.py
@@ -2,7 +2,6 @@ import pytest
 
 from tests.helpers import create_asset_via_api
 
-
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 

--- a/backend/tests/integration/test_pseudo_etf_analysis.py
+++ b/backend/tests/integration/test_pseudo_etf_analysis.py
@@ -1,7 +1,7 @@
 """Integration tests for pseudo-ETF analysis router (performance + constituent indicators)."""
 
 from datetime import date, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/backend/tests/integration/test_quotes.py
+++ b/backend/tests/integration/test_quotes.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import patch, AsyncMock, MagicMock
 
 from app.services.quote_service import _reset_asset_list_cache
 from tests.conftest import TestSession

--- a/backend/tests/integration/test_search.py
+++ b/backend/tests/integration/test_search.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.models.symbol_directory import SymbolDirectory
-from tests.conftest import TestSession
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 

--- a/backend/tests/integration/test_symbol_sources.py
+++ b/backend/tests/integration/test_symbol_sources.py
@@ -1,12 +1,9 @@
 """Integration tests for the symbol sources router."""
 
-from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.models.symbol_source import SymbolSource
 from app.models.symbol_directory import SymbolDirectory
-from tests.conftest import TestSession
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 

--- a/backend/tests/integration/test_tags.py
+++ b/backend/tests/integration/test_tags.py
@@ -2,7 +2,6 @@ import pytest
 
 from tests.helpers import create_asset_via_api
 
-
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
@@ -48,7 +47,7 @@ async def test_duplicate_tag_name(client):
 
 
 async def test_attach_tag_to_asset(client):
-    asset = await create_asset_via_api(client, "AAPL", "Apple")
+    await create_asset_via_api(client, "AAPL", "Apple")
     tag_resp = await client.post("/api/tags", json={"name": "tech"})
     tid = tag_resp.json()["id"]
 
@@ -60,7 +59,7 @@ async def test_attach_tag_to_asset(client):
 
 
 async def test_detach_tag_from_asset(client):
-    asset = await create_asset_via_api(client, "AAPL", "Apple")
+    await create_asset_via_api(client, "AAPL", "Apple")
     t1 = (await client.post("/api/tags", json={"name": "tech"})).json()
     t2 = (await client.post("/api/tags", json={"name": "growth"})).json()
 
@@ -75,7 +74,7 @@ async def test_detach_tag_from_asset(client):
 
 
 async def test_tags_appear_in_asset_response(client):
-    asset = await create_asset_via_api(client, "AAPL", "Apple")
+    await create_asset_via_api(client, "AAPL", "Apple")
     tag_resp = await client.post("/api/tags", json={"name": "tech"})
     tid = tag_resp.json()["id"]
 

--- a/backend/tests/repositories/test_annotation_repo.py
+++ b/backend/tests/repositories/test_annotation_repo.py
@@ -4,7 +4,6 @@ from datetime import date
 
 import pytest
 
-from app.models import Annotation, Asset, AssetType
 from app.repositories.annotation_repo import AnnotationRepository
 from tests.helpers import create_test_asset as _create_asset
 

--- a/backend/tests/repositories/test_asset_repo.py
+++ b/backend/tests/repositories/test_asset_repo.py
@@ -86,7 +86,7 @@ async def test_list_in_any_group_symbols(db):
 
 async def test_list_in_group_id_symbol_pairs(db):
     aapl = await _create_asset(db, "AAPL")
-    msft = await _create_asset(db, "MSFT")
+    await _create_asset(db, "MSFT")
     await _add_to_default_group(db, aapl)
 
     default_group = await GroupRepository(db).get_default()
@@ -123,7 +123,7 @@ async def test_create_and_save(db):
 
 async def test_get_by_ids(db):
     a1 = await _create_asset(db, "AAPL")
-    a2 = await _create_asset(db, "MSFT")
+    await _create_asset(db, "MSFT")
     a3 = await _create_asset(db, "GOOGL")
     repo = AssetRepository(db)
 

--- a/backend/tests/repositories/test_group_repo.py
+++ b/backend/tests/repositories/test_group_repo.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from app.models import Group
 from app.repositories.group_repo import GroupRepository
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")

--- a/backend/tests/repositories/test_note_repo.py
+++ b/backend/tests/repositories/test_note_repo.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from app.models import Asset, AssetType, Note
 from app.repositories.note_repo import NoteRepository
 from tests.helpers import create_test_asset as _create_asset
 

--- a/backend/tests/repositories/test_price_repo.py
+++ b/backend/tests/repositories/test_price_repo.py
@@ -1,11 +1,11 @@
 """Tests for PriceRepository — date-range queries and aggregations against real SQLite DB."""
 
-import pytest
 from datetime import date, timedelta
 
 import pandas as pd
+import pytest
 
-from app.models import Asset, AssetType, PriceHistory
+from app.models import PriceHistory
 from app.repositories.price_repo import PriceRepository
 from tests.helpers import create_test_asset as _create_asset
 

--- a/backend/tests/repositories/test_pseudo_etf_repo.py
+++ b/backend/tests/repositories/test_pseudo_etf_repo.py
@@ -1,9 +1,10 @@
 """Tests for PseudoEtfRepository — CRUD, note, and annotation operations."""
 
-import pytest
 from datetime import date
 
-from app.models.pseudo_etf import PseudoETF, PseudoEtfAnnotation, PseudoEtfNote
+import pytest
+
+from app.models.pseudo_etf import PseudoETF
 from app.repositories.pseudo_etf_repo import PseudoEtfRepository
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")

--- a/backend/tests/repositories/test_settings_repo.py
+++ b/backend/tests/repositories/test_settings_repo.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from app.models.user_settings import UserSettings
 from app.repositories.settings_repo import SettingsRepository
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")

--- a/backend/tests/repositories/test_tag_repo.py
+++ b/backend/tests/repositories/test_tag_repo.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from app.models import Tag
 from app.repositories.tag_repo import TagRepository
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")

--- a/backend/tests/services/test_annotation_service.py
+++ b/backend/tests/services/test_annotation_service.py
@@ -1,7 +1,8 @@
 """Unit tests for annotation_service — tests service logic with mocked repos."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.services.annotation_service import (
     create_annotation,

--- a/backend/tests/services/test_asset_service.py
+++ b/backend/tests/services/test_asset_service.py
@@ -1,7 +1,8 @@
 """Unit tests for asset_service — tests service logic with mocked repos."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.models import AssetType
 from app.services.asset_service import create_asset, delete_asset, list_assets, update_asset

--- a/backend/tests/services/test_currency_service.py
+++ b/backend/tests/services/test_currency_service.py
@@ -1,10 +1,10 @@
 """Tests for the currency lookup service (cache + DB integration)."""
 
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
 from app.models.currency import Currency
-from app.services.currency_service import _cache, load_cache, lookup, ensure_currency
+from app.services.currency_service import _cache, ensure_currency, load_cache, lookup
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 

--- a/backend/tests/services/test_earnings.py
+++ b/backend/tests/services/test_earnings.py
@@ -8,6 +8,8 @@ import pytest
 from app.services.yahoo import yahoo_client
 from app.services.yahoo._parsers import (
     last_reported_date as _extract_last_reported_date,
+)
+from app.services.yahoo._parsers import (
     parse_earnings_date as _parse_earnings_date,
 )
 

--- a/backend/tests/services/test_group_service.py
+++ b/backend/tests/services/test_group_service.py
@@ -1,7 +1,8 @@
 """Unit tests for group_service — tests service logic with mocked repos."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.services.group_service import (
     add_assets,

--- a/backend/tests/services/test_holdings_service.py
+++ b/backend/tests/services/test_holdings_service.py
@@ -1,7 +1,8 @@
 """Unit tests for holdings_service — tests service logic with mocked lookups."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.services.holdings_service import get_holdings, get_holdings_indicators
 

--- a/backend/tests/services/test_note_service.py
+++ b/backend/tests/services/test_note_service.py
@@ -1,9 +1,9 @@
 """Unit tests for note_service — tests service logic with mocked repos."""
 
 import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.schemas.note import NoteResponse
 from app.services.note_service import get_note, upsert_note

--- a/backend/tests/services/test_price_service.py
+++ b/backend/tests/services/test_price_service.py
@@ -1,23 +1,21 @@
 """Unit tests for price_service — tests caching, ephemeral fetch, warmup logic."""
 
-import pytest
 from datetime import date, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
+import pytest
 
-from app.models import Asset, AssetType, PriceHistory
+from app.models import PriceHistory
 from app.services.price_service import (
     _backfill_already_attempted,
     _display_start,
     _earliest_date_cache,
     _fetch_ephemeral,
-    get_detail,
     get_indicators,
     get_prices,
     refresh_prices,
 )
-
 from tests.helpers import make_model_asset as _make_asset
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -1,17 +1,17 @@
 """Tests for the price_sync service (sync orchestration and upsert logic)."""
 
-import pytest
 from datetime import date
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from app.models import Asset, AssetType
 from app.services.price_sync import (
+    _upsert_prices,
+    sync_all_prices,
     sync_asset_prices,
     sync_asset_prices_range,
-    sync_all_prices,
-    _upsert_prices,
 )
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")

--- a/backend/tests/services/test_pseudo_etf_service.py
+++ b/backend/tests/services/test_pseudo_etf_service.py
@@ -1,7 +1,8 @@
 """Unit tests for pseudo_etf_service — CRUD, constituents, note, annotations."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.models import Asset
 from app.models.pseudo_etf import PseudoETF, PseudoEtfAnnotation, PseudoEtfNote

--- a/backend/tests/services/test_quote_service.py
+++ b/backend/tests/services/test_quote_service.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.services.quote_service import get_quotes, quote_event_generator
 

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -1,10 +1,11 @@
 """Unit tests for search_service — DB-backed symbol directory with Yahoo fallback."""
 
-import pytest
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from app.models.symbol_directory import SymbolDirectory
-from app.services.search_service import search_symbols, _parse_yahoo_results
+from app.services.search_service import _parse_yahoo_results, search_symbols
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 

--- a/backend/tests/services/test_settings_service.py
+++ b/backend/tests/services/test_settings_service.py
@@ -1,7 +1,8 @@
 """Unit tests for settings_service — tests service logic with mocked repos."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.schemas.settings import SettingsResponse
 from app.services.settings_service import get_settings, update_settings

--- a/backend/tests/services/test_symbol_providers.py
+++ b/backend/tests/services/test_symbol_providers.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from app.services.symbol_providers import get_provider, get_available_providers
-from app.services.symbol_providers.euronext import _resolve_market, EuronextProvider
+from app.services.symbol_providers import get_available_providers, get_provider
+from app.services.symbol_providers.euronext import EuronextProvider, _resolve_market
 from app.services.symbol_providers.xetra import XetraProvider
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
@@ -130,7 +130,6 @@ SAMPLE_ETFS_CSV = """\
 
 def _make_mock_client(stocks_csv, etfs_csv):
     """Create a mock httpx.AsyncClient that returns different CSVs per URL."""
-    from app.services.symbol_providers.euronext import EURONEXT_STOCKS_URL, EURONEXT_ETFS_URL
 
     class MockResponse:
         def __init__(self, text):

--- a/backend/tests/services/test_symbol_sync_service.py
+++ b/backend/tests/services/test_symbol_sync_service.py
@@ -1,10 +1,8 @@
 """Tests for symbol sync service (provider execution and symbol_directory upserts)."""
 
-from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from sqlalchemy import select
 
 from app.models.symbol_source import SymbolSource
 from app.services.symbol_providers.base import SymbolEntry

--- a/backend/tests/services/test_tag_service.py
+++ b/backend/tests/services/test_tag_service.py
@@ -1,9 +1,10 @@
 """Unit tests for tag_service — CRUD, attach/detach M2M operations."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.models import Asset, Tag
+import pytest
+
+from app.models import Tag
 from app.services.tag_service import (
     attach_tag,
     create_tag,

--- a/backend/tests/services/test_yahoo_currency.py
+++ b/backend/tests/services/test_yahoo_currency.py
@@ -5,9 +5,9 @@ import pytest
 
 from app.services.yahoo import (
     EXCHANGE_CURRENCY_MAP,
+    _normalize_ohlcv_df,
     currency_from_suffix,
     resolve_currency,
-    _normalize_ohlcv_df,
 )
 
 

--- a/backend/tests/services/test_yahoo_fundamentals.py
+++ b/backend/tests/services/test_yahoo_fundamentals.py
@@ -1,6 +1,5 @@
 """Tests for Yahoo Finance fundamental metrics fetching."""
 
-import math
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +7,8 @@ import pytest
 from app.services.yahoo import yahoo_client
 from app.services.yahoo._parsers import (
     FUNDAMENTAL_FIELDS,
+)
+from app.services.yahoo._parsers import (
     safe_float as _safe_float,
 )
 

--- a/backend/tests/services/test_yahoo_history.py
+++ b/backend/tests/services/test_yahoo_history.py
@@ -125,8 +125,9 @@ class TestFetchHistory:
     @patch("app.services.yahoo.client.Ticker")
     async def test_normalizes_mixed_date_datetime_index(self, mock_ticker_cls):
         """Yahoo can append a tz-aware datetime row for intraday data to daily date index."""
-        import pytz
         from datetime import datetime as dt
+
+        import pytz
 
         daily_dates = [date(2026, 4, 2), date(2026, 4, 3)]
         intraday = dt(2026, 4, 6, 9, 0, tzinfo=pytz.timezone("Asia/Seoul"))

--- a/backend/tests/services/test_yahoo_quotes.py
+++ b/backend/tests/services/test_yahoo_quotes.py
@@ -7,6 +7,8 @@ import pytest
 from app.services.yahoo import yahoo_client
 from app.services.yahoo._parsers import (
     parse_quotes as _parse_quotes,
+)
+from app.services.yahoo._parsers import (
     sanitize_float as _sanitize_float,
 )
 from app.services.yahoo.rate_limit import crumb_rejected


### PR DESCRIPTION
Follow-up to a discussion about catching the class of issues we kept hitting (unused imports, import order, shadowing). The backend had **no static-analysis gate** — CI ran only `pytest` + `pip-audit`, while the frontend has eslint + tsc. This closes that asymmetry with **ruff**.

## What's added
- `backend/pyproject.toml` — ruff config, deliberately **lenient to start**: `select = ["F", "I"]` (pyflakes + isort), `line-length = 120`, migrations excluded.
- `ruff==0.15.21` in `requirements-dev.txt`.
- `ruff check .` step in the `test-backend` CI job (before `pytest`).

## The 87 findings it surfaced (all fixed → `ruff check` is clean)
| | count | how |
|---|---|---|
| unsorted-imports (I001) | 51 | auto-fixed |
| unused-import (F401) | 30 | auto-fixed — **all in test files**; no `app/` imports removed |
| unused-variable (F841) | 5 | manual: dropped `x = await …` bindings, kept the call |
| import-shadowed-by-loop-var (F402) | 1 | manual: renamed a `field` loop var in `indicators.py` that shadowed `dataclasses.field` |

## Why this shape
- **ruff, not pylint** — ruff reimplements most of pylint's useful rules and runs ~100× faster; pylint is effectively superseded.
- **F + I only** — near-zero false positives. Broaden `select` (bugbear, pyupgrade, …) in follow-ups once the baseline is green.
- **Type checking is out of scope** — the `Group | None` access / return-type-mismatch class needs pyright/mypy, which is a separate PR (a first run surfaces a batch of pre-existing pandas-stub findings to work through).

## Reviewer note
The big file count is mechanical: import reordering + unused-import removal, mostly in tests. App files got **only** import reordering. isort alphabetized the runtime circular-import blocks in `models/asset.py` and `models/__init__.py` — they stay bottom-of-file / re-exports with `# noqa` intact, are order-independent, and the passing suite confirms it.

**Verification:** `ruff check .` clean · full backend `pytest` green (667 passed).

An untracked `scripts/` dir is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
