### PR TITLE
fix: address pre-promotion review findings (σ-Move sync/heal, movement stats, cleanups)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,6 +122,13 @@ async def _startup_warmup() -> None:
 
 async def scheduled_price_heal():
     """Background job: refresh symbols whose stored bars contradict live quotes."""
+    # No market is open anywhere on the weekend, so quotes are frozen and no
+    # stored bar can newly diverge — skip the full portfolio quote+DB scan
+    # entirely (~288 no-op fetches/weekend). Weekdays always have some market
+    # open across the Asia/EU/US rotation, so this is the practical "all markets
+    # closed" gate. Mirrors the intraday sync's weekend guard.
+    if date.today().weekday() >= 5:
+        return
     async with async_session() as db:
         try:
             healed = await heal_unreconciled_prices(db)

--- a/backend/app/repositories/price_repo.py
+++ b/backend/app/repositories/price_repo.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 import pandas as pd
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import PriceHistory
@@ -121,6 +121,23 @@ class PriceRepository:
             (p.asset_id, p.date): p.close
             for p in result.scalars().all()
         }
+
+    async def delete_prices_after(self, asset_id: int, last_date: date) -> int:
+        """Delete stored bars strictly after ``last_date`` for one asset.
+
+        Purges a stale current-session partial that a re-sync dropped from its
+        fetched frame but left orphaned in the DB — an upsert can only update
+        the rows it received, never remove one it no longer has. Returns the
+        number of rows deleted.
+        """
+        result = await self.db.execute(
+            delete(PriceHistory).where(
+                PriceHistory.asset_id == asset_id,
+                PriceHistory.date > last_date,
+            )
+        )
+        await self.db.commit()
+        return result.rowcount or 0
 
     async def upsert_prices(self, asset_id: int, df: pd.DataFrame) -> int:
         """Upsert price rows from a DataFrame. Returns row count.

--- a/backend/app/services/price_heal.py
+++ b/backend/app/services/price_heal.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.price_repo import PriceRepository
 from app.services.price_providers import get_price_provider
-from app.services.price_sync import _reconciles, sync_asset_prices
+from app.services.price_sync import Anchor, _as_date, _reconciles, sync_asset_prices
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,10 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
     latest = await PriceRepository(db).get_latest_closes([a.id for a in assets])
     quotes = await get_price_provider().batch_fetch_quotes(list(by_symbol))
 
-    stale: list[str] = []
+    # Carry each stale symbol's reconciliation anchor so the per-symbol refresh
+    # below can reuse the quote we already fetched instead of round-tripping to
+    # Yahoo again for the same (price, previous_close, market_state) data.
+    stale: list[tuple[str, Anchor]] = []
     for q in quotes:
         sym = q.get("symbol")
         if not sym:
@@ -69,14 +72,15 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
             "%s: stored %s close %s reconciles with neither price %s nor previous_close %s",
             sym, bar_date, bar_close, price, previous_close,
         )
-        stale.append(sym)
+        anchor: Anchor = (price, previous_close, q.get("market_state"), _as_date(q.get("session_date")))
+        stale.append((sym, anchor))
 
     if not stale:
         return {}
 
     now = time.monotonic()
     due = [
-        s for s in stale
+        (s, a) for (s, a) in stale
         if (t := _last_attempt.get(s)) is None or now - t >= HEAL_COOLDOWN_SECONDS
     ]
     skipped_cooldown = len(stale) - len(due)
@@ -89,10 +93,10 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
         )
 
     healed: dict[str, int] = {}
-    for sym in due:
+    for sym, anchor in due:
         _last_attempt[sym] = now
         try:
-            healed[sym] = await sync_asset_prices(db, by_symbol[sym], period="1mo")
+            healed[sym] = await sync_asset_prices(db, by_symbol[sym], period="1mo", anchor=anchor)
         except Exception:
             logger.warning("Price heal for %s failed", sym, exc_info=True)
     return healed

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -39,6 +39,7 @@ def drop_unsettled_last_bar(
     previous_close: float | None,
     market_state: str | None,
     symbol: str | None = None,
+    session_date: date | None = None,
 ) -> pd.DataFrame:
     """Drop a trailing daily bar that reflects an in-progress / unsettled session.
 
@@ -57,6 +58,14 @@ def drop_unsettled_last_bar(
     last completed close, which always reconciles, letting the frontend
     recompute σ-Move live from the quote.
 
+    ``session_date`` is the current session's exchange-local date (from the
+    quote). When known, it disambiguates the one case the close heuristic can't:
+    if Yahoo's daily feed hasn't appended today's forming bar yet, the trailing
+    row is a *completed* prior session whose own predecessor can still fall
+    within tol of ``previous_close`` (a flat prior day) — which would otherwise
+    misfire the drop and discard a real completed bar. A trailing bar dated
+    before the session is therefore kept.
+
     A no-op (returns ``df`` unchanged) when the quote is missing, the frame is
     too short to have a predecessor, the last bar is already a completed prior
     session, or a closed session's bar has settled to the live price.
