### PR TITLE
feat(indicators): RVOL (relative volume) indicator

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -233,6 +233,25 @@ def volume_stats(df: pd.DataFrame, period: int = 20) -> dict[str, pd.Series]:
     return {"volume": df["volume"], "avg_volume": df["volume"].rolling(window=period).mean()}
 
 
+def relative_volume(df: pd.DataFrame, period: int = 20) -> pd.Series:
+    """Relative Volume (RVOL) — a session's volume vs its recent normal.
+
+    RVOL = volume / SMA(volume over the *prior* ``period`` sessions).
+
+    Puts volume on a cross-asset scale: 1.0 is an average day, >1.5 elevated,
+    >2 unusually heavy (news / breakout / capitulation), <0.5 quiet. The
+    baseline is shifted by one bar so the current session is excluded from its
+    own average — a volume spike therefore doesn't inflate the reference it is
+    measured against. A flat/zero baseline becomes NaN to guard the division.
+
+    Note: this is the daily-over-N-days RVOL. An intraday "volume so far vs
+    average volume at this time of day" measure would need minute bars the
+    daily pipeline doesn't carry.
+    """
+    baseline = df["volume"].shift(1).rolling(window=period).mean().replace(0, float("nan"))
+    return df["volume"] / baseline
+
+
 def bb_position(close: float, upper: float, middle: float, lower: float) -> str:
     """Classify where price sits relative to Bollinger Bands."""
     if close > upper:
@@ -315,6 +334,20 @@ def _vnr_post_compute(result: pd.DataFrame) -> None:
     stretches yield NaN, which ``build_indicator_snapshot`` renders as None.
     """
     result["vnr_sigma"] = _ewma_daily_vol(result["close"], VNR_LAMBDA)
+
+
+def _rvol_snapshot_derived(row: pd.Series) -> dict:
+    """Derive a qualitative relative-volume state from the latest row."""
+    val = row.get("rvol")
+    if pd.notna(val):
+        if val >= 2:
+            return {"rvol_state": "high"}
+        elif val >= 1.5:
+            return {"rvol_state": "elevated"}
+        elif val < 0.5:
+            return {"rvol_state": "quiet"}
+        return {"rvol_state": "normal"}
+    return {"rvol_state": None}
 
 
 def _chop_snapshot_derived(row: pd.Series) -> dict:
@@ -426,6 +459,16 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
         decimals=0,
         warmup_periods=20,
         uses_ohlc=True,
+    ),
+    "rvol": IndicatorDef(
+        func=relative_volume,
+        params={"period": 20},
+        output_fields=["rvol"],
+        decimals=2,
+        # 20-session baseline + 1 shifted bar before the first finite value.
+        warmup_periods=21,
+        uses_ohlc=True,
+        snapshot_derived=_rvol_snapshot_derived,
     ),
     "nefi": IndicatorDef(
         func=normalized_force_index,

--- a/backend/tests/services/test_indicators_technical.py
+++ b/backend/tests/services/test_indicators_technical.py
@@ -1,4 +1,4 @@
-"""Tests for momentum / trend / volume-flow indicators: RSI, SMA, MACD, NEFI, CMF."""
+"""Tests for momentum / trend / volume-flow indicators: RSI, SMA, MACD, NEFI, CMF, RVOL."""
 
 import pandas as pd
 import pytest
@@ -9,6 +9,7 @@ from app.services.compute.indicators import (
     compute_indicators,
     macd,
     normalized_force_index,
+    relative_volume,
     rsi,
     sma,
 )
@@ -169,3 +170,79 @@ def test_cmf_snapshot_derived():
     assert "values" in snapshot
     assert "cmf_signal" in snapshot["values"]
     assert snapshot["values"]["cmf_signal"] in ("buying", "selling", None)
+
+
+def _make_volume_df(volumes: list[float]) -> pd.DataFrame:
+    """Build a price frame with an explicit volume series (prices held flat)."""
+    n = len(volumes)
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    return pd.DataFrame({
+        "open": [100.0] * n,
+        "high": [101.0] * n,
+        "low": [99.0] * n,
+        "close": [100.0] * n,
+        "volume": volumes,
+    }, index=dates)
+
+
+def test_rvol_calculation():
+    """RVOL = volume / mean of the prior 20 sessions' volume (current bar excluded)."""
+    # 25 flat sessions at 1M, then a 2.5M spike on the final bar.
+    df = _make_volume_df([1_000_000.0] * 25 + [2_500_000.0])
+    rvol = relative_volume(df, period=20)
+    # Baseline for the last bar is the mean of the prior 20 flat bars = 1M.
+    assert rvol.iloc[-1] == pytest.approx(2.5)
+    # A bar inside the flat stretch sits at exactly 1×.
+    assert rvol.iloc[24] == pytest.approx(1.0)
+
+
+def test_rvol_excludes_current_bar_from_baseline():
+    """The spike must not dilute its own baseline (baseline is shifted by one)."""
+    df = _make_volume_df([1_000_000.0] * 20 + [5_000_000.0])
+    rvol = relative_volume(df, period=20)
+    # If the current bar leaked into the mean, the ratio would be < 5.
+    assert rvol.iloc[-1] == pytest.approx(5.0)
+
+
+def test_rvol_warmup_nans():
+    """First 20 sessions are NaN (20-window rolling mean over a 1-bar-shifted series)."""
+    df = _make_volume_df([1_000_000.0] * 40)
+    rvol = relative_volume(df, period=20)
+    assert rvol.iloc[:20].isna().all()
+    assert pd.notna(rvol.iloc[20])
+
+
+def test_rvol_zero_baseline_is_nan():
+    """A flat-zero baseline must not divide-by-zero — it yields NaN."""
+    df = _make_volume_df([0.0] * 20 + [1_000_000.0])
+    rvol = relative_volume(df, period=20)
+    assert pd.isna(rvol.iloc[-1])
+
+
+def test_rvol_in_compute_indicators():
+    """RVOL should be computed as part of the full indicator pass."""
+    df = _make_price_df(100)
+    result = compute_indicators(df)
+    assert "rvol" in result.columns
+    valid = result["rvol"].dropna()
+    assert len(valid) > 0
+    assert all(v > 0 for v in valid)
+
+
+def test_rvol_snapshot_derived():
+    """RVOL snapshot should expose the numeric value and a qualitative state."""
+    df = _make_volume_df([1_000_000.0] * 25 + [2_500_000.0])
+    snapshot = build_indicator_snapshot(compute_indicators(df))
+    assert snapshot["values"]["rvol"] == pytest.approx(2.5)
+    assert snapshot["values"]["rvol_state"] == "high"
+
+
+def test_rvol_state_thresholds():
+    """rvol_state buckets: high ≥2, elevated ≥1.5, quiet <0.5, else normal."""
+    from app.services.compute.indicators import _rvol_snapshot_derived
+
+    assert _rvol_snapshot_derived(pd.Series({"rvol": 2.4}))["rvol_state"] == "high"
+    assert _rvol_snapshot_derived(pd.Series({"rvol": 1.7}))["rvol_state"] == "elevated"
+    assert _rvol_snapshot_derived(pd.Series({"rvol": 1.0}))["rvol_state"] == "normal"
+    assert _rvol_snapshot_derived(pd.Series({"rvol": 0.3}))["rvol_state"] == "quiet"
+    assert _rvol_snapshot_derived(pd.Series({"rvol": float("nan")}))["rvol_state"] is None

