### PR TITLE
fix(backend): log, retry, and self-heal price-sync gaps that blank σ-Move

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.routers import settings as settings_router
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
 from app.services.intraday import cleanup_old_intraday, fetch_and_store_intraday
+from app.services.price_heal import heal_unreconciled_prices
 from app.services.price_providers import init_price_provider
 from app.services.price_sync import sync_all_prices
 from app.services.symbol_sync_service import sync_all_enabled as sync_all_symbol_sources
@@ -117,6 +118,19 @@ async def _startup_warmup() -> None:
             logger.info(f"Startup warmup complete: {warmed} groups cached")
     except Exception:
         logger.exception("Startup indicator warmup failed (non-fatal)")
+
+
+async def scheduled_price_heal():
+    """Background job: refresh symbols whose stored bars contradict live quotes."""
+    async with async_session() as db:
+        try:
+            healed = await heal_unreconciled_prices(db)
+            if healed:
+                logger.info(
+                    f"Price heal: refreshed {len(healed)} symbol(s): {', '.join(sorted(healed))}"
+                )
+        except Exception:
+            logger.exception("Price heal failed")
 
 
 async def scheduled_symbol_sync():
@@ -211,6 +225,16 @@ async def lifespan(app: FastAPI):
             scheduled_intraday_sync,
             IntervalTrigger(seconds=60),
             id="intraday_sync",
+        )
+
+        # Self-heal stragglers the scheduled refreshes missed: when a symbol's
+        # latest stored bar reconciles with neither the live price nor the
+        # quote's previous close (the state that blanks σ-Move), refresh just
+        # that symbol instead of waiting for the next full run.
+        scheduler.add_job(
+            scheduled_price_heal,
+            IntervalTrigger(minutes=10),
+            id="price_heal",
         )
 
         scheduler.start()

--- a/backend/app/repositories/price_repo.py
+++ b/backend/app/repositories/price_repo.py
@@ -81,6 +81,30 @@ class PriceRepository:
         )
         return {row.asset_id: row.last_date for row in result}
 
+    async def get_latest_closes(
+        self, asset_ids: list[int]
+    ) -> dict[int, tuple[date, float]]:
+        """Latest stored (date, close) per asset."""
+        if not asset_ids:
+            return {}
+        last_dates = (
+            select(
+                PriceHistory.asset_id,
+                func.max(PriceHistory.date).label("last_date"),
+            )
+            .where(PriceHistory.asset_id.in_(asset_ids))
+            .group_by(PriceHistory.asset_id)
+            .subquery()
+        )
+        result = await self.db.execute(
+            select(PriceHistory.asset_id, PriceHistory.date, PriceHistory.close).join(
+                last_dates,
+                (PriceHistory.asset_id == last_dates.c.asset_id)
+                & (PriceHistory.date == last_dates.c.last_date),
+            )
+        )
+        return {row.asset_id: (row.date, row.close) for row in result}
+
     async def get_prices_at_dates(
         self, asset_ids: list[int], dates: set[date]
     ) -> dict[tuple[int, date], float]:

--- a/backend/app/services/price_heal.py
+++ b/backend/app/services/price_heal.py
@@ -1,0 +1,98 @@
+"""Self-heal stored daily bars that contradict the live quote.
+
+The frontend blanks σ-Move when an asset's latest stored close reconciles with
+neither the live price nor the quote's previous close (``isStoredVnrStale`` in
+``frontend/src/lib/indicator-registry.ts``). That state means the stored data
+is at least two sessions behind the quote — e.g. ``drop_unsettled_last_bar``
+discarded a lagging bar and every scheduled sync since missed the symbol, so
+once the quote's previous_close rolled at the next open, nothing reconciled.
+
+Rather than waiting up to a day for the next scheduled sync, this job detects
+the broken invariant server-side and refreshes just the affected symbols.
+"""
+
+import logging
+import time
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.asset_repo import AssetRepository
+from app.repositories.price_repo import PriceRepository
+from app.services.price_providers import get_price_provider
+from app.services.price_sync import _reconciles, sync_asset_prices
+
+logger = logging.getLogger(__name__)
+
+# Skip symbols attempted recently: when Yahoo itself is serving unreconcilable
+# data (daily feed lagging the quote for hours), a refresh changes nothing and
+# retrying every run would just hammer the API.
+HEAL_COOLDOWN_SECONDS = 30 * 60
+
+# Bound per-symbol fetches per run. Wider breakage than this is a sync-level
+# outage for the scheduled full runs to handle, not the straggler loop.
+MAX_HEALS_PER_RUN = 10
+
+_last_attempt: dict[str, float] = {}
+
+
+async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
+    """Refresh grouped assets whose latest stored bar contradicts the live quote.
+
+    Returns ``{symbol: rows_upserted}`` for the symbols refreshed this run.
+    """
+    assets = await AssetRepository(db).list_in_any_group()
+    if not assets:
+        return {}
+    by_symbol = {a.symbol: a for a in assets}
+
+    latest = await PriceRepository(db).get_latest_closes([a.id for a in assets])
+    quotes = await get_price_provider().batch_fetch_quotes(list(by_symbol))
+
+    stale: list[str] = []
+    for q in quotes:
+        sym = q.get("symbol")
+        if not sym:
+            continue
+        asset = by_symbol.get(sym)
+        if asset is None:
+            continue
+        stored = latest.get(asset.id)
+        if stored is None:  # no bars yet — initial fill is the sync's job
+            continue
+        price, previous_close = q.get("price"), q.get("previous_close")
+        if price is None and previous_close is None:  # dead quote, nothing to anchor on
+            continue
+        bar_date, bar_close = stored
+        if _reconciles(bar_close, price) or _reconciles(bar_close, previous_close):
+            continue
+        logger.info(
+            "%s: stored %s close %s reconciles with neither price %s nor previous_close %s",
+            sym, bar_date, bar_close, price, previous_close,
+        )
+        stale.append(sym)
+
+    if not stale:
+        return {}
+
+    now = time.monotonic()
+    due = [
+        s for s in stale
+        if (t := _last_attempt.get(s)) is None or now - t >= HEAL_COOLDOWN_SECONDS
+    ]
+    skipped_cooldown = len(stale) - len(due)
+    deferred = due[MAX_HEALS_PER_RUN:]
+    due = due[:MAX_HEALS_PER_RUN]
+    if skipped_cooldown or deferred:
+        logger.info(
+            "Price heal: %d stale symbol(s); healing %d (%d on cooldown, %d deferred to next run)",
+            len(stale), len(due), skipped_cooldown, len(deferred),
+        )
+
+    healed: dict[str, int] = {}
+    for sym in due:
+        _last_attempt[sym] = now
+        try:
+            healed[sym] = await sync_asset_prices(db, by_symbol[sym], period="1mo")
+        except Exception:
+            logger.warning("Price heal for %s failed", sym, exc_info=True)
+    return healed

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -38,6 +38,7 @@ def drop_unsettled_last_bar(
     price: float | None,
     previous_close: float | None,
     market_state: str | None,
+    symbol: str | None = None,
 ) -> pd.DataFrame:
     """Drop a trailing daily bar that reflects an in-progress / unsettled session.
 
@@ -74,6 +75,10 @@ def drop_unsettled_last_bar(
     # An open session's bar is always a live partial — drop it even though it
     # matches the live price right now, because it will drift as trading goes on.
     if market_state in _ACTIVE_SESSION_STATES:
+        logger.debug(
+            "%s: dropping trailing %s bar (session open; close=%s, live=%s)",
+            symbol or "?", df.index[-1], last_close, price,
+        )
         return df.iloc[:-1]
 
     # Market closed: keep the bar once it has settled to the live close; drop it
@@ -81,6 +86,13 @@ def drop_unsettled_last_bar(
     if _reconciles(last_close, price):
         return df
 
+    # Noteworthy: this leaves the symbol without its latest session's bar. Once
+    # the quote's previous_close rolls at the next open, the remaining stored
+    # bar reconciles with nothing and σ-Move blanks until a sync stores it.
+    logger.info(
+        "%s: dropping trailing %s bar (market %s; close=%s hasn't settled to quote %s)",
+        symbol or "?", df.index[-1], market_state, last_close, price,
+    )
     return df.iloc[:-1]
 
 
@@ -113,7 +125,7 @@ async def sync_asset_prices(db: AsyncSession, asset: Asset, period: str = "3mo")
     price, previous_close, market_state = (await _quote_anchors(provider, [asset.symbol])).get(
         asset.symbol, (None, None, None)
     )
-    df = drop_unsettled_last_bar(df, price, previous_close, market_state)
+    df = drop_unsettled_last_bar(df, price, previous_close, market_state, symbol=asset.symbol)
     return await _upsert_prices(db, asset.id, df)
 
 
@@ -144,8 +156,34 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
         asset_id = asset_map.get(sym)
         if asset_id:
             price, previous_close, market_state = anchors.get(sym, (None, None, None))
-            df = drop_unsettled_last_bar(df, price, previous_close, market_state)
+            df = drop_unsettled_last_bar(df, price, previous_close, market_state, symbol=sym)
             counts[sym] = await _upsert_prices(db, asset_id, df)
+
+    # The batch response silently omits symbols Yahoo hiccupped on; without a
+    # retry those stay stale until the next scheduled run (up to a full day).
+    missing = [s for s in symbols if s not in data]
+    if missing and not data:
+        logger.error(
+            "Batch history returned no data for all %d symbols; skipping per-symbol retries",
+            len(symbols),
+        )
+    elif missing:
+        logger.warning(
+            "Batch history missing %d/%d symbols; retrying individually: %s",
+            len(missing), len(symbols), ", ".join(sorted(missing)),
+        )
+        for sym in missing:
+            try:
+                df = await provider.fetch_history(sym, period=period)
+            except Exception:
+                logger.warning("Retry fetch for %s failed", sym, exc_info=True)
+                continue
+            if df is None or df.empty:
+                logger.warning("Retry fetch for %s returned no data", sym)
+                continue
+            price, previous_close, market_state = anchors.get(sym, (None, None, None))
+            df = drop_unsettled_last_bar(df, price, previous_close, market_state, symbol=sym)
+            counts[sym] = await _upsert_prices(db, asset_map[sym], df)
 
     return counts
 

--- a/backend/app/services/yahoo/_history.py
+++ b/backend/app/services/yahoo/_history.py
@@ -92,6 +92,7 @@ class _HistoryMixin(_YahooBase):
                     else:
                         df = hist.copy()
                     if df.empty or len(df) < 2:
+                        logger.debug("batch_history: %s returned %d rows; skipping", sym, len(df))
                         continue
                     info = price_data.get(sym, {}) if isinstance(price_data, dict) else {}
                     info = info if isinstance(info, dict) else {}
@@ -99,6 +100,7 @@ class _HistoryMixin(_YahooBase):
                     df = _normalize_ohlcv_df(df, divisor)
                     out[sym] = normalize_date_index(df)
                 except KeyError:
+                    logger.debug("batch_history: %s missing from Yahoo batch response", sym)
                     continue
             return out
 

--- a/backend/tests/services/test_price_heal.py
+++ b/backend/tests/services/test_price_heal.py
@@ -1,0 +1,141 @@
+"""Tests for the price self-heal service.
+
+``heal_unreconciled_prices`` refreshes grouped assets whose latest stored bar
+reconciles with neither the live quote price nor its previous close — the
+exact condition under which the frontend blanks σ-Move.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.repositories.price_repo import PriceRepository
+from app.services import price_heal
+from app.services.price_heal import MAX_HEALS_PER_RUN, heal_unreconciled_prices
+from tests.helpers import seed_asset_with_prices
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldowns():
+    price_heal._last_attempt.clear()
+    yield
+    price_heal._last_attempt.clear()
+
+
+def _provider_with_quotes(quotes):
+    provider = MagicMock()
+    provider.batch_fetch_quotes = AsyncMock(return_value=quotes)
+    return provider
+
+
+def _quote(symbol, price, prev, state="REGULAR"):
+    return {
+        "symbol": symbol, "price": price,
+        "previous_close": prev, "market_state": state,
+    }
+
+
+async def _latest_close(db, asset) -> float:
+    latest = await PriceRepository(db).get_latest_closes([asset.id])
+    return latest[asset.id][1]
+
+
+async def test_heal_refreshes_unreconciled_asset(db):
+    """A stored close matching neither price nor previous_close gets refreshed."""
+    asset = await seed_asset_with_prices(db, "PRY.MI", n_days=30)
+    close = await _latest_close(db, asset)
+
+    # Quote two sessions ahead of the stored bar: nothing reconciles.
+    provider = _provider_with_quotes([_quote("PRY.MI", close * 0.90, close * 0.95)])
+    with patch("app.services.price_heal.get_price_provider", return_value=provider), \
+         patch("app.services.price_heal.sync_asset_prices",
+               new_callable=AsyncMock, return_value=22) as mock_sync:
+        healed = await heal_unreconciled_prices(db)
+
+    assert healed == {"PRY.MI": 22}
+    mock_sync.assert_awaited_once_with(db, asset, period="1mo")
+
+
+async def test_heal_skips_reconciling_assets(db):
+    """Assets whose stored bar matches price or previous_close are left alone."""
+    a1 = await seed_asset_with_prices(db, "PREV", n_days=30)
+    a2 = await seed_asset_with_prices(db, "CURR", n_days=30)
+    c1 = await _latest_close(db, a1)
+    c2 = await _latest_close(db, a2)
+
+    provider = _provider_with_quotes([
+        # Normal market-hours state: stored bar is the quote's prior session.
+        _quote("PREV", c1 * 0.95, c1),
+        # Current session already stored (settled close equals the price).
+        _quote("CURR", c2, c2 * 1.05),
+    ])
+    with patch("app.services.price_heal.get_price_provider", return_value=provider), \
+         patch("app.services.price_heal.sync_asset_prices", new_callable=AsyncMock) as mock_sync:
+        healed = await heal_unreconciled_prices(db)
+
+    assert healed == {}
+    mock_sync.assert_not_awaited()
+
+
+async def test_heal_skips_assets_without_stored_bars(db):
+    """No stored bars → initial fill is the sync's job, not the heal loop's."""
+    await seed_asset_with_prices(db, "NEWB", n_days=0)
+
+    provider = _provider_with_quotes([_quote("NEWB", 100.0, 99.0)])
+    with patch("app.services.price_heal.get_price_provider", return_value=provider), \
+         patch("app.services.price_heal.sync_asset_prices", new_callable=AsyncMock) as mock_sync:
+        healed = await heal_unreconciled_prices(db)
+
+    assert healed == {}
+    mock_sync.assert_not_awaited()
+
+
+async def test_heal_skips_dead_quotes(db):
+    """A quote with neither price nor previous_close can't anchor a comparison."""
+    await seed_asset_with_prices(db, "DEAD", n_days=30)
+
+    provider = _provider_with_quotes([_quote("DEAD", None, None)])
+    with patch("app.services.price_heal.get_price_provider", return_value=provider), \
+         patch("app.services.price_heal.sync_asset_prices", new_callable=AsyncMock) as mock_sync:
+        healed = await heal_unreconciled_prices(db)
+
+    assert healed == {}
+    mock_sync.assert_not_awaited()
+
+
+async def test_heal_cooldown_prevents_hammering(db):
+    """A symbol healed once is not re-attempted within the cooldown window."""
+    seed = await seed_asset_with_prices(db, "LAG.MI", n_days=30)
+    close = await _latest_close(db, seed)
+
+    # Still unreconcilable after the heal (Yahoo keeps serving lagged data).
+    provider = _provider_with_quotes([_quote("LAG.MI", close * 0.90, close * 0.95)])
+    with patch("app.services.price_heal.get_price_provider", return_value=provider), \
+         patch("app.services.price_heal.sync_asset_prices",
+               new_callable=AsyncMock, return_value=0) as mock_sync:
+        await heal_unreconciled_prices(db)
+        await heal_unreconciled_prices(db)
+
+    mock_sync.assert_awaited_once()
+
+
+async def test_heal_caps_per_run_and_defers_rest(db):
+    """At most MAX_HEALS_PER_RUN symbols are refreshed per run; the rest follow."""
+    n = MAX_HEALS_PER_RUN + 2
+    assets = [await seed_asset_with_prices(db, f"S{i:02d}", n_days=10) for i in range(n)]
+    closes = {a.symbol: await _latest_close(db, a) for a in assets}
+
+    provider = _provider_with_quotes(
+        [_quote(s, c * 0.90, c * 0.95) for s, c in closes.items()]
+    )
+    with patch("app.services.price_heal.get_price_provider", return_value=provider), \
+         patch("app.services.price_heal.sync_asset_prices",
+               new_callable=AsyncMock, return_value=1) as mock_sync:
+        first = await heal_unreconciled_prices(db)
+        second = await heal_unreconciled_prices(db)
+
+    assert len(first) == MAX_HEALS_PER_RUN
+    assert len(second) == 2  # deferred symbols healed next run, not lost
+    assert mock_sync.await_count == n

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -1,5 +1,6 @@
 """Tests for the price_sync service (sync orchestration and upsert logic)."""
 