@@ -71,6 +80,17 @@ def drop_unsettled_last_bar(
     # the quote's previous close). Otherwise it is already a completed bar.
     if not _reconciles(prev_bar_close, previous_close):
         return df
+
+    # If we know the live session's date and the trailing bar predates it, Yahoo
+    # simply hasn't appended today's forming bar yet: this row is a completed
+    # prior session, not an unsettled one — keep it. (Without this a flat prior
+    # day, where the predecessor also matches ``previous_close``, would be
+    # wrongly dropped and blank σ-Move until a heal.)
+    if session_date is not None:
+        last_bar_dt = df.index[-1]
+        last_bar_date = last_bar_dt.date() if hasattr(last_bar_dt, "date") else last_bar_dt
+        if last_bar_date < session_date:
+            return df
 
     # An open session's bar is always a live partial — drop it even though it
     # matches the live price right now, because it will drift as trading goes on.
@@ -96,10 +116,27 @@ def drop_unsettled_last_bar(
     return df.iloc[:-1]
 
 
+# A per-symbol reconciliation anchor: (price, previous_close, market_state,
+# session_date). ``session_date`` is the exchange-local date of the live
+# session, used to keep a completed bar Yahoo's feed hasn't superseded yet.
+Anchor = tuple[float | None, float | None, str | None, date | None]
+_NO_ANCHOR: Anchor = (None, None, None, None)
+
+
+def _as_date(value: str | None) -> date | None:
+    """Parse an ISO date string (from a quote's ``session_date``) to a date."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
 async def _quote_anchors(
     provider: PriceProvider, symbols: list[str],
-) -> dict[str, tuple[float | None, float | None, str | None]]:
-    """Fetch ``{symbol: (price, previous_close, market_state)}`` for reconciliation.
+) -> dict[str, Anchor]:
+    """Fetch ``{symbol: (price, previous_close, market_state, session_date)}``.
 
     Best-effort: a quote-fetch failure degrades to storing every bar (the prior
     behaviour) rather than aborting the sync.
@@ -112,21 +149,54 @@ async def _quote_anchors(
         logger.warning("Quote fetch for settlement check failed; storing all bars", exc_info=True)
         return {}
     return {
-        q["symbol"]: (q.get("price"), q.get("previous_close"), q.get("market_state"))
+        q["symbol"]: (
+            q.get("price"), q.get("previous_close"),
+            q.get("market_state"), _as_date(q.get("session_date")),
+        )
         for q in quotes
         if q.get("symbol")
     }
 
 
-async def sync_asset_prices(db: AsyncSession, asset: Asset, period: str = "3mo") -> int:
-    """Fetch and upsert price data for a single asset. Returns number of rows upserted."""
+async def _drop_and_persist(
+    db: AsyncSession, asset_id: int, df: pd.DataFrame, anchor: Anchor, symbol: str,
+) -> int:
+    """Drop the trailing unsettled bar (if any), upsert the rest, and purge any
+    stale copy left behind. Returns the number of rows upserted.
+
+    When the trailing bar is dropped, a partial persisted at that date by an
+    earlier (e.g. quote-degraded) sync would linger in the DB — upsert only
+    touches the completed rows it received, so it can never clear a row it no
+    longer has. That orphan keeps ``get_latest_closes`` returning an unreconciled
+    close and blanks σ-Move for the whole session. Delete any row past the last
+    kept bar so the settled data is authoritative.
+    """
+    price, previous_close, market_state, session_date = anchor
+    kept = drop_unsettled_last_bar(
+        df, price, previous_close, market_state, symbol=symbol, session_date=session_date,
+    )
+    count = await _upsert_prices(db, asset_id, kept)
+    if not kept.empty and len(kept) < len(df):
+        last_kept = kept.index[-1]
+        last_kept = last_kept.date() if hasattr(last_kept, "date") else last_kept
+        await PriceRepository(db).delete_prices_after(asset_id, last_kept)
+    return count
+
+
+async def sync_asset_prices(
+    db: AsyncSession, asset: Asset, period: str = "3mo", anchor: Anchor | None = None,
+) -> int:
+    """Fetch and upsert price data for a single asset. Returns number of rows upserted.
+
+    ``anchor`` lets a caller that already holds the symbol's reconciliation
+    anchor (e.g. the price-heal loop, which batch-fetched every quote) pass it
+    in, avoiding a redundant per-symbol quote round-trip.
+    """
     provider = get_price_provider()
     df = await provider.fetch_history(asset.symbol, period=period)
-    price, previous_close, market_state = (await _quote_anchors(provider, [asset.symbol])).get(
-        asset.symbol, (None, None, None)
-    )
-    df = drop_unsettled_last_bar(df, price, previous_close, market_state, symbol=asset.symbol)
-    return await _upsert_prices(db, asset.id, df)
+    if anchor is None:
+        anchor = (await _quote_anchors(provider, [asset.symbol])).get(asset.symbol, _NO_ANCHOR)
+    return await _drop_and_persist(db, asset.id, df, anchor, asset.symbol)
 
 
 async def sync_asset_prices_range(
@@ -155,9 +225,9 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
     for sym, df in data.items():
         asset_id = asset_map.get(sym)
         if asset_id:
-            price, previous_close, market_state = anchors.get(sym, (None, None, None))
-            df = drop_unsettled_last_bar(df, price, previous_close, market_state, symbol=sym)
-            counts[sym] = await _upsert_prices(db, asset_id, df)
+            counts[sym] = await _drop_and_persist(
+                db, asset_id, df, anchors.get(sym, _NO_ANCHOR), sym,
+            )
 
     # The batch response silently omits symbols Yahoo hiccupped on; without a
     # retry those stay stale until the next scheduled run (up to a full day).
@@ -181,9 +251,9 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
             if df is None or df.empty:
                 logger.warning("Retry fetch for %s returned no data", sym)
                 continue
-            price, previous_close, market_state = anchors.get(sym, (None, None, None))
-            df = drop_unsettled_last_bar(df, price, previous_close, market_state, symbol=sym)
-            counts[sym] = await _upsert_prices(db, asset_map[sym], df)
+            counts[sym] = await _drop_and_persist(
+                db, asset_map[sym], df, anchors.get(sym, _NO_ANCHOR), sym,
+            )
 
     return counts
 

--- a/backend/app/services/yahoo/_parsers.py
+++ b/backend/app/services/yahoo/_parsers.py
@@ -9,13 +9,44 @@ import datetime
 import logging
 import math
 from datetime import datetime as _datetime
+from datetime import timezone as _timezone
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pandas as pd
 
 from app.services.yahoo.currency import resolve_currency
 
 logger = logging.getLogger(__name__)
+
+
+def _quote_session_date(info: dict) -> str | None:
+    """Exchange-local calendar date of the quote's current session (ISO string).
+
+    Derived from the /v7 quote's epoch ``regularMarketTime`` interpreted in the
+    exchange's own timezone. Lets price-sync tell a still-forming current-session
+    daily bar from a completed prior one when Yahoo's daily history lags the live
+    session (see ``drop_unsettled_last_bar``). Best-effort: ``None`` when either
+    field is absent or unparseable, in which case the sync falls back to its
+    close-reconciliation heuristic.
+    """
+    ts = info.get("regularMarketTime")
+    tz_name = info.get("exchangeTimezoneName")
+    if ts is None or not tz_name:
+        return None
+    try:
+        tz = ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+    try:
+        # Yahoo's /v7 quote gives epoch seconds; be tolerant of a datetime too.
+        if isinstance(ts, _datetime):
+            moment = ts if ts.tzinfo else ts.replace(tzinfo=_timezone.utc)
+        else:
+            moment = _datetime.fromtimestamp(int(ts), tz=_timezone.utc)
+    except (ValueError, OSError, OverflowError, TypeError):
+        return None
+    return moment.astimezone(tz).date().isoformat()
 
 
 # Period strings accepted by Yahoo's history endpoint.
@@ -118,6 +149,9 @@ def parse_quote_row(sym: str, info: dict) -> dict:
         "avg_volume": int(avg_volume) if avg_volume is not None else None,
         "currency": currency,
         "market_state": info.get("marketState"),
+        # Exchange-local session date (ISO str, best-effort). Internal reconciliation
+        # aid for price-sync; QuoteResponse ignores it, the SSE forwards it harmlessly.
+        "session_date": _quote_session_date(info),
     }
 
 

--- a/backend/tests/repositories/test_price_repo.py
+++ b/backend/tests/repositories/test_price_repo.py
@@ -53,6 +53,38 @@ async def test_list_by_asset_since(db):
     assert all(p.date >= since for p in result)
 
 
+async def test_delete_prices_after(db):
+    """delete_prices_after removes only rows strictly after the cutoff date."""
+    asset = await _create_asset(db)
+    await _seed_prices(db, asset.id, n_days=20)
+    repo = PriceRepository(db)
+
+    all_rows = await repo.list_by_asset(asset.id)
+    cutoff = all_rows[len(all_rows) // 2].date
+    expected = sum(1 for p in all_rows if p.date > cutoff)
+
+    deleted = await repo.delete_prices_after(asset.id, cutoff)
+
+    assert deleted == expected
+    assert deleted > 0  # the split actually left rows past the cutoff to delete
+    remaining = await repo.list_by_asset(asset.id)
+    assert all(p.date <= cutoff for p in remaining)
+
+
+async def test_delete_prices_after_scoped_to_asset(db):
+    """Deletion never touches another asset's rows."""
+    a1 = await _create_asset(db, "AAPL")
+    a2 = await _create_asset(db, "MSFT")
+    await _seed_prices(db, a1.id, n_days=10)
+    await _seed_prices(db, a2.id, n_days=10)
+    repo = PriceRepository(db)
+
+    await repo.delete_prices_after(a1.id, date(1900, 1, 1))  # wipe a1 entirely
+
+    assert await repo.list_by_asset(a1.id) == []
+    assert len(await repo.list_by_asset(a2.id)) > 0
+
+
 async def test_list_by_assets_since(db):
     a1 = await _create_asset(db, "AAPL")
     a2 = await _create_asset(db, "MSFT")

--- a/backend/tests/services/test_price_heal.py
+++ b/backend/tests/services/test_price_heal.py
@@ -55,7 +55,11 @@ async def test_heal_refreshes_unreconciled_asset(db):
         healed = await heal_unreconciled_prices(db)
 
     assert healed == {"PRY.MI": 22}
-    mock_sync.assert_awaited_once_with(db, asset, period="1mo")
+    # The heal threads the already-fetched quote anchor into the sync so it
+    # doesn't re-fetch the same quote (#5): (price, previous_close, state, date).
+    mock_sync.assert_awaited_once_with(
+        db, asset, period="1mo", anchor=(close * 0.90, close * 0.95, "REGULAR", None),
+    )
 
 
 async def test_heal_skips_reconciling_assets(db):

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -7,8 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pandas as pd
 import pytest
 
-from app.models import Asset, AssetType
+from app.models import Asset, AssetType, PriceHistory
+from app.repositories.price_repo import PriceRepository
 from app.services.price_sync import (
+    _drop_and_persist,
     _upsert_prices,
     drop_unsettled_last_bar,
     sync_all_prices,
@@ -325,3 +327,83 @@ async def test_sync_all_keeps_settled_bar(db):
         await sync_all_prices(db, period="1y")
 
     assert captured["len"] == 3  # nothing dropped
+
+
+# --- drop_unsettled_last_bar: session-date guard (mid-session Yahoo lag) ---
+#
+# When Yahoo hasn't appended today's forming bar yet, the trailing row is a
+# *completed* prior session whose own predecessor can coincidentally fall within
+# tol of previous_close (a flat prior day). The close heuristic alone would drop
+# that real bar; the session date keeps it.
+
+async def test_drop_unsettled_keeps_completed_bar_before_session():
+    """A trailing bar dated before the live session is completed → kept, even
+    when its predecessor reconciles with previous_close (the flat-day misfire)."""
+    # Last bar (100.0) is yesterday; predecessor (99.8) is within 0.5% of the
+    # quote's previous_close (100.0) — the exact coincidence that misfires.
+    df = _df_from_closes([100.0, 99.8, 100.0])
+    session_date = date(2025, 1, 7)  # after the last bar's date (2025-01-06)
+    out = drop_unsettled_last_bar(
+        df, price=102.0, previous_close=100.0, market_state="REGULAR",
+        session_date=session_date,
+    )
+    assert len(out) == len(df)  # kept — it is a completed prior session
+
+    # Without the session date the close heuristic can't tell and drops it —
+    # this is the latent bug the guard closes.
+    out_no_date = drop_unsettled_last_bar(df, 102.0, 100.0, "REGULAR")
+    assert len(out_no_date) == len(df) - 1
+
+
+async def test_drop_unsettled_drops_forming_bar_on_session_date():
+    """A trailing bar dated on the live session is the forming bar → still dropped."""
+    df = _df_from_closes([305.0, 290.23, 224.14])
+    out = drop_unsettled_last_bar(
+        df, price=220.84, previous_close=290.23, market_state="REGULAR",
+        session_date=date(2025, 1, 6),  # == the last bar's date
+    )
+    assert len(out) == len(df) - 1
+    assert float(out.iloc[-1]["close"]) == 290.23
+
+
+# --- _drop_and_persist: purge an orphaned partial a re-sync can't upsert away ---
+
+async def test_drop_and_persist_deletes_orphaned_partial(db):
+    """When a bar is dropped, a stale partial persisted past it is purged, so an
+    upsert-only re-sync can't leave σ-Move blank all session."""
+    asset = Asset(symbol="ORPH", name="Orphan", type=AssetType.STOCK, currency="USD")
+    db.add(asset)
+    await db.flush()
+    # A leftover partial at a later date than anything the fetch will keep.
+    db.add(PriceHistory(asset_id=asset.id, date=date(2025, 6, 30),
+                        open=1, high=1, low=1, close=999.0, volume=0))
+    await db.commit()
+
+    # Fetched frame's last bar is a forming partial (predecessor == previous_close),
+    # so drop_unsettled removes it; kept ends at an early-January date.
+    df = _df_from_closes([305.0, 290.23, 224.14])
+    anchor = (220.84, 290.23, "REGULAR", None)
+    with patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=2):
+        await _drop_and_persist(db, asset.id, df, anchor, "ORPH")
+
+    latest = await PriceRepository(db).get_latest_closes([asset.id])
+    assert asset.id not in latest  # the orphaned 2025-06-30 partial was deleted
+
+
+async def test_drop_and_persist_keeps_rows_when_nothing_dropped(db):
+    """No drop → no delete: a settled frame leaves later stored rows untouched."""
+    asset = Asset(symbol="KEEP", name="Keep", type=AssetType.STOCK, currency="USD")
+    db.add(asset)
+    await db.flush()
+    db.add(PriceHistory(asset_id=asset.id, date=date(2025, 6, 30),
+                        open=1, high=1, low=1, close=500.0, volume=0))
+    await db.commit()
+
+    # Closed, settled bar (matches live price) → drop_unsettled keeps everything.
+    df = _df_from_closes([57.5, 58.04, 59.0])
+    anchor = (58.72, 58.04, "POSTPOST", None)
+    with patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=3):
+        await _drop_and_persist(db, asset.id, df, anchor, "KEEP")
+
+    latest = await PriceRepository(db).get_latest_closes([asset.id])
+    assert latest[asset.id][0] == date(2025, 6, 30)  # untouched

