### PR TITLE
feat: drag-to-reorder indicator columns in the group table

### DIFF
--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -22,6 +22,9 @@ class AppSettingsData(BaseModel):
     group_sort_dir: Literal["asc", "desc"] | None = None
     group_table_columns: dict[str, bool] | None = None
     group_table_column_widths: dict[str, float] | None = None
+    # Persisted left-to-right order of the indicator columns (list of field ids).
+    # Empty/absent = registry order. Stale/new fields are reconciled client-side.
+    group_table_column_order: list[str] | None = None
     # Thesis layout for the table view, plus whether the list view clusters a
     # thesis's members together when sorting. Legacy keys (`group_by_thesis`, the
     # old "none"/"inline" thesis_grouping values) are tolerated via extra="allow"

--- a/backend/tests/integration/test_settings.py
+++ b/backend/tests/integration/test_settings.py
@@ -25,6 +25,19 @@ async def test_put_get_roundtrip(client):
     assert resp.json()["data"] == {"chart_type": "line", "decimal_places": 4}
 
 
+async def test_put_get_column_order_roundtrip(client):
+    order = ["macd", "rsi", "atr_pct"]
+    await client.put("/api/settings", json={"data": {"group_table_column_order": order}})
+    resp = await client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["group_table_column_order"] == order
+
+
+async def test_put_rejects_non_list_column_order(client):
+    resp = await client.put("/api/settings", json={"data": {"group_table_column_order": "macd"}})
+    assert resp.status_code == 422
+
+
 async def test_put_overwrites(client):
     await client.put("/api/settings", json={"data": {"theme": "dark"}})
     await client.put("/api/settings", json={"data": {"theme": "light", "extra": 1}})

--- a/frontend/src/components/group-table/column-visibility-menu.tsx
+++ b/frontend/src/components/group-table/column-visibility-menu.tsx
@@ -1,85 +1,187 @@
 import { useMemo } from "react"
-import { Settings2 } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { Settings2, GripVertical } from "lucide-react"
 import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuCheckboxItem,
-} from "@/components/ui/dropdown-menu"
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
 import { getSeriesByField } from "@/lib/indicator-registry"
-import { BASE_COLUMN_DEFS, SORTABLE_FIELDS, isColumnVisible } from "./shared"
+import { BASE_COLUMN_DEFS, isColumnVisible } from "./shared"
+
+interface ColumnVisibilityMenuProps {
+  columnSettings: Record<string, boolean>
+  onToggle: (key: string) => void
+  responsiveHidden: Set<string>
+  /** All indicator field ids in the user's persisted order (drag reorders these). */
+  orderedIndicatorFields: string[]
+  onReorder: (nextOrder: string[]) => void
+}
+
+/** A draggable indicator row: grip handle + visibility checkbox + label. */
+function SortableIndicatorRow({
+  field,
+  label,
+  checked,
+  narrow,
+  onToggle,
+}: {
+  field: string
+  label: string
+  checked: boolean
+  narrow: boolean
+  onToggle: (key: string) => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: field })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 rounded px-1 py-1 hover:bg-accent"
+    >
+      <button
+        type="button"
+        aria-label={`Reorder ${label} column`}
+        className="cursor-grab touch-none text-muted-foreground/50 hover:text-muted-foreground shrink-0"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-3.5 w-3.5" />
+      </button>
+      <Checkbox
+        id={`col-${field}`}
+        checked={checked}
+        disabled={narrow}
+        onCheckedChange={() => onToggle(field)}
+      />
+      <Label
+        htmlFor={`col-${field}`}
+        className="flex flex-1 items-center justify-between gap-2 text-sm font-normal"
+      >
+        {label}
+        {narrow && <span className="text-[10px] text-muted-foreground">narrow</span>}
+      </Label>
+    </div>
+  )
+}
 
 export function ColumnVisibilityMenu({
   columnSettings,
   onToggle,
   responsiveHidden,
-}: {
-  columnSettings: Record<string, boolean>
-  onToggle: (key: string) => void
-  responsiveHidden: Set<string>
-}) {
-  // Build indicator column defs from registry
-  const indicatorColumnDefs = useMemo(
-    () =>
-      SORTABLE_FIELDS.map((field) => {
-        const series = getSeriesByField(field)
-        return { key: field, label: series?.label ?? field }
-      }),
-    [],
+  orderedIndicatorFields,
+  onReorder,
+}: ColumnVisibilityMenuProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   )
 
+  const indicatorLabels = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const field of orderedIndicatorFields) {
+      map[field] = getSeriesByField(field)?.label ?? field
+    }
+    return map
+  }, [orderedIndicatorFields])
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = orderedIndicatorFields.indexOf(active.id as string)
+    const newIndex = orderedIndicatorFields.indexOf(over.id as string)
+    if (oldIndex === -1 || newIndex === -1) return
+    onReorder(arrayMove(orderedIndicatorFields, oldIndex, newIndex))
+  }
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
         <Button
           variant="ghost"
           size="sm"
           className="h-6 w-6 p-0"
