### PR TITLE
fix: live σ-Move tracks the current day, not the last daily bar (#547)

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -84,7 +84,27 @@ def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
     return _wilder_smooth(tr, period)
 
 
-def volatility_normalized_return(closes: pd.Series, lam: float = 0.94) -> pd.Series:
+# RiskMetrics daily decay; shared by the vnr indicator and its live forecast.
+VNR_LAMBDA = 0.94
+
+
+def _ewma_daily_vol(closes: pd.Series, lam: float) -> pd.Series:
+    """Forward EWMA volatility forecast (RiskMetrics zero-mean).
+
+    Returns the sqrt of the EWMA variance built from returns *through each bar*
+    — i.e. the volatility with which to normalize the *next* bar's return. Flat
+    stretches (variance 0) become NaN to guard division. This is the un-shifted
+    counterpart of the ``sigma_forecast`` inside :func:`volatility_normalized_return`;
+    the value at the last bar is the forecast for the in-progress day, which the
+    live snapshot uses to score today's move before its bar is written.
+    """
+    returns = closes.pct_change()
+    # RiskMetrics zero-mean EWMA variance: sigma^2_t = lam*sigma^2_{t-1} + (1-lam)*r^2_{t-1}
+    ewma_var = (returns**2).ewm(alpha=1 - lam, adjust=False).mean()
+    return np.sqrt(ewma_var).replace(0, float("nan"))
+
+
+def volatility_normalized_return(closes: pd.Series, lam: float = VNR_LAMBDA) -> pd.Series:
     """Volatility-normalized daily return — a "sigma move" / return z-score.
 
     Expresses each day's close-to-close return in units of the asset's own
@@ -101,10 +121,8 @@ def volatility_normalized_return(closes: pd.Series, lam: float = 0.94) -> pd.Ser
     abruptly and stepping the score ("ghosting").
     """
     returns = closes.pct_change()
-    # RiskMetrics zero-mean EWMA variance: sigma^2_t = lam*sigma^2_{t-1} + (1-lam)*r^2_{t-1}
-    ewma_var = (returns**2).ewm(alpha=1 - lam, adjust=False).mean()
     # Forecast vol from data through the previous day; guard flat series (0 -> NaN).
-    sigma_forecast = np.sqrt(ewma_var.shift(1)).replace(0, float("nan"))
+    sigma_forecast = _ewma_daily_vol(closes, lam).shift(1)
     return returns / sigma_forecast
 
 
@@ -288,6 +306,17 @@ def _cmf_snapshot_derived(row: pd.Series) -> dict:
     return {"cmf_signal": None}
 
 
+def _vnr_post_compute(result: pd.DataFrame) -> None:
+    """Attach the forward EWMA vol forecast used to score an in-progress day.
+
+    ``vnr`` itself normalizes the *last completed* bar's return; ``vnr_sigma`` is
+    the vol (a return fraction) to divide a live intraday return by so the UI can
+    show today's σ-move before today's bar has been written to the DB. Flat
+    stretches yield NaN, which ``build_indicator_snapshot`` renders as None.
+    """
+    result["vnr_sigma"] = _ewma_daily_vol(result["close"], VNR_LAMBDA)
+
+
 def _chop_snapshot_derived(row: pd.Series) -> dict:
     """Derive choppiness state from latest row."""
     if pd.notna(row.get("chop")):
@@ -428,10 +457,12 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
     ),
     "vnr": IndicatorDef(
         func=volatility_normalized_return,
-        params={"lam": 0.94},
-        output_fields=["vnr"],
+        params={"lam": VNR_LAMBDA},
+        output_fields=["vnr", "vnr_sigma"],
         decimals=2,
         warmup_periods=60,
+        post_compute=_vnr_post_compute,
+        field_decimals={"vnr_sigma": 6},
     ),
 }
 