--- a/backend/tests/services/test_yahoo_quotes.py
+++ b/backend/tests/services/test_yahoo_quotes.py
@@ -1,10 +1,15 @@
 """Tests for Yahoo Finance real-time quote fetching."""
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.services.yahoo import yahoo_client
+from app.services.yahoo._parsers import (
+    _quote_session_date,
+    parse_quote_row,
+)
 from app.services.yahoo._parsers import (
     parse_quotes as _parse_quotes,
 )
@@ -12,6 +17,40 @@ from app.services.yahoo._parsers import (
     sanitize_float as _sanitize_float,
 )
 from app.services.yahoo.rate_limit import crumb_rejected
+
+
+class TestSessionDate:
+    """``session_date`` is the exchange-local calendar date of the live session,
+    used by price-sync to tell a forming bar from a completed prior one."""
+
+    def test_uses_exchange_timezone(self):
+        # 23:30 UTC is already the next calendar day in Tokyo but not in New York.
+        epoch = int(datetime(2024, 1, 1, 23, 30, tzinfo=timezone.utc).timestamp())
+        assert _quote_session_date(
+            {"regularMarketTime": epoch, "exchangeTimezoneName": "Asia/Tokyo"}
+        ) == "2024-01-02"
+        assert _quote_session_date(
+            {"regularMarketTime": epoch, "exchangeTimezoneName": "America/New_York"}
+        ) == "2024-01-01"
+
+    def test_missing_fields_return_none(self):
+        assert _quote_session_date({}) is None
+        assert _quote_session_date({"regularMarketTime": 1704151800}) is None
+        assert _quote_session_date({"exchangeTimezoneName": "Asia/Tokyo"}) is None
+
+    def test_bad_timezone_returns_none(self):
+        assert _quote_session_date(
+            {"regularMarketTime": 1704151800, "exchangeTimezoneName": "Not/AZone"}
+        ) is None
+
+    def test_parse_quote_row_includes_session_date(self):
+        epoch = int(datetime(2024, 1, 2, 15, 0, tzinfo=timezone.utc).timestamp())
+        row = parse_quote_row("AAPL", {
+            "currency": "USD", "regularMarketPrice": 100.0,
+            "regularMarketPreviousClose": 99.0, "marketState": "REGULAR",
+            "regularMarketTime": epoch, "exchangeTimezoneName": "America/New_York",
+        })
+        assert row["session_date"] == "2024-01-02"
 
 
 class TestSanitize:

--- a/frontend/src/components/group-table/index.tsx
+++ b/frontend/src/components/group-table/index.tsx
@@ -6,6 +6,8 @@ import type { GroupSortBy, SortDir } from "@/lib/settings"
 import { getSeriesByField } from "@/lib/indicator-registry"
 import { toggleSetItem } from "@/lib/utils"
 import { useSettings } from "@/lib/settings"
+import { useAddAssetToThesis } from "@/lib/queries"
+import { NewThesisDialog } from "@/components/thesis/new-thesis-dialog"
 const noop = () => {}
 
 import { SortableHeader } from "./sortable-header"
@@ -52,6 +54,10 @@ interface GroupTableProps {
 
 export function GroupTable({ assets, quotes, indicators, renderContextMenu, compactMode, onHover, sortBy, sortDir, onSort, moreAssets, moreLabel, moreOpen, onToggleMore, accentColors, accentTitles, accentIcons }: GroupTableProps) {
   const [expandedSymbols, setExpandedSymbols] = useState<Set<string>>(new Set())
+  // Single "new thesis for asset" dialog owned by the table, targeted by the
+  // active row — instead of every row mounting its own dialog + mutation.
+  const [newThesisFor, setNewThesisFor] = useState<Asset | null>(null)
+  const addToThesis = useAddAssetToThesis()
   const [internalMoreOpen, setInternalMoreOpen] = useState(false)
   const moreOpenState = moreOpen ?? internalMoreOpen
   const toggleMore = onToggleMore ?? (() => setInternalMoreOpen((o) => !o))
@@ -112,6 +118,7 @@ export function GroupTable({ assets, quotes, indicators, renderContextMenu, comp
       visibleIndicatorFields={visibleIndicatorFields}
       totalColSpan={totalColSpan}
       renderContextMenu={renderContextMenu}
+      onNewThesis={setNewThesisFor}
       accent={accentColors?.[asset.symbol]}
       accentTitle={accentTitles?.[asset.symbol]}
       accentIcon={accentIcons?.[asset.symbol]}
@@ -229,6 +236,13 @@ export function GroupTable({ assets, quotes, indicators, renderContextMenu, comp
           )}
         </tbody>
       </table>
+      <NewThesisDialog
+        open={newThesisFor != null}
+        onOpenChange={(o) => { if (!o) setNewThesisFor(null) }}
+        onCreated={(thesis) => {
+          if (newThesisFor) addToThesis.mutate({ thesisId: thesis.id, assetId: newThesisFor.id })
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -5,8 +5,6 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu"
 import { EditAssetDialog } from "@/components/assets/edit-asset-dialog"
-import { NewThesisDialog } from "@/components/thesis/new-thesis-dialog"
-import { useAddAssetToThesis } from "@/lib/queries"
 import { TagBadge } from "@/components/tags/tag-badge"
 import { MarketStatusDot } from "@/components/market-status-dot"
 import { ExpandedAssetChart } from "@/components/chart/expanded-asset-chart"
@@ -79,6 +77,7 @@ export const TableRow = memo(function TableRow({
   visibleIndicatorFields,
   totalColSpan,
   renderContextMenu,
+  onNewThesis,
   accent,
   accentTitle,
   accentIcon,
@@ -94,6 +93,8 @@ export const TableRow = memo(function TableRow({
   visibleIndicatorFields: string[]
   totalColSpan: number
   renderContextMenu?: RowMenuRenderer
+  /** Open the (table-owned, single) "new thesis for this asset" dialog. */
+  onNewThesis?: (asset: Asset) => void
   /** Left-border accent colour (thesis colour) for the "inline" thesis grouping. */
   accent?: string
   /** Tooltip for the accent bar — the thesis name(s) this row belongs to. */
@@ -132,15 +133,13 @@ export const TableRow = memo(function TableRow({
   const handleToggle = useCallback(() => onToggle(asset.symbol), [onToggle, asset.symbol])
   const handleHover = useCallback(() => onHover(asset.symbol), [onHover, asset.symbol])
   const [editOpen, setEditOpen] = useState(false)
-  const [newThesisOpen, setNewThesisOpen] = useState(false)
-  const addToThesis = useAddAssetToThesis()
   // resolveIcon returns stable refs from lucide's static icon map.
   const AccentIcon = resolveIcon(accentIcon)
 
   const menu = renderContextMenu?.({
     asset,
     openEdit: () => setEditOpen(true),
-    openNewThesis: () => setNewThesisOpen(true),
+    openNewThesis: () => onNewThesis?.(asset),
   })
 
   const row = (
@@ -339,11 +338,6 @@ export const TableRow = memo(function TableRow({
         row
       )}
       <EditAssetDialog asset={asset} open={editOpen} onOpenChange={setEditOpen} />
-      <NewThesisDialog
-        open={newThesisOpen}
-        onOpenChange={setNewThesisOpen}
-        onCreated={(thesis) => addToThesis.mutate({ thesisId: thesis.id, assetId: asset.id })}
-      />
       {expanded && (
         <tr>
           <td colSpan={totalColSpan} className="bg-muted/20 p-4 border-b border-border">

--- a/frontend/src/components/scanner-view.tsx
+++ b/frontend/src/components/scanner-view.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { ChartSyncProvider } from "@/components/chart/chart-sync-provider"
 import { SubChart } from "@/components/chart/sub-chart"
 import { useAssetDetail } from "@/lib/queries"
+import { toggleSetItem } from "@/lib/utils"
 import type { Asset } from "@/lib/api"
 
 interface ScannerViewProps {
@@ -20,12 +21,7 @@ export function ScannerView({ assets, descriptorId, period }: ScannerViewProps) 
   const hiddenAssets = assets.filter((a) => hiddenSymbols.has(a.symbol))
 
   const toggleHide = (symbol: string) => {
-    setHiddenSymbols((prev) => {
-      const next = new Set(prev)
-      if (next.has(symbol)) next.delete(symbol)
-      else next.add(symbol)
-      return next
-    })
+    setHiddenSymbols((prev) => toggleSetItem(prev, symbol))
   }
 
   return (

--- a/frontend/src/components/thesis/thesis-grouped-table.tsx
+++ b/frontend/src/components/thesis/thesis-grouped-table.tsx
@@ -3,6 +3,7 @@ import { Pencil, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { Asset, Group, IndicatorSummary, Quote, Thesis } from "@/lib/api"
 import { buildAssetsById } from "@/lib/assets"
+import { toggleSetItem } from "@/lib/utils"
 import type { GroupSortBy, SortDir } from "@/lib/settings"
 import { useIndicators } from "@/lib/queries"
 import { GroupTable, type RowMenuRenderer } from "@/components/group-table"
@@ -35,13 +36,7 @@ export function ThesisGroupedTable({
   // Which theses have their "+N more" fold expanded (drives the lazy indicator fetch).
   const [revealed, setRevealed] = useState<Set<number>>(new Set())
 
-  const toggleReveal = (id: number) =>
-    setRevealed((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
+  const toggleReveal = (id: number) => setRevealed((prev) => toggleSetItem(prev, id))
 
   // Full Asset objects keyed by id, sourced from every group. Lets the "elsewhere"
   // fold render the same rich GroupTable rows (price/change/indicators) as the

--- a/frontend/src/lib/movement-stats.test.ts
+++ b/frontend/src/lib/movement-stats.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest"
+import { computeMovementStats } from "./movement-stats"
+import type { Price } from "@/lib/types"
+
+/** Build an ascending-by-date price series from a list of closes. */
+function series(closes: number[]): Price[] {
+  return closes.map((close, i) => ({
+    date: `2025-01-${String(i + 1).padStart(2, "0")}`,
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 1_000_000,
+  }))
+}
+
+describe("computeMovementStats — max daily gain/loss sign guards", () => {
+  it("reports no daily loss for an all-up window (the bug: smallest gain mislabelled as a loss)", () => {
+    const stats = computeMovementStats(series([100, 101, 103, 106]))!
+    expect(stats.maxDailyLoss).toBeNull()
+    expect(stats.maxDailyGain).not.toBeNull()
+    expect(stats.maxDailyGain!.pct).toBeGreaterThan(0)
+    expect(stats.downDays).toBe(0)
+  })
+
+  it("reports no daily gain for an all-down window", () => {
+    const stats = computeMovementStats(series([106, 103, 101, 100]))!
+    expect(stats.maxDailyGain).toBeNull()
+    expect(stats.maxDailyLoss).not.toBeNull()
+    expect(stats.maxDailyLoss!.pct).toBeLessThan(0)
+    expect(stats.upDays).toBe(0)
+  })
+
+  it("picks the correct extreme of each sign in a mixed window", () => {
+    // Day moves: +5%, -10% (biggest loss), +1%, +8% (biggest gain).
+    const stats = computeMovementStats(series([100, 105, 94.5, 95.445, 103.08]))!
+    expect(stats.maxDailyGain!.pct).toBeGreaterThan(stats.maxDailyLoss!.pct)
+    expect(stats.maxDailyGain!.pct).toBeGreaterThan(0)
+    expect(stats.maxDailyLoss!.pct).toBeLessThan(0)
+    // The biggest gain is the last day (~+8%), the biggest loss the second (~-10%).
+    expect(stats.maxDailyGain!.date).toBe("2025-01-05")
+    expect(stats.maxDailyLoss!.date).toBe("2025-01-03")
+  })
+
+  it("treats a flat day as neither a gain nor a loss", () => {
+    const stats = computeMovementStats(series([100, 100, 100]))!
+    expect(stats.maxDailyGain).toBeNull()
+    expect(stats.maxDailyLoss).toBeNull()
+    expect(stats.upDays).toBe(0)
+    expect(stats.downDays).toBe(0)
+  })
+})

--- a/frontend/src/lib/movement-stats.ts
+++ b/frontend/src/lib/movement-stats.ts
@@ -23,9 +23,9 @@ export interface MovementStats {
   startClose: number
   /** Latest close in the window. */
   endClose: number
-  /** Largest single-day gain (close-to-close). Null only when there are no day-over-day transitions. */
+  /** Largest single-day gain (close-to-close); `pct` is positive. Null when the window has no up day. */
   maxDailyGain: DailyExtreme | null
-  /** Largest single-day loss (close-to-close); `pct` is negative for a genuine loss. */
+  /** Largest single-day loss (close-to-close); `pct` is negative. Null when the window has no down day. */
   maxDailyLoss: DailyExtreme | null
   /** Largest peak-to-trough decline over the window. Null when the close never fell below a running peak. */
   maxDrawdown: Drawdown | null
@@ -73,8 +73,12 @@ export function computeMovementStats(prices: Price[]): MovementStats | null {
       const dayPct = (cur / prev - 1) * 100
       if (dayPct > 0) upDays++
       else if (dayPct < 0) downDays++
-      if (maxDailyGain === null || dayPct > maxDailyGain.pct) maxDailyGain = { pct: dayPct, date }
-      if (maxDailyLoss === null || dayPct < maxDailyLoss.pct) maxDailyLoss = { pct: dayPct, date }
+      // Sign-guarded so an all-up (or all-down) window can't file the smallest
+      // gain under "Max daily loss" (or vice versa): a gain is only a gain, a
+      // loss only a loss. A window with no down day leaves maxDailyLoss null,
+      // which the UI renders as "—".
+      if (dayPct > 0 && (maxDailyGain === null || dayPct > maxDailyGain.pct)) maxDailyGain = { pct: dayPct, date }
+      if (dayPct < 0 && (maxDailyLoss === null || dayPct < maxDailyLoss.pct)) maxDailyLoss = { pct: dayPct, date }
     }
 
     if (cur > peak) {

--- a/frontend/src/pages/theses/index.tsx
+++ b/frontend/src/pages/theses/index.tsx
@@ -6,6 +6,8 @@ import { useQuotes } from "@/lib/quote-stream"
 import { useSettings } from "@/lib/settings"
 import type { Thesis, ThesisPerformancePoint } from "@/lib/api"
 import { GroupTable } from "@/components/group-table"
+import { compareSortValues } from "@/lib/use-group-filter"
+import { toggleSetItem } from "@/lib/utils"
 import { ThesisSectionHeader } from "@/components/thesis/thesis-section-header"
 import { ThesisMemberContextMenuContent } from "@/components/thesis/thesis-member-context-menu"
 import { CrosshairTimeSyncProvider } from "@/components/chart/crosshair-time-sync"
@@ -34,14 +36,11 @@ export function ThesesPage() {
   )
 
   // Visible theses, sorted as a leaderboard: best aggregate first, nulls last.
+  // Reuse the group table's nulls-last comparator (args swapped for descending)
+  // so the leaderboard can't order null aggregates differently from the table.
   const visible = useMemo(() => {
     const filtered = showPlayedOut ? allTheses : allTheses.filter((t) => t.status !== "played_out")
-    return [...filtered].sort((a, b) => {
-      if (a.aggregate_pct == null && b.aggregate_pct == null) return 0
-      if (a.aggregate_pct == null) return 1
-      if (b.aggregate_pct == null) return -1
-      return b.aggregate_pct - a.aggregate_pct
-    })
+    return [...filtered].sort((a, b) => compareSortValues(b.aggregate_pct, a.aggregate_pct))
   }, [allTheses, showPlayedOut])
 
   // Fetch indicators only for the members of expanded theses (lazy on expand).
@@ -55,13 +54,7 @@ export function ThesesPage() {
   }, [visible, expanded])
   const { data: indicators } = useIndicators(expandedSymbols)
 
-  const toggle = (id: number) =>
-    setExpanded((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
+  const toggle = (id: number) => setExpanded((prev) => toggleSetItem(prev, id))
 
   const allExpanded = visible.length > 0 && visible.every((t) => expanded.has(t.id))
   const toggleAll = () => setExpanded(allExpanded ? new Set() : new Set(visible.map((t) => t.id)))


### PR DESCRIPTION
## What

Fixes for the 9 findings from the high-effort pre-promotion review of `dev`, so the eventual `dev → main` promotion is clean. **8 of 9 fixed; 1 (#9) intentionally deferred — see below.**

### Correctness (3)

1. **Movement-stats mislabel** — `maxDailyGain`/`maxDailyLoss` had no sign guard, so an all-up "since" window showed the smallest gain under a green "Max daily loss" (and vice versa). Sign-guarded; a window with no down (or up) day now renders "—".
2. **Heal couldn't clear a persisted current-session partial** — an upsert only touches the completed rows it receives, so a partial left by an earlier quote-degraded sync lingered and kept σ-Move blank all session. `_drop_and_persist` now deletes any row past the last kept bar (new `PriceRepository.delete_prices_after`) whenever a bar is dropped.
3. **`drop_unsettled_last_bar` could drop a real completed bar** — when Yahoo's daily feed hasn't appended today's forming bar yet, the trailing row is a completed prior session whose predecessor can coincidentally match `previous_close` (a flat prior day), misfiring the drop. Now guarded by the exchange-local **session date** derived from the `/v7` quote (`regularMarketTime` + `exchangeTimezoneName`); best-effort, falls back to the old heuristic when unavailable. This preserves the "never store open-session partials" invariant (a close-only fix would have regressed it).

### Cleanups (5)

4. **Heal job** now skips weekends (the practical "all markets closed" window) — avoids ~288 no-op full-portfolio quote fetches/weekend.
5. **Heal** threads its already-fetched quote anchor into `sync_asset_prices`, dropping the redundant per-symbol quote re-fetch.
6. **Per-row `NewThesisDialog` + mutation** hoisted out of `TableRow` into a single table-owned instance targeted by the active row (cost no longer scales with row count).
7. **Hand-rolled Set clone-toggle** in the theses page, thesis-grouped-table, and scanner-view replaced with the existing `toggleSetItem` util.
8. **Theses leaderboard sort** reuses `compareSortValues` (args swapped for descending) instead of re-implementing nulls-last.

### Deferred (1)

9. **`hard_delete_asset` hand-enumerates cascades** the FKs already declare `ON DELETE CASCADE`. The suggested fix — enabling `PRAGMA foreign_keys=ON` globally in the SQLite test engine — was **attempted and reverted**: it turns one full-suite test (`test_indicators_tracked_asset`) red by perturbing timing enough to expose a **pre-existing test-isolation flake** (a leaked `fundamentals_cache` background task + module-level cache). The current `hard_delete_asset` is documented and correct. Recommend handling #9 as a separate change that also hardens the leaked background task — not worth destabilizing this promotion. (Suite is green without the PRAGMA.)

## Verification

- Backend: `pytest` — **724 passed** (+10 new: session-date TZ derivation, drop-guard keep/drop, orphan purge, `delete_prices_after` scope)
- Frontend: `tsc -b` clean · `eslint .` clean · `vitest run` — **26 passed** (+4 movement-stats sign guards) · `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