+import logging
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -152,6 +153,59 @@ async def test_sync_all_skips_unknown_symbols(db):
     assert "EXTRA" not in counts
 
 
+async def test_sync_all_retries_symbols_missing_from_batch(db, caplog):
+    """Symbols Yahoo silently omits from the batch response are retried one by one."""
+    a1 = Asset(symbol="AAPL", name="Apple", type=AssetType.STOCK, currency="USD")
+    a2 = Asset(symbol="PRY.MI", name="Prysmian", type=AssetType.STOCK, currency="EUR")
+    db.add_all([a1, a2])
+    await db.commit()
+
+    # Batch response only contains AAPL; PRY.MI must come from the per-symbol retry.
+    mock_prov = _mock_provider(batch_fetch_history={"AAPL": _make_df()})
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=10), \
+         caplog.at_level(logging.WARNING, logger="app.services.price_sync"):
+        counts = await sync_all_prices(db, period="1y")
+
+    mock_prov.fetch_history.assert_awaited_once_with("PRY.MI", period="1y")
+    assert counts == {"AAPL": 10, "PRY.MI": 10}
+    assert "PRY.MI" in caplog.text
+
+
+async def test_sync_all_no_retry_when_batch_entirely_empty(db, caplog):
+    """A fully empty batch (breaker open / Yahoo down) is not retried per symbol."""
+    a1 = Asset(symbol="AAPL", name="Apple", type=AssetType.STOCK, currency="USD")
+    a2 = Asset(symbol="MSFT", name="Microsoft", type=AssetType.STOCK, currency="USD")
+    db.add_all([a1, a2])
+    await db.commit()
+
+    mock_prov = _mock_provider(batch_fetch_history={})
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=10), \
+         caplog.at_level(logging.ERROR, logger="app.services.price_sync"):
+        counts = await sync_all_prices(db)
+
+    mock_prov.fetch_history.assert_not_awaited()
+    assert counts == {}
+    assert "no data" in caplog.text
+
+
+async def test_sync_all_retry_failure_is_non_fatal(db):
+    """A failing per-symbol retry doesn't abort the sync of other symbols."""
+    a1 = Asset(symbol="AAPL", name="Apple", type=AssetType.STOCK, currency="USD")
+    a2 = Asset(symbol="KOG.OL", name="Kongsberg", type=AssetType.STOCK, currency="NOK")
+    db.add_all([a1, a2])
+    await db.commit()
+
+    mock_prov = _mock_provider(batch_fetch_history={"AAPL": _make_df()})
+    mock_prov.fetch_history = AsyncMock(side_effect=Exception("boom"))
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=10):
+        counts = await sync_all_prices(db)
+
+    assert counts == {"AAPL": 10}
+
+
 # --- drop_unsettled_last_bar (settlement reconciliation) ---
 #
 # The last stored bar must reconcile with the live quote or the frontend blanks