--- a/backend/tests/services/test_indicators_volatility.py
+++ b/backend/tests/services/test_indicators_volatility.py
@@ -340,3 +340,31 @@ def test_vnr_lambda_affects_result():
     fast = volatility_normalized_return(df["close"], lam=0.80).iloc[-1]
     slow = volatility_normalized_return(df["close"], lam=0.97).iloc[-1]
     assert fast != pytest.approx(slow)
+
+
+def test_vnr_sigma_in_snapshot():
+    """The forward vol forecast is exposed so the UI can score an in-progress day."""
+    df = _make_price_df(200)
+    snapshot = build_indicator_snapshot(compute_indicators(df))
+    assert "vnr_sigma" in snapshot["values"]
+    assert snapshot["values"]["vnr_sigma"] > 0
+
+
+def test_vnr_sigma_reconstructs_live_move():
+    """vnr_sigma is exactly the forecast that turns a next-day return into its σ-move.
+
+    Mirrors the frontend live recompute: the DB snapshot holds bars through
+    'yesterday'; today's live return divided by the snapshot's vnr_sigma must
+    reproduce the σ-move the full series (with today's bar) computes for that day.
+    """
+    df = _make_price_df(200)
+    # DB state = everything up to but excluding the final ("today") bar.
+    db_snapshot = build_indicator_snapshot(compute_indicators(df.iloc[:-1]))
+    vnr_sigma = db_snapshot["values"]["vnr_sigma"]
+
+    closes = df["close"]
+    today_return = closes.iloc[-1] / closes.iloc[-2] - 1
+    live_vnr = today_return / vnr_sigma
+
+    full = compute_indicators(df)
+    assert live_vnr == pytest.approx(full["vnr"].iloc[-1], rel=1e-4)

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -19,6 +19,7 @@ import {
   formatDeltaAnnotation,
   getDescriptorByField,
   formatIndicatorField,
+  computeLiveVnr,
 } from "@/lib/indicator-registry"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useSettings } from "@/lib/settings"
