### PR TITLE
feat: volatility-normalized return (σ-move) indicator (#543)

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -84,6 +84,30 @@ def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
     return _wilder_smooth(tr, period)
 
 
+def volatility_normalized_return(closes: pd.Series, lam: float = 0.94) -> pd.Series:
+    """Volatility-normalized daily return — a "sigma move" / return z-score.
+
+    Expresses each day's close-to-close return in units of the asset's own
+    recent volatility, so moves become comparable across assets regardless of
+    how volatile each one usually is: a +3% day in a calm name can be a bigger
+    event (larger sigma move) than a +6% day in a high-beta name. A value of
+    +2.0 means "today's up-move was twice the size recent volatility predicted".
+
+    Volatility is a RiskMetrics-style zero-mean EWMA forecast built from returns
+    through the *previous* day (``shift(1)``), so a large move does not deflate
+    its own score. ``lam`` is the EWMA decay (RiskMetrics daily default 0.94);
+    a larger lam means longer memory. Unlike a fixed rolling window, the EWMA
+    has no hard edge, so an old shock decays smoothly instead of dropping out
+    abruptly and stepping the score ("ghosting").
+    """
+    returns = closes.pct_change()
+    # RiskMetrics zero-mean EWMA variance: sigma^2_t = lam*sigma^2_{t-1} + (1-lam)*r^2_{t-1}
+    ewma_var = (returns**2).ewm(alpha=1 - lam, adjust=False).mean()
+    # Forecast vol from data through the previous day; guard flat series (0 -> NaN).
+    sigma_forecast = np.sqrt(ewma_var.shift(1)).replace(0, float("nan"))
+    return returns / sigma_forecast
+
+
 def adx(df: pd.DataFrame, period: int = 14) -> dict[str, pd.Series]:
     """Average Directional Index with +DI and -DI using Wilder's smoothing.
 
@@ -401,6 +425,13 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
         warmup_periods=14,
         uses_ohlc=True,
         snapshot_derived=_chop_snapshot_derived,
+    ),
+    "vnr": IndicatorDef(
+        func=volatility_normalized_return,
+        params={"lam": 0.94},
+        output_fields=["vnr"],
+        decimals=2,
+        warmup_periods=60,
     ),
 }
 

--- a/backend/tests/services/test_indicators.py
+++ b/backend/tests/services/test_indicators.py
@@ -17,6 +17,7 @@ from app.services.compute.indicators import (
     normalized_force_index,
     rsi,
     sma,
+    volatility_normalized_return,
 )
 from tests.helpers import make_price_df as _make_price_df
 
@@ -465,3 +466,97 @@ def test_nefi_snapshot_crossover_signal():
     assert "values" in snapshot
     assert "nefi_signal" in snapshot["values"]
     assert snapshot["values"]["nefi_signal"] in ("bullish", "bearish", None)
+
+
+# ---------------------------------------------------------------------------
+# Volatility-normalized return (σ-move / return z-score) tests (#543)
+# ---------------------------------------------------------------------------
+
+
+def _series_from_returns(returns: list[float], start: float = 100.0) -> pd.Series:
+    """Build a close series from a list of simple returns (cumulative product)."""
+    closes = [start]
+    for r in returns:
+        closes.append(closes[-1] * (1 + r))
+    return pd.Series(closes)
+
+
+def test_vnr_length():
+    """VNR output should have the same length as its input."""
+    df = _make_price_df(100)
+    result = volatility_normalized_return(df["close"])
+    assert len(result) == 100
+
+
+def test_vnr_first_value_nan():
+    """First value is NaN — there is no prior close to compute a return from."""
+    df = _make_price_df(100)
+    result = volatility_normalized_return(df["close"])
+    assert pd.isna(result.iloc[0])
+
+
+def test_vnr_in_compute_indicators():
+    """VNR should appear as a column in compute_indicators output."""
+    df = _make_price_df(100)
+    result = compute_indicators(df)
+    assert "vnr" in result.columns
+    valid = result["vnr"].dropna()
+    assert len(valid) > 0
+
+
+def test_vnr_in_snapshot():
+    """vnr should appear in snapshot values."""
+    df = _make_price_df(200)
+    snapshot = build_indicator_snapshot(compute_indicators(df))
+    assert "values" in snapshot
+    assert "vnr" in snapshot["values"]
+
+
+def test_vnr_in_all_output_fields():
+    """vnr should be listed in get_all_output_fields."""
+    assert "vnr" in get_all_output_fields()
+
+
+def test_vnr_sign_matches_return():
+    """A day that closes up gets a positive σ-move; a down day gets a negative one."""
+    up = _series_from_returns([0.01, -0.01] * 40 + [0.02])
+    down = _series_from_returns([0.01, -0.01] * 40 + [-0.02])
+    assert volatility_normalized_return(up).iloc[-1] > 0
+    assert volatility_normalized_return(down).iloc[-1] < 0
+
+
+def test_vnr_normalizes_across_volatility_regimes():
+    """The core property: a move that is 2× the asset's own typical move scores
+    ~2σ regardless of the asset's absolute volatility level.
+
+    Asset A oscillates ±1%/day; asset B ±4%/day (4× more volatile). Both take a
+    final move of exactly twice their usual size. Their σ-moves should be nearly
+    equal (~2.0) even though B's headline % move is 4× A's.
+    """
+    calm = _series_from_returns([0.01, -0.01] * 60 + [0.02])
+    wild = _series_from_returns([0.04, -0.04] * 60 + [0.08])
+
+    vnr_calm = volatility_normalized_return(calm).iloc[-1]
+    vnr_wild = volatility_normalized_return(wild).iloc[-1]
+
+    assert vnr_calm == pytest.approx(2.0, abs=0.05)
+    assert vnr_wild == pytest.approx(2.0, abs=0.05)
+    # Same normalized surprise despite a 4× difference in raw move size.
+    assert abs(vnr_calm - vnr_wild) < 0.05
+
+
+def test_vnr_flat_series_no_inf():
+    """A flat (zero-volatility) series must not produce inf (division guard)."""
+    result = volatility_normalized_return(pd.Series([100.0] * 50))
+    assert not np.isinf(result.to_numpy()[~np.isnan(result.to_numpy())]).any()
+
+
+def test_vnr_lambda_affects_result():
+    """The decay `lam` must actually feed through: on a series with *varying*
+    volatility, different decays produce different σ-moves. (On a constant-vol
+    series every decay converges to the same estimate, so a real-world varying
+    series is used here.)"""
+    df = _make_price_df(200)
+    fast = volatility_normalized_return(df["close"], lam=0.80).iloc[-1]
+    slow = volatility_normalized_return(df["close"], lam=0.97).iloc[-1]
+    assert fast != pytest.approx(slow)

--- a/frontend/src/components/group-table/shared.ts
+++ b/frontend/src/components/group-table/shared.ts
@@ -19,6 +19,7 @@ export function isColumnVisible(columnSettings: Record<string, boolean>, key: st
 const RESPONSIVE_HIDE_BREAKPOINTS: Record<string, number> = {
   adx: 1280,
   atr_pct: 1280,
+  vnr: 1280,
   avg_volume: 1280,
   atr: 1024,
   volume: 1024,

--- a/frontend/src/lib/indicator-descriptors.ts
+++ b/frontend/src/lib/indicator-descriptors.ts
@@ -185,6 +185,34 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
     holdingSummary: { label: "ATR%", field: "atr_pct", format: "numeric" },
   },
   {
+    id: "vnr",
+    label: "σ-Move",
+    shortLabel: "σ-Move",
+    description:
+      "Volatility-normalized daily return — today's move in units of the asset's own EWMA volatility. Puts every asset on one scale: ±1σ is a typical day, ±2σ or more is a genuine surprise regardless of headline %.",
+    category: "volatility",
+    placement: "card",
+    capabilities: ["group_table", "group_card", "detail_card", "detail_stats"],
+    defaults: ["group_table", "detail_card"],
+    fields: ["vnr"],
+    sortableFields: ["vnr"],
+    series: [
+      {
+        field: "vnr",
+        label: "σ-Move",
+        color: "#eab308",
+        lineWidth: 2,
+        thresholdColors: [
+          { condition: "gte", value: 0, className: "text-emerald-500" },
+          { condition: "lt", value: 0, className: "text-red-500" },
+        ],
+      },
+    ],
+    decimals: 2,
+    suffix: "σ",
+    holdingSummary: { label: "σ-Move", field: "vnr", format: "numeric" },
+  },
+  {
     id: "adx",
     label: "ADX (14)",
     shortLabel: "ADX",


### PR DESCRIPTION
Closes #543 (on merge to `main`; this PR targets `dev` for staging validation first).

## What
Adds `vnr` — the **volatility-normalized daily return** ("σ-move" / return z-score). Each day's close-to-close return is expressed in units of the asset's own EWMA volatility, so moves are comparable across assets on one scale: a +3% day in a calm name can outrank a +6% day in a high-beta one. ±1σ ≈ a typical day; ±2σ+ is a genuine surprise regardless of headline %.

## How
- **Backend** (`indicators.py`): `volatility_normalized_return(closes, lam=0.94)` + `INDICATOR_REGISTRY["vnr"]`. Volatility is a RiskMetrics-style zero-mean EWMA variance, taken as a **one-day-ahead forecast** (`shift(1)`) so a large move can't deflate its own denominator. Flat/zero-vol series guarded against div-by-zero (`0 → NaN`). Registered so warmup, caching and the snapshot pick it up automatically.
- **Frontend** (`indicator-descriptors.ts`): σ-Move descriptor — volatility category, sortable group-table column + detail card, sign-colored (green up / red down), `σ` suffix. Hidden below 1280px like ATR%/ADX (`group-table/shared.ts`).
- **Tests**: 10 cases, including the core cross-volatility normalization property (a 2× move scores ~2σ regardless of the asset's absolute vol level).

## Verification
- Backend: **675 passed** (full suite; network-bound holdings deselected). `ruff check .` clean.
- Frontend: `pnpm lint` clean, `pnpm build` (tsc + vite) succeeds.
- Live smoke test on the running dev backend: `GET /api/assets/NKT.CO/indicators` returns `vnr` (1.19σ last bar), no non-finite values leaked.

## Design note
Sort is **signed** descending (biggest up-surprises top, down-surprises bottom) — consistent with all other columns and matching the scan-both-ends workflow. Magnitude sort was considered and deferred (trivial declarative follow-up).

## Follow-ups (not in this PR)
- Cheaper MVP sibling `change%/atr%` ("move in ATRs") — discussed as a quick win; can coexist.
- Optional magnitude-sort toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)