@@ -198,6 +252,20 @@ async def test_drop_unsettled_missing_quote_kept():
     df = _df_from_closes([100.0, 105.0, 130.0])
     assert len(drop_unsettled_last_bar(df, None, None, "REGULAR")) == len(df)
     assert len(drop_unsettled_last_bar(df, 130.0, None, "REGULAR")) == len(df)
+
+
+async def test_drop_unsettled_logs_closed_market_lag(caplog):
+    """Dropping a closed session's lagging bar is logged with the symbol.
+
+    This is the path that leaves a symbol without its latest session's bar —
+    the state the heal job repairs — so it must be diagnosable from logs.
+    """
+    df = _df_from_closes([130.0, 133.35, 137.0])
+    with caplog.at_level(logging.INFO, logger="app.services.price_sync"):
+        out = drop_unsettled_last_bar(df, 137.85, 133.35, "POSTPOST", symbol="PRY.MI")
+    assert len(out) == len(df) - 1
+    assert "PRY.MI" in caplog.text
+    assert "settled" in caplog.text
 
 
 async def test_drop_unsettled_short_frame_kept():


### PR DESCRIPTION
## Problem

On 2026-07-17, PRY.MI, NEX.PA and KOG.OL showed a blank σ-Move all morning (again). Investigation found their settled Jul-16 bar missing from the DB even though three scheduled syncs had run since that session closed (16:00 UTC, 23:00 UTC nightly, 08:00 UTC). Two silent failure paths made the incident both unrecoverable and undiagnosable:

- **Silent batch omissions**: `batch_history` skips symbols missing from Yahoo's batch response with a bare `KeyError` → `continue`, and `sync_all_prices` only iterates over what came back. A transient Yahoo hiccup leaves a symbol stale for up to a day, with zero log traces.
- **Drop with no follow-through**: `drop_unsettled_last_bar` (#550) discards a closed session's still-lagging bar by design, assuming the remaining bar "always reconciles". That assumption expires at the next session open: the quote's `previous_close` rolls forward, the stored bar then matches neither anchor, and the frontend guard (de0e5c0) blanks σ-Move until some sync finally stores the missing bar.

## Fixes

1. **Log both silent paths** — every drop decision (debug for routine open-session partials, info for closed-market lag drops) now includes the symbol and bar date; batch-response omissions log at the sync layer.
2. **Per-symbol retry in `sync_all_prices`** — symbols missing from the batch response are retried individually (reusing already-fetched quote anchors). A fully-empty batch (breaker open) skips retries; a failing retry is non-fatal.
3. **Self-heal job** (`price_heal.py`, every 10 min) — detects grouped assets whose latest stored close reconciles with neither the live price nor `previous_close` (the exact frontend blank condition, same 0.5% tolerance) and refreshes just those symbols. 30-min per-symbol cooldown, 10-per-run cap with logged deferral. Turns a ~24h blank into minutes.

Backed by a new portable `PriceRepository.get_latest_closes()` (subquery join, SQLite-compatible for tests).

## Testing

- 707 backend tests pass, ruff clean.
- New tests: batch-retry (present/empty/failing), lag-drop logging, heal service (heals unreconciled; skips reconciled, bar-less, dead-quote assets; cooldown; cap + next-run pickup).
- The affected prod symbols were manually healed today via `POST /api/assets/{symbol}/refresh` — the same code path the heal job invokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)