### PR TITLE
chore: split test_indicators.py into category-grouped files (#545)

### DIFF
--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -100,6 +100,14 @@ def make_price_df(n: int = 100, start_price: float = 100.0) -> pd.DataFrame:
     }, index=dates)
 
 
+def make_series_from_returns(returns: list[float], start: float = 100.0) -> pd.Series:
+    """Build a close series from a list of simple returns (cumulative product)."""
+    closes = [start]
+    for r in returns:
+        closes.append(closes[-1] * (1 + r))
+    return pd.Series(closes)
+
+
 # ---------------------------------------------------------------------------
 # Repository test helpers — real SQLAlchemy model instances (need db session)
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_indicators_core.py
+++ b/backend/tests/services/test_indicators_core.py
@@ -1,0 +1,27 @@
+"""Registry-level indicator tests — cross-cutting machinery that exercises the
+whole INDICATOR_REGISTRY rather than any single indicator."""
+
+from app.services.compute.indicators import compute_indicators, get_all_output_fields
+from tests.helpers import make_price_df as _make_price_df
+
+
+def test_compute_indicators_columns():
+    df = _make_price_df()
+    result = compute_indicators(df)
+    expected_cols = {"close"} | set(get_all_output_fields())
+    assert set(result.columns) == expected_cols
+
+
+def test_compute_indicators_length():
+    df = _make_price_df(100)
+    result = compute_indicators(df)
+    assert len(result) == 100
+
+
+def test_atr_adx_in_all_output_fields():
+    """ATR and ADX fields should be listed in get_all_output_fields."""
+    fields = get_all_output_fields()
+    assert "atr" in fields
+    assert "adx" in fields
+    assert "plus_di" in fields
+    assert "minus_di" in fields