--- a/frontend/src/lib/indicator-descriptors.ts
+++ b/frontend/src/lib/indicator-descriptors.ts
@@ -267,6 +267,44 @@ export const INDICATOR_REGISTRY: IndicatorDescriptor[] = [
     decimals: 0,
     compactFormat: true,
   },
+  {
+    id: "rvol",
+    label: "RVOL (20)",
+    shortLabel: "RVOL",
+    description:
+      "Relative Volume — last session's volume vs its 20-day average. 1× is a normal day, above 1.5× elevated, above 2× unusually heavy, below 0.5× quiet.",
+    category: "market_data",
+    placement: "card",
+    capabilities: ["group_table", "group_card", "detail_card", "detail_stats"],
+    defaults: ["group_table", "detail_card"],
+    fields: ["rvol"],
+    sortableFields: ["rvol"],
+    series: [
+      {
+        field: "rvol",
+        label: "RVOL",
+        color: "#f97316",
+        lineWidth: 2,
+        thresholdColors: [
+          { condition: "gte", value: 2, className: "text-orange-500" },
+          { condition: "gte", value: 1.5, className: "text-amber-500" },
+          { condition: "lt", value: 0.5, className: "text-zinc-400" },
+        ],
+      },
+    ],
+    decimals: 2,
+    suffix: "×",
+    holdingSummary: {
+      label: "RVOL",
+      field: "rvol_state",
+      format: "string_map",
+      colorMap: {
+        high: "text-orange-500",
+        elevated: "text-amber-500",
+        quiet: "text-zinc-400",
+      },
+    },
+  },
 
   {
     id: "nefi",


### PR DESCRIPTION
## What

Adds a **Relative Volume (RVOL)** indicator: how a session's volume compares to what's normal for the asset.

`RVOL = volume / SMA(volume over the prior 20 sessions)`. The baseline is shifted one bar so a volume spike doesn't dilute its own reference. Scale: 1× normal, >1.5× elevated, >2× unusually heavy (news / breakout / capitulation), <0.5× quiet.

Closes #552.

## Scope

Implements the **daily-over-N-days** flavor. The intraday "volume so far vs average volume at this time of day" flavor needs minute bars the daily `compute_indicators` pipeline doesn't carry, so it's out of scope. The snapshot reflects the **last completed daily session** (like every other daily indicator); RVOL is deliberately **not** recomputed against the live intraday quote, since partial-day volume would understate it against a full-day baseline.

## Changes

- **backend/app/services/compute/indicators.py** — `relative_volume()` + `rvol` registry entry (`uses_ohlc`, warmup 21) with a `_rvol_snapshot_derived` classifier emitting `rvol_state` (high / elevated / normal / quiet). Zero baseline → NaN → `None` in the snapshot.
- **frontend/src/lib/indicator-descriptors.ts** — `rvol` card descriptor (`market_data`), heat-colored value (`×` suffix), holdings-grid `rvol_state` summary.
- **backend/tests/services/test_indicators_technical.py** — 7 tests: calculation, current-bar-excluded baseline, warmup NaNs, zero-baseline guard, compute integration, snapshot, state thresholds.

Purely additive — the indicator `values` dict is dynamically typed on both ends, so **no schema change and no DB migration**. The mobile companion app ports `indicators.py` itself and only couples via `/api/companion/config`, so **no companion impact**.

## Verification

- `pytest` — 714 passed (7 new)
- `eslint .` — 0 errors · `tsc -b` — 0 errors · `vite build` — clean · `vitest run` — 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