@@ -280,12 +281,22 @@ export const TableRow = memo(function TableRow({
                 </td>
               )
             }
-            const val = getNumericValue(indicator?.values, field)
+            // σ-Move is a daily-bar indicator; its stored value reflects the last
+            // completed bar (yesterday during market hours), which can contradict
+            // the live change % beside it. Recompute it against the live quote so
+            // it tracks today. Falls back to the DB value once today's bar syncs.
+            const liveVnr = field === "vnr"
+              ? computeLiveVnr(quote, indicator?.values, indicator?.close)
+              : null
+            const values = liveVnr != null
+              ? { ...indicator?.values, vnr: liveVnr }
+              : indicator?.values
+            const val = getNumericValue(values, field)
             const desc = getDescriptorByField(field)
             // Route through the shared registry formatter so the table matches the
             // card/detail rendering (decimals, threshold colours, currency prefix).
-            const formatted = val != null && desc && indicator?.values
-              ? formatIndicatorField(field, desc, indicator.values, asset.currency)
+            const formatted = val != null && desc && values
+              ? formatIndicatorField(field, desc, values, asset.currency)
               : null
             return (
               <td key={field} className={`${py} px-3 text-right text-sm tabular-nums`}>

--- a/frontend/src/lib/indicator-registry.ts
+++ b/frontend/src/lib/indicator-registry.ts
@@ -174,6 +174,40 @@ export function getStringValue(
   return typeof v === "string" ? v : null
 }
 
+/**
+ * Recompute the σ-Move (vnr) against a live intraday quote so the table shows
+ * *today's* move in σ units instead of the last completed daily bar.
+ *
+ * vnr = daily_return / EWMA_vol_forecast. The DB snapshot's `vnr` is anchored to
+ * the last stored bar; during market hours that bar is *yesterday*, so it can
+ * contradict the live change % shown beside it (positive σ next to a red day).
+ * Here we normalize the live return (`quote.change_percent`) by the forward vol
+ * forecast (`vnr_sigma` — the EWMA vol built through the last stored bar).
+ *
+ * The forecast only applies to the quote's day when the last stored bar is the
+ * session *before* the quote — detected by `quote.previous_close ≈ dbClose`.
+ * Once today's bar is synced (previous_close no longer matches the stored close),
+ * the DB `vnr` is already current, so we return null and let the caller fall back
+ * to it. Also returns null when the forecast/quote data is missing or degenerate.
+ */
+export function computeLiveVnr(
+  quote: { change_percent: number | null; previous_close: number | null } | undefined,
+  values: Record<string, number | string | null | undefined> | undefined,
+  dbClose: number | null | undefined,
+): number | null {
+  if (!quote) return null
+  const changePct = quote.change_percent
+  const prevClose = quote.previous_close
+  const sigma = getNumericValue(values, "vnr_sigma")
+  if (changePct == null || prevClose == null || sigma == null || sigma <= 0) return null
+  if (dbClose == null || dbClose === 0) return null
+  // Only reuse the forecast when the stored bar is the quote's prior session.
+  // (When they differ, the two anchors are close enough that either formula
+  // agrees — a flat day — or today's bar is stored and the DB vnr is correct.)
+  if (Math.abs(prevClose - dbClose) / dbClose > 0.005) return null
+  return changePct / 100 / sigma
+}
+
 export function getOverlayDescriptors(): IndicatorDescriptor[] {
   return INDICATOR_REGISTRY.filter((d) => d.placement === "overlay")
 }


### PR DESCRIPTION
Closes #547.

## Problem
The group table rendered the **live** change % (today's in-progress move) next to a **σ-Move (vnr)** sourced only from the last completed daily bar. During market hours that bar is *yesterday*, so vnr could contradict the change beside it — e.g. a **positive (green)** σ-Move next to a **negative (red)** day. Observed in prod: group 14, `COFF.MI`.

`vnr = daily_return / EWMA_vol_forecast`. The DB vnr's sign was correct *for the bar it was computed on* — it was just an older bar than the live change shown next to it.

## Fix
Recompute the σ-Move against the live quote so it reflects **today**.

**Backend** (`services/compute/indicators.py`)
- Expose the forward EWMA vol forecast as a new snapshot value `vnr_sigma` (a return-fraction) — the volatility to normalize an in-progress day's move by.
- Extracted a shared `_ewma_daily_vol()` helper out of `volatility_normalized_return` (behaviour of `vnr` itself is unchanged — verified by existing tests).
- Declared `vnr_sigma` as an output field with a `field_decimals` override, mirroring the `atr_pct` pattern (so `get_all_output_fields()` / snapshot values stay consistent).

**Frontend** (`lib/indicator-registry.ts`, `components/group-table/table-row.tsx`)
- `computeLiveVnr()` normalizes the live `change_percent` by `vnr_sigma`, gated on `quote.previous_close ≈ stored close` so the forecast only applies to the quote's own day. Once today's bar is synced (previous_close no longer matches), it falls back to the now-correct DB vnr.
- The group-table σ-Move cell uses the live value when available, else the DB value.

## Why this is correct across the day
- **Market open** (DB bar = yesterday): `previous_close ≈ stored close` → recompute → today's live σ-move.
- **After close, pre-sync** (17:30–23:00): still matches → shows today's settled σ-move.
- **After the 23:00 sync** (DB bar = today): `previous_close` no longer matches → fall back to DB vnr, which is now today's and correct. Seamless.
- **Flat day** (close ≈ prev close): both formulas agree (~0), so any misclassification is harmless.

## Verification
- Backend: `pytest` → **684 passed** (added `test_vnr_sigma_in_snapshot` and `test_vnr_sigma_reconstructs_live_move`, which mirrors the frontend recompute). `ruff` clean.
- Frontend: `pnpm lint` clean, `pnpm build` passes.
- End-to-end over HTTP on dev: `vnr_sigma` is served, and `change_pct/100/vnr_sigma` reproduces the DB vnr with matching sign for every symbol checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)