--- a/backend/tests/services/test_indicators_technical.py
+++ b/backend/tests/services/test_indicators_technical.py
@@ -1,0 +1,171 @@
+"""Tests for momentum / trend / volume-flow indicators: RSI, SMA, MACD, NEFI, CMF."""
+
+import pandas as pd
+import pytest
+
+from app.services.compute.indicators import (
+    build_indicator_snapshot,
+    chaikin_money_flow,
+    compute_indicators,
+    macd,
+    normalized_force_index,
+    rsi,
+    sma,
+)
+from tests.helpers import make_price_df as _make_price_df
+
+
+def test_rsi_range():
+    df = _make_price_df()
+    result = rsi(df["close"])
+    valid = result.dropna()
+    assert all(0 <= v <= 100 for v in valid)
+
+
+def test_rsi_period_start_is_nan():
+    df = _make_price_df()
+    result = rsi(df["close"], period=14)
+    assert pd.isna(result.iloc[0])
+
+
+def test_sma_correct():
+    data = pd.Series([1, 2, 3, 4, 5], dtype=float)
+    result = sma(data, 3)
+    assert result.iloc[2] == pytest.approx(2.0)
+    assert result.iloc[4] == pytest.approx(4.0)
+
+
+def test_macd_keys():
+    df = _make_price_df()
+    result = macd(df["close"])
+    assert "macd" in result
+    assert "signal" in result
+    assert "histogram" in result
+
+
+def test_nefi_keys():
+    """NEFI should return nefi_short and nefi_long."""
+    df = _make_price_df(300)
+    result = normalized_force_index(df)
+    assert "nefi_short" in result
+    assert "nefi_long" in result
+
+
+def test_nefi_length():
+    """NEFI output should have same length as input."""
+    df = _make_price_df(300)
+    result = normalized_force_index(df)
+    assert len(result["nefi_short"]) == 300
+    assert len(result["nefi_long"]) == 300
+
+
+def test_nefi_in_compute_indicators():
+    """NEFI fields should appear in compute_indicators output."""
+    df = _make_price_df(300)
+    result = compute_indicators(df)
+    assert "nefi_short" in result.columns
+    assert "nefi_long" in result.columns
+
+
+def test_nefi_scales_with_price_not_volume():
+    """NEFI should be comparable across assets with different volume levels.
+
+    Two assets with identical price moves but 10× different volume
+    should produce similar short NEFI values (since volume cancels out).
+    """
+    n = 100
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    prices = [100.0 + i * 0.5 for i in range(n)]
+
+    # Asset A: low volume
+    df_a = pd.DataFrame({
+        "open": [p - 0.3 for p in prices],
+        "high": [p + 0.5 for p in prices],
+        "low": [p - 0.5 for p in prices],
+        "close": prices,
+        "volume": [100_000] * n,
+    }, index=dates)
+
+    # Asset B: 10× higher volume, same prices
+    df_b = pd.DataFrame({
+        "open": [p - 0.3 for p in prices],
+        "high": [p + 0.5 for p in prices],
+        "low": [p - 0.5 for p in prices],
+        "close": prices,
+        "volume": [1_000_000] * n,
+    }, index=dates)
+
+    nefi_a = normalized_force_index(df_a)["nefi_short"].dropna().iloc[-1]
+    nefi_b = normalized_force_index(df_b)["nefi_short"].dropna().iloc[-1]
+
+    # Should be approximately equal (volume normalizes out)
+    assert abs(nefi_a - nefi_b) < 0.01, f"NEFI should normalize volume: A={nefi_a}, B={nefi_b}"
+
+
+def test_nefi_snapshot_crossover_signal():
+    """NEFI snapshot should classify bullish/bearish based on short vs long crossover."""
+    df = _make_price_df(300)
+    indicators = compute_indicators(df)
+    snapshot = build_indicator_snapshot(indicators)
+    assert "values" in snapshot
+    assert "nefi_signal" in snapshot["values"]
+    assert snapshot["values"]["nefi_signal"] in ("bullish", "bearish", None)
+
+
+def test_cmf_range():
+    """CMF values should be between -1 and +1."""
+    df = _make_price_df(200)
+    result = chaikin_money_flow(df)
+    valid = result.dropna()
+    assert len(valid) > 0
+    assert all(-1 <= v <= 1 for v in valid), "CMF values out of -1 to +1 range"
+
+
+def test_cmf_length():
+    """CMF output should have same length as input."""
+    df = _make_price_df(100)
+    result = chaikin_money_flow(df)
+    assert len(result) == 100
+
+
+def test_cmf_warmup_nans():
+    """CMF should have NaN values during the warmup period."""
+    df = _make_price_df(30)
+    result = chaikin_money_flow(df, period=20)
+    assert pd.isna(result.iloc[0])
+
+
+def test_cmf_in_compute_indicators():
+    """CMF should appear in compute_indicators output."""
+    df = _make_price_df(100)
+    result = compute_indicators(df)
+    assert "cmf" in result.columns
+    valid = result["cmf"].dropna()
+    assert len(valid) > 0
+    assert all(-1 <= v <= 1 for v in valid)
+
+
+def test_cmf_positive_for_closes_near_high():
+    """CMF should be positive when closes are consistently near highs."""
+    n = 100
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    df = pd.DataFrame({
+        "open": [100.0] * n,
+        "high": [105.0] * n,
+        "low": [95.0] * n,
+        "close": [104.0] * n,  # Close near high → positive MF multiplier
+        "volume": [1_000_000] * n,
+    }, index=dates)
+    result = chaikin_money_flow(df)
+    last_valid = result.dropna().iloc[-1]
+    assert last_valid > 0, f"CMF should be positive for closes near highs, got {last_valid}"
+
+
+def test_cmf_snapshot_derived():
+    """CMF snapshot should classify buying/selling pressure."""
+    df = _make_price_df(200)
+    indicators = compute_indicators(df)
+    snapshot = build_indicator_snapshot(indicators)
+    assert "values" in snapshot
+    assert "cmf_signal" in snapshot["values"]
+    assert snapshot["values"]["cmf_signal"] in ("buying", "selling", None)

--- a/backend/tests/services/test_indicators_volatility.py
+++ b/backend/tests/services/test_indicators_volatility.py
@@ -1,4 +1,5 @@
-"""Tests for the indicator computation service (no DB needed)."""
+"""Tests for volatility / range indicators: ATR, ATR%, ADX, Choppiness, and the
+volatility-normalized return (sigma-move)."""
 
 import numpy as np
 import pandas as pd
@@ -9,63 +10,17 @@ from app.services.compute.indicators import (
     adx,
     atr,
     build_indicator_snapshot,
-    chaikin_money_flow,
     choppiness_index,
     compute_indicators,
     get_all_output_fields,
-    macd,
-    normalized_force_index,
-    rsi,
-    sma,
     volatility_normalized_return,
 )
-from tests.helpers import make_price_df as _make_price_df
-
-
-def test_rsi_range():
-    df = _make_price_df()
-    result = rsi(df["close"])
-    valid = result.dropna()
-    assert all(0 <= v <= 100 for v in valid)
-
-
-def test_rsi_period_start_is_nan():
-    df = _make_price_df()
-    result = rsi(df["close"], period=14)
-    assert pd.isna(result.iloc[0])
-
-
-def test_sma_correct():
-    data = pd.Series([1, 2, 3, 4, 5], dtype=float)
-    result = sma(data, 3)
-    assert result.iloc[2] == pytest.approx(2.0)
-    assert result.iloc[4] == pytest.approx(4.0)
-
-
-def test_macd_keys():
-    df = _make_price_df()
-    result = macd(df["close"])
-    assert "macd" in result
-    assert "signal" in result
-    assert "histogram" in result
-
-
-def test_compute_indicators_columns():
-    df = _make_price_df()
-    result = compute_indicators(df)
-    expected_cols = {"close"} | set(get_all_output_fields())
-    assert set(result.columns) == expected_cols
-
-
-def test_compute_indicators_length():
-    df = _make_price_df(100)
-    result = compute_indicators(df)
-    assert len(result) == 100
-
-
-# ---------------------------------------------------------------------------
-# ATR tests (#214)
-# ---------------------------------------------------------------------------
+from tests.helpers import (
+    make_price_df as _make_price_df,
+)
+from tests.helpers import (
+    make_series_from_returns as _series_from_returns,
+)
 
 
 def test_true_range_basic():
