### PR TITLE
fix(backend): don't persist unsettled current-session bars on sync

### DIFF
--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -1,5 +1,6 @@
 """Sync price data from the configured price provider to the database."""
 
+import logging
 from datetime import date
 
 import pandas as pd
@@ -8,13 +9,111 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import Asset
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.price_repo import PriceRepository
-from app.services.price_providers import get_price_provider
+from app.services.price_providers import PriceProvider, get_price_provider
+
+logger = logging.getLogger(__name__)
+
+# The frontend's σ-Move (vnr) only trusts a stored daily bar when its close
+# reconciles with the live quote — within this tolerance of either the current
+# price (same session) or the previous close (prior session). Keep it in sync
+# with ``SESSION_MATCH_TOL`` in ``frontend/src/lib/indicator-registry.ts``.
+SESSION_MATCH_TOL = 0.005  # 0.5%
+
+# Market states in which the current session's daily bar is still forming, so
+# the trailing bar Yahoo returns is a live partial regardless of whether it
+# momentarily matches the live price. Other states (PRE/PREPRE before the open,
+# POST/POSTPOST/CLOSED after it) leave a settled daily bar we reconcile instead.
+_ACTIVE_SESSION_STATES = frozenset({"REGULAR"})
+
+
+def _reconciles(a: float | None, b: float | None, tol: float = SESSION_MATCH_TOL) -> bool:
+    """True when ``a`` is within ``tol`` (relative) of ``b``."""
+    if a is None or b is None or b == 0:
+        return False
+    return abs(a - b) / abs(b) <= tol
+
+
+def drop_unsettled_last_bar(
+    df: pd.DataFrame,
+    price: float | None,
+    previous_close: float | None,
+    market_state: str | None,
+) -> pd.DataFrame:
+    """Drop a trailing daily bar that reflects an in-progress / unsettled session.
+
+    Yahoo's daily history appends a live, still-forming bar for the current
+    session, and a sync running mid-session (or before Yahoo settles the bar
+    after a market's close) persists that partial value. Once the price moves
+    on, the stored close matches neither the live price nor the previous close,
+    so the frontend blanks σ-Move (see ``isStoredVnrStale``).
+
+    This keeps the daily table to *completed* sessions. The last bar is dropped
+    when it is identifiably the current session (its predecessor equals the
+    quote's previous close) AND it is not yet final — either because the market
+    is still open (``market_state`` active; the partial matches the live price
+    now but will drift) or because the market has closed but Yahoo's daily bar
+    has not settled to the live close. The remaining most-recent bar is then the
+    last completed close, which always reconciles, letting the frontend
+    recompute σ-Move live from the quote.
+
+    A no-op (returns ``df`` unchanged) when the quote is missing, the frame is
+    too short to have a predecessor, the last bar is already a completed prior
+    session, or a closed session's bar has settled to the live price.
+    """
+    if len(df) < 2 or price is None or previous_close is None:
+        return df
+
+    last_close = float(df.iloc[-1]["close"])
+    prev_bar_close = float(df.iloc[-2]["close"])
+
+    # Only act when the trailing bar is the current session (its predecessor is
+    # the quote's previous close). Otherwise it is already a completed bar.
+    if not _reconciles(prev_bar_close, previous_close):
+        return df
+
+    # An open session's bar is always a live partial — drop it even though it
+    # matches the live price right now, because it will drift as trading goes on.
+    if market_state in _ACTIVE_SESSION_STATES:
+        return df.iloc[:-1]
+
+    # Market closed: keep the bar once it has settled to the live close; drop it
+    # while Yahoo's daily feed still lags the (already-settled) quote.
+    if _reconciles(last_close, price):
+        return df
+
+    return df.iloc[:-1]
+
+
+async def _quote_anchors(
+    provider: PriceProvider, symbols: list[str],
+) -> dict[str, tuple[float | None, float | None, str | None]]:
+    """Fetch ``{symbol: (price, previous_close, market_state)}`` for reconciliation.
+
+    Best-effort: a quote-fetch failure degrades to storing every bar (the prior
+    behaviour) rather than aborting the sync.
+    """
+    if not symbols:
+        return {}
+    try:
+        quotes = await provider.batch_fetch_quotes(symbols)
+    except Exception:
+        logger.warning("Quote fetch for settlement check failed; storing all bars", exc_info=True)
+        return {}
+    return {
+        q["symbol"]: (q.get("price"), q.get("previous_close"), q.get("market_state"))
+        for q in quotes
+        if q.get("symbol")
+    }
 
 
 async def sync_asset_prices(db: AsyncSession, asset: Asset, period: str = "3mo") -> int:
     """Fetch and upsert price data for a single asset. Returns number of rows upserted."""
     provider = get_price_provider()
     df = await provider.fetch_history(asset.symbol, period=period)
+    price, previous_close, market_state = (await _quote_anchors(provider, [asset.symbol])).get(
+        asset.symbol, (None, None, None)
+    )
+    df = drop_unsettled_last_bar(df, price, previous_close, market_state)
     return await _upsert_prices(db, asset.id, df)
 
 