-          aria-label="Toggle column visibility"
+          aria-label="Configure columns"
         >
           <Settings2 className="h-3.5 w-3.5" />
         </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuLabel>Columns</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {BASE_COLUMN_DEFS.map(({ key, label }) => (
-          <DropdownMenuCheckboxItem
-            key={key}
-            checked={isColumnVisible(columnSettings, key)}
-            onCheckedChange={() => onToggle(key)}
-            onSelect={(e) => e.preventDefault()}
-          >
-            {label}
-          </DropdownMenuCheckboxItem>
-        ))}
-        {indicatorColumnDefs.length > 0 && (
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 gap-2 p-2">
+        <div className="px-1 text-xs font-medium text-muted-foreground">Columns</div>
+        <div className="flex flex-col">
+          {BASE_COLUMN_DEFS.map(({ key, label }) => (
+            <div key={key} className="flex items-center gap-2 rounded px-1 py-1 hover:bg-accent">
+              {/* Spacer aligns base-column checkboxes with the draggable rows below. */}
+              <span className="w-3.5 shrink-0" aria-hidden />
+              <Checkbox
+                id={`col-${key}`}
+                checked={isColumnVisible(columnSettings, key)}
+                onCheckedChange={() => onToggle(key)}
+              />
+              <Label htmlFor={`col-${key}`} className="flex-1 text-sm font-normal">
+                {label}
+              </Label>
+            </div>
+          ))}
+        </div>
+        {orderedIndicatorFields.length > 0 && (
           <>
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel>Indicators</DropdownMenuLabel>
-            {indicatorColumnDefs.map(({ key, label }) => {
-              const isHidden = responsiveHidden.has(key)
-              return (
-                <DropdownMenuCheckboxItem
-                  key={key}
-                  checked={isColumnVisible(columnSettings, key)}
-                  disabled={isHidden}
-                  onCheckedChange={() => onToggle(key)}
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  <span className="flex items-center justify-between w-full gap-2">
-                    {label}
-                    {isHidden && <span className="text-[10px] text-muted-foreground">narrow</span>}
-                  </span>
-                </DropdownMenuCheckboxItem>
-              )
-            })}
+            <Separator className="my-1" />
+            <div className="px-1 text-xs font-medium text-muted-foreground">Indicators</div>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={orderedIndicatorFields}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="flex flex-col">
+                  {orderedIndicatorFields.map((field) => (
+                    <SortableIndicatorRow
+                      key={field}
+                      field={field}
+                      label={indicatorLabels[field]}
+                      checked={isColumnVisible(columnSettings, field)}
+                      narrow={responsiveHidden.has(field)}
+                      onToggle={onToggle}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
           </>
         )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -12,7 +12,7 @@ import { SortableHeader } from "./sortable-header"
 import { ColumnVisibilityMenu } from "./column-visibility-menu"
 import { TableRow, type RowMenuRenderer } from "./table-row"
 export type { RowMenuContext, RowMenuRenderer } from "./table-row"
-import { SORTABLE_FIELDS, BASE_COLUMN_DEFS, isColumnVisible, useResponsiveHidden } from "./shared"
+import { BASE_COLUMN_DEFS, isColumnVisible, useResponsiveHidden, useOrderedIndicatorFields } from "./shared"
 import { useColumnResize } from "./use-column-resize"
 
 
@@ -71,6 +71,10 @@ export function GroupTable({ assets, quotes, indicators, renderContextMenu, comp
     })
   }
 
+  const reorderColumns = (nextOrder: string[]) => {
+    updateSettings({ group_table_column_order: nextOrder })
+  }
+
   const allExpanded = assets.length > 0 && assets.every((a) => expandedSymbols.has(a.symbol))
 
   const toggleExpandAll = () => {
@@ -81,9 +85,10 @@ export function GroupTable({ assets, quotes, indicators, renderContextMenu, comp
     }
   }
 
+  const orderedIndicatorFields = useOrderedIndicatorFields()
   const visibleIndicatorFields = useMemo(
-    () => SORTABLE_FIELDS.filter((f) => isColumnVisible(columnSettings, f) && !responsiveHidden.has(f)),
-    [columnSettings, responsiveHidden],
+    () => orderedIndicatorFields.filter((f) => isColumnVisible(columnSettings, f) && !responsiveHidden.has(f)),
+    [orderedIndicatorFields, columnSettings, responsiveHidden],
   )
 
   // Total visible columns: expand chevron (1) + symbol (1) + toggleable base + toggleable indicators
@@ -133,6 +138,8 @@ export function GroupTable({ assets, quotes, indicators, renderContextMenu, comp
           columnSettings={columnSettings}
           onToggle={toggleColumn}
           responsiveHidden={responsiveHidden}
+          orderedIndicatorFields={orderedIndicatorFields}
+          onReorder={reorderColumns}
         />
       </div>
       <table className="w-full table-fixed">

--- a/frontend/src/components/group-table/shared.ts
+++ b/frontend/src/components/group-table/shared.ts
@@ -1,7 +1,40 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { getAllSortableFields } from "@/lib/indicator-registry"
+import { useSettings } from "@/lib/settings"
 
 export const SORTABLE_FIELDS = getAllSortableFields()
+
+/**
+ * Reconcile a persisted column order against the current indicator registry.
+ *
+ * The saved order can go stale: a field may have been removed since it was
+ * saved, or a new indicator (e.g. `vnr`) may have been added afterwards. We keep
+ * the saved fields that still exist, then append any registry fields the saved
+ * order doesn't mention — in registry order — so new indicators show up at the
+ * right end automatically. An empty order therefore yields pure registry order
+ * (today's behaviour), which is why the default needs no migration.
+ */
+export function applyColumnOrder(order: string[]): string[] {
+  const known = new Set(SORTABLE_FIELDS)
+  const seen = new Set<string>()
+  const ordered: string[] = []
+  for (const f of order) {
+    // Drop unknown (removed) fields and any duplicates from corrupt storage.
+    if (known.has(f) && !seen.has(f)) {
+      seen.add(f)
+      ordered.push(f)
+    }
+  }
+  const rest = SORTABLE_FIELDS.filter((f) => !seen.has(f))
+  return [...ordered, ...rest]
+}
+
+/** The full indicator field list in the user's persisted order (registry order by default). */
+export function useOrderedIndicatorFields(): string[] {
+  const { settings } = useSettings()
+  const order = settings.group_table_column_order
+  return useMemo(() => applyColumnOrder(order), [order])
+}
 
 /** Column identifiers for base (non-indicator) toggleable columns. */
 export const BASE_COLUMN_DEFS: { key: string; label: string }[] = [

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -22,6 +22,8 @@ export interface AppSettings {
   group_sort_dir: SortDir
   group_table_columns: Record<string, boolean>
   group_table_column_widths: Record<string, number>
+  /** Left-to-right order of indicator columns (field ids). Empty = registry order. */
+  group_table_column_order: string[]
   thesis_grouping: ThesisGrouping
   /** In list view, keep a thesis's members together when sorting (average-and-interleave). */
   thesis_cluster: boolean
@@ -98,6 +100,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   group_sort_dir: "asc",
   group_table_columns: {},
   group_table_column_widths: {},
+  group_table_column_order: [],
   thesis_grouping: "list",
   thesis_cluster: false,
   chart_default_period: "1y",


### PR DESCRIPTION
## What

Adds per-user **drag-to-reorder** for the group-table indicator columns. Open the column gear menu, drag an indicator by its handle to change its left-to-right position; the order persists per user.

## Scope & design decisions

- **Scope A — indicator columns only.** Base columns (Symbol / Name / Price / Change) stay pinned on the left in fixed order. Fully-generic interleaving of base columns among indicators was considered and deliberately deferred (it would require refactoring the hardcoded header/row `<td>` blocks into a unified cell dispatch — bigger, touches the row hot-path).
- **UI: Popover, not the DropdownMenu.** The gear menu is reworked from a Radix `DropdownMenu` into a `Popover` hosting a vertical `@dnd-kit` `SortableContext` (drag handle + visibility checkbox per row). DnD inside a `DropdownMenu` fights Radix's pointer/focus capture; the Popover sidesteps that. Reuses the existing sidebar-group reorder pattern (`groups-section.tsx`).

## How it works

- New setting `group_table_column_order: string[]`, persisted through the existing dual localStorage + backend sync (timestamp-merge). Default `[]`.
- `applyColumnOrder()` reconciles the saved order against the live indicator registry each render: drops removed fields, appends newly-added indicators at the end (in registry order), and dedupes corrupt entries. An empty order therefore yields today's exact registry order — **no migration needed**.
- Order flows through the single `SORTABLE_FIELDS` seam, so the header, the row cells, and the menu all follow automatically.
- Column **widths**, **visibility**, and **responsive auto-hide** are all keyed by field id, so they compose unchanged with any order. Sorting (`group_sort_by`) is orthogonal — clicking a header still sorts.

## Backend

- `group_table_column_order: list[str] | None` added to `AppSettingsData`, with round-trip and validation (422 on non-list) integration tests.

## Testing

- **Frontend:** `pnpm lint` clean; `pnpm build` (tsc + vite) clean.
- **Backend:** settings integration tests pass (9); `ruff check` clean.
- **Not yet manually exercised in-browser** — the drag interaction itself should get a quick manual smoke on the dev environment before promoting to `main`.

## Notes

- Targets `dev` per the branching strategy (touches core group-table logic). Branched off `dev` @ `bf731fe`; file set is disjoint from the concurrent live-σ-move work on another branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