@@ -128,11 +83,6 @@ def test_atr_in_compute_indicators():
     valid = result["atr"].dropna()
     assert len(valid) > 0
     assert all(v > 0 for v in valid)
-
-
-# ---------------------------------------------------------------------------
-# ADX tests (#215)
-# ---------------------------------------------------------------------------
 
 
 def test_adx_keys():
@@ -203,11 +153,6 @@ def test_adx_snapshot_derived():
     assert snapshot["values"]["adx_trend"] in ("strong", "weak", "absent", None)
 
 
-# ---------------------------------------------------------------------------
-# ATR% tests (#399)
-# ---------------------------------------------------------------------------
-
-
 def test_atr_pct_in_snapshot():
     """atr_pct should appear in snapshot values and be positive."""
     df = _make_price_df(200)
@@ -254,20 +199,6 @@ def test_atr_pct_in_compute_indicators():
     valid = result["atr_pct"].dropna()
     assert len(valid) > 0
     assert all(v > 0 for v in valid)
-
-
-def test_atr_adx_in_all_output_fields():
-    """ATR and ADX fields should be listed in get_all_output_fields."""
-    fields = get_all_output_fields()
-    assert "atr" in fields
-    assert "adx" in fields
-    assert "plus_di" in fields
-    assert "minus_di" in fields
-
-
-# ---------------------------------------------------------------------------
-# Choppiness Index tests (#482)
-# ---------------------------------------------------------------------------
 
 
 def test_chop_range():
@@ -328,157 +259,6 @@ def test_chop_snapshot_derived():
     assert "values" in snapshot
     assert "chop_state" in snapshot["values"]
     assert snapshot["values"]["chop_state"] in ("choppy", "trending", "neutral", None)