@@ -38,11 +137,14 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
     asset_map = {a.symbol: a.id for a in assets}
     provider = get_price_provider()
     data = await provider.batch_fetch_history(symbols, period=period)
+    anchors = await _quote_anchors(provider, symbols)
 
     counts = {}
     for sym, df in data.items():
         asset_id = asset_map.get(sym)
         if asset_id:
+            price, previous_close, market_state = anchors.get(sym, (None, None, None))
+            df = drop_unsettled_last_bar(df, price, previous_close, market_state)
             counts[sym] = await _upsert_prices(db, asset_id, df)
 
     return counts

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -9,6 +9,7 @@ import pytest
 from app.models import Asset, AssetType
 from app.services.price_sync import (
     _upsert_prices,
+    drop_unsettled_last_bar,
     sync_all_prices,
     sync_asset_prices,
     sync_asset_prices_range,
@@ -29,11 +30,25 @@ def _make_df(n=10, base_price=100.0):
     }, index=dates)
 
 
+def _df_from_closes(closes):
+    """OHLCV DataFrame with the given trailing close sequence (bdate index)."""
+    n = len(closes)
+    dates = pd.bdate_range("2025-01-02", periods=n)
+    return pd.DataFrame({
+        "open": closes,
+        "high": [c + 1 for c in closes],
+        "low": [c - 1 for c in closes],
+        "close": closes,
+        "volume": [1_000_000] * n,
+    }, index=dates)
+
+
 def _mock_provider(**overrides):
     """Create a mock PriceProvider with async method stubs."""
     provider = MagicMock()
     provider.fetch_history = AsyncMock(return_value=overrides.get("fetch_history", _make_df()))
     provider.batch_fetch_history = AsyncMock(return_value=overrides.get("batch_fetch_history", {}))
+    provider.batch_fetch_quotes = AsyncMock(return_value=overrides.get("batch_fetch_quotes", []))
     return provider
 
 
@@ -135,3 +150,110 @@ async def test_sync_all_skips_unknown_symbols(db):
 
     assert "AAPL" in counts
     assert "EXTRA" not in counts
+
+
+# --- drop_unsettled_last_bar (settlement reconciliation) ---
+#
+# The last stored bar must reconcile with the live quote or the frontend blanks
+# σ-Move. Each case names a real ticker observed on the watchlist (group 5).
+
+@pytest.mark.parametrize("name,closes,price,prev,state,expect_drop", [
+    # In-progress US session (REGULAR): partial bar, drop even though it matched
+    # the live price at capture — it drifts as the session continues (IBM's case).
+    ("IBM open-partial", [305.0, 290.23, 224.14], 220.84, 290.23, "REGULAR", True),
+    # Open session whose partial still matches the live price now: still dropped,
+    # because keeping it would blank σ-Move once the price moves on (MNST's case).
+    ("MNST open", [96.5, 97.07, 97.44], 97.565, 97.07, "REGULAR", True),
+    # Closed EU session, Yahoo daily bar not yet settled to the official close.
+    ("PRY.MI unsettled", [130.0, 133.35, 137.0], 137.85, 133.35, "POSTPOST", True),
+    # Closed session, within 0.5% of the settled close — keep (shows stored vnr).
+    ("MT.AS within-tol", [57.5, 58.04, 59.0], 58.72, 58.04, "POSTPOST", False),
+    # Closed, exact settled close — keep (Asian bar published overnight: f69ff59).
+    ("001440.KS settled", [28500.0, 28300.0, 28000.0], 28000.0, 28300.0, "PREPRE", False),
+    # Fully closed session, last bar equals current price — keep.
+    ("completed bar", [90.0, 95.0, 100.0], 100.0, 95.0, "CLOSED", False),
+])
+async def test_drop_unsettled_cases(name, closes, price, prev, state, expect_drop):
+    df = _df_from_closes(closes)
+    out = drop_unsettled_last_bar(df, price, prev, state)
+    if expect_drop:
+        assert len(out) == len(df) - 1, name
+        assert float(out.iloc[-1]["close"]) == closes[-2], name
+    else:
+        assert len(out) == len(df), name
+
+
+async def test_drop_unsettled_no_today_bar_kept():
+    """Market open but no current-session bar yet (halt): completed bar is kept."""
+    # Last bar (100.0) is yesterday's completed close == quote previous_close;
+    # its predecessor (98.0) does NOT match previous_close, so it's not treated
+    # as an in-progress session even though today's live price (101.0) differs.
+    df = _df_from_closes([95.0, 98.0, 100.0])
+    out = drop_unsettled_last_bar(df, price=101.0, previous_close=100.0, market_state="REGULAR")
+    assert len(out) == len(df)
+
+
+async def test_drop_unsettled_missing_quote_kept():
+    """No quote anchors (fetch failed) → store every bar (prior behaviour)."""
+    df = _df_from_closes([100.0, 105.0, 130.0])
+    assert len(drop_unsettled_last_bar(df, None, None, "REGULAR")) == len(df)
+    assert len(drop_unsettled_last_bar(df, 130.0, None, "REGULAR")) == len(df)
+
+
+async def test_drop_unsettled_short_frame_kept():
+    """A single-row frame has no predecessor to reconcile — unchanged."""
+    df = _df_from_closes([100.0])
+    assert len(drop_unsettled_last_bar(df, 120.0, 100.0, "REGULAR")) == 1
+
+
+async def test_sync_all_drops_unsettled_bar(db):
+    """sync_all_prices strips the partial current-session bar before upsert."""
+    a1 = Asset(symbol="IBM", name="IBM", type=AssetType.STOCK, currency="USD")
+    db.add(a1)
+    await db.commit()
+
+    # 3 bars; last (224.14) is today's partial, predecessor (290.23) == prev close.
+    mock_data = {"IBM": _df_from_closes([305.0, 290.23, 224.14])}
+    quotes = [{"symbol": "IBM", "price": 220.84, "previous_close": 290.23,
+               "market_state": "REGULAR"}]
+    mock_prov = _mock_provider(batch_fetch_history=mock_data, batch_fetch_quotes=quotes)
+
+    captured = {}
+
+    async def _capture(*args):
+        df = args[-1]
+        captured["len"] = len(df)
+        captured["last_close"] = float(df.iloc[-1]["close"])
+        return len(df)
+
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", side_effect=_capture):
+        await sync_all_prices(db, period="1y")
+
+    assert captured["len"] == 2  # 3 bars minus the dropped partial
+    assert captured["last_close"] == 290.23  # last completed close remains
+
+
+async def test_sync_all_keeps_settled_bar(db):
+    """A closed, settled current-session bar (matches live close) is preserved."""
+    a1 = Asset(symbol="MT.AS", name="ArcelorMittal", type=AssetType.STOCK, currency="EUR")
+    db.add(a1)
+    await db.commit()
+
+    # Market closed (POSTPOST), last bar within tolerance of the settled close.
+    mock_data = {"MT.AS": _df_from_closes([57.5, 58.04, 59.0])}
+    quotes = [{"symbol": "MT.AS", "price": 58.72, "previous_close": 58.04,
+               "market_state": "POSTPOST"}]
+    mock_prov = _mock_provider(batch_fetch_history=mock_data, batch_fetch_quotes=quotes)
+
+    captured = {}
+
+    async def _capture(*args):
+        captured["len"] = len(args[-1])
+        return len(args[-1])
+
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", side_effect=_capture):
+        await sync_all_prices(db, period="1y")
+
+    assert captured["len"] == 3  # nothing dropped