-
-
-# ---------------------------------------------------------------------------
-# Chaikin Money Flow tests (#483)
-# ---------------------------------------------------------------------------
-
-
-def test_cmf_range():
-    """CMF values should be between -1 and +1."""
-    df = _make_price_df(200)
-    result = chaikin_money_flow(df)
-    valid = result.dropna()
-    assert len(valid) > 0
-    assert all(-1 <= v <= 1 for v in valid), "CMF values out of -1 to +1 range"
-
-
-def test_cmf_length():
-    """CMF output should have same length as input."""
-    df = _make_price_df(100)
-    result = chaikin_money_flow(df)
-    assert len(result) == 100
-
-
-def test_cmf_warmup_nans():
-    """CMF should have NaN values during the warmup period."""
-    df = _make_price_df(30)
-    result = chaikin_money_flow(df, period=20)
-    assert pd.isna(result.iloc[0])
-
-
-def test_cmf_in_compute_indicators():
-    """CMF should appear in compute_indicators output."""
-    df = _make_price_df(100)
-    result = compute_indicators(df)
-    assert "cmf" in result.columns
-    valid = result["cmf"].dropna()
-    assert len(valid) > 0
-    assert all(-1 <= v <= 1 for v in valid)
-
-
-def test_cmf_positive_for_closes_near_high():
-    """CMF should be positive when closes are consistently near highs."""
-    n = 100
-    dates = pd.date_range("2024-01-01", periods=n, freq="B")
-    df = pd.DataFrame({
-        "open": [100.0] * n,
-        "high": [105.0] * n,
-        "low": [95.0] * n,
-        "close": [104.0] * n,  # Close near high → positive MF multiplier
-        "volume": [1_000_000] * n,
-    }, index=dates)
-    result = chaikin_money_flow(df)
-    last_valid = result.dropna().iloc[-1]
-    assert last_valid > 0, f"CMF should be positive for closes near highs, got {last_valid}"
-
-
-def test_cmf_snapshot_derived():
-    """CMF snapshot should classify buying/selling pressure."""
-    df = _make_price_df(200)
-    indicators = compute_indicators(df)
-    snapshot = build_indicator_snapshot(indicators)
-    assert "values" in snapshot
-    assert "cmf_signal" in snapshot["values"]
-    assert snapshot["values"]["cmf_signal"] in ("buying", "selling", None)
-
-
-# ---------------------------------------------------------------------------
-# Normalized Elder's Force Index (NEFI) tests (#484)
-# ---------------------------------------------------------------------------
-
-
-def test_nefi_keys():
-    """NEFI should return nefi_short and nefi_long."""
-    df = _make_price_df(300)
-    result = normalized_force_index(df)
-    assert "nefi_short" in result
-    assert "nefi_long" in result
-
-
-def test_nefi_length():
-    """NEFI output should have same length as input."""
-    df = _make_price_df(300)
-    result = normalized_force_index(df)
-    assert len(result["nefi_short"]) == 300
-    assert len(result["nefi_long"]) == 300
-
-
-def test_nefi_in_compute_indicators():
-    """NEFI fields should appear in compute_indicators output."""
-    df = _make_price_df(300)
-    result = compute_indicators(df)
-    assert "nefi_short" in result.columns
-    assert "nefi_long" in result.columns
-
-
-def test_nefi_scales_with_price_not_volume():
-    """NEFI should be comparable across assets with different volume levels.
-
-    Two assets with identical price moves but 10× different volume
-    should produce similar short NEFI values (since volume cancels out).
-    """
-    n = 100
-    dates = pd.date_range("2024-01-01", periods=n, freq="B")
-    prices = [100.0 + i * 0.5 for i in range(n)]
-
-    # Asset A: low volume
-    df_a = pd.DataFrame({
-        "open": [p - 0.3 for p in prices],
-        "high": [p + 0.5 for p in prices],
-        "low": [p - 0.5 for p in prices],
-        "close": prices,
-        "volume": [100_000] * n,
-    }, index=dates)
-
-    # Asset B: 10× higher volume, same prices
-    df_b = pd.DataFrame({
-        "open": [p - 0.3 for p in prices],
-        "high": [p + 0.5 for p in prices],
-        "low": [p - 0.5 for p in prices],
-        "close": prices,
-        "volume": [1_000_000] * n,
-    }, index=dates)
-
-    nefi_a = normalized_force_index(df_a)["nefi_short"].dropna().iloc[-1]
-    nefi_b = normalized_force_index(df_b)["nefi_short"].dropna().iloc[-1]
-
-    # Should be approximately equal (volume normalizes out)
-    assert abs(nefi_a - nefi_b) < 0.01, f"NEFI should normalize volume: A={nefi_a}, B={nefi_b}"
-
-
-def test_nefi_snapshot_crossover_signal():
-    """NEFI snapshot should classify bullish/bearish based on short vs long crossover."""
-    df = _make_price_df(300)
-    indicators = compute_indicators(df)
-    snapshot = build_indicator_snapshot(indicators)
-    assert "values" in snapshot
-    assert "nefi_signal" in snapshot["values"]
-    assert snapshot["values"]["nefi_signal"] in ("bullish", "bearish", None)
-
-
-# ---------------------------------------------------------------------------
-# Volatility-normalized return (σ-move / return z-score) tests (#543)
-# ---------------------------------------------------------------------------
-
-
-def _series_from_returns(returns: list[float], start: float = 100.0) -> pd.Series:
-    """Build a close series from a list of simple returns (cumulative product)."""
-    closes = [start]
-    for r in returns:
-        closes.append(closes[-1] * (1 + r))
-    return pd.Series(closes)
 
 
 def test_vnr_length():


### PR DESCRIPTION
Closes #545 (on merge to `main`). Targets `dev` — the split includes the `vnr` tests, whose indicator only exists on `dev`, so this can't go to `main` until #544 promotes.

## What
Splits the 562-line `test_indicators.py` (the suite's largest file, growing with every new indicator) into three cohesive files, grouped by the frontend registry's category taxonomy:

| File | Indicators | Tests |
|---|---|---|
| `test_indicators_technical.py` | rsi, sma, macd, nefi, cmf | 15 |
| `test_indicators_volatility.py` | atr, atr_pct, adx, chop, vnr | 32 |
| `test_indicators_core.py` | registry/compute cross-cutting | 3 |

## How
- **Pure move.** Each test body is byte-identical — extracted via `ast` (start..end_lineno slices), not retyped — so no assertion could have drifted.
- `_series_from_returns` relocated to `tests/helpers.py` as the public `make_series_from_returns`, aliased back on import so the test bodies are unchanged.
- Per-file imports trimmed to exactly what each uses (ruff `F`/`I` clean).

## Verification
- **Same 50 tests collected** (`--collect-only`) — nothing silently dropped.
- Full backend suite: **675 passed** (unchanged from before the split; network-bound holdings deselected).
- `ruff check .` clean.
- No other test files touched; no references to the old module remain.

## Note
`test_indicators_volatility.py` is the largest at 342 lines — cohesive (one category), well under the old 562. If the volatility group keeps growing it can split again later; not warranted now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)