### PR DESCRIPTION
## Problem

Some watchlist tickers show a blank **σ-Move** (`—`) mid-session — e.g. IBM (during a real ~-24% move, exactly when you'd want σ-Move visible), PL, PRY.MI, NEX.PA, RIVN — while others render normally.

**Root cause:** the daytime price syncs (08:00/16:00 UTC, added in `f69ff59`) pull Yahoo's daily history *mid-session*, where the trailing daily bar is the still-forming current-day bar. The sync persisted that partial close. Once the live price drifts >0.5% from it, the stored bar reconciles with neither the quote's `price` nor its `previous_close`, so the `de0e5c0` guard (`isStoredVnrStale`) blanks σ-Move.

Confirmed against live data — for every blank ticker the stored bar's *implied* previous close matched the live quote's `previous_close` to the cent (same trading day), i.e. a same-session partial capture, not a genuinely old bar.

## Fix

`drop_unsettled_last_bar()` keeps the daily `prices` table to **completed sessions**. It drops the trailing bar when it's identifiably the current session (its predecessor equals the quote's `previous_close`) **and** not yet final:

- **Market open (`market_state == REGULAR`)** → drop the partial. Mid-session the partial *equals* the live price at capture, so a price-only reconciliation would keep it and let it drift — the market-state signal is required here.
- **Market closed but Yahoo's daily bar hasn't settled** to the live close → drop (the PRY.MI/NEX.PA lag case).
- **Closed & settled**, a genuinely completed prior bar, or an Asian bar published overnight (`f69ff59`'s purpose) → **keep**.

The remaining most-recent bar is the last completed close (= `previous_close`), so the frontend recomputes σ-Move **live** from the quote — the same path MNST already uses. The quote fetch is best-effort: on failure the sync stores every bar as before rather than aborting.

## Tests

New coverage in `test_price_sync.py` for each real case (IBM open-partial, MNST open, PRY.MI unsettled-closed, MT.AS within-tol keep, KRX overnight keep, no-today-bar/halt safety, missing-quote fallback, short frame) plus two `sync_all_prices` integration tests. **697 backend tests pass** (excluding the documented network-only `test_holdings`).

## Notes

- Prevents *future* bad writes; it does not retroactively delete partial rows already stored. Those self-heal at the next post-close sync (23:00 UTC nightly) when settled bars overwrite them.
- Targets `dev` per the branching rules (core sync logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)