### PR TITLE
fix: rely on DB cascade for hard_delete_asset + isolate fundamentals cache (review #9)

### DIFF
--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -8,12 +8,9 @@ from app.models import (
     AssetType,
     Group,
     Note,
-    PriceHistory,
     PseudoETF,
     group_assets,
     pseudo_etf_constituents,
-    tag_assets,
-    thesis_assets,
 )
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
@@ -151,22 +148,20 @@ async def get_attachments(db: AsyncSession, symbol: str) -> AssetAttachments:
 
 async def hard_delete_asset(db: AsyncSession, symbol: str):
     """Permanently delete the asset row and everything attached to it: group and
-    pseudo-ETF memberships, thesis memberships, tags, note, annotations, prices.
+    pseudo-ETF memberships, thesis memberships, tags, note, annotations, prices,
+    intraday bars.
 
     This is the explicit lifecycle choice offered in the remove dialog — distinct
-    from the soft ``delete_asset`` (default-group only). Every dependent row is
-    cleared explicitly rather than via ``ON DELETE CASCADE`` (which the SQLite test
-    DB doesn't enforce) or async ORM cascade (which would lazy-load during flush),
-    so the delete behaves identically on Postgres and SQLite.
+    from the soft ``delete_asset`` (default-group only). A single Core ``DELETE``
+    on the asset relies on the ``ON DELETE CASCADE`` every dependent FK declares,
+    so the database clears the dependent rows in one statement (no ORM cascade, so
+    nothing lazy-loads during flush). Tests enforce SQLite FK cascade to match
+    Postgres (see ``conftest``), so this path is exercised the same everywhere.
     """
     asset = await get_asset(symbol, db)
     aid = asset.id
-    # Detach the ORM object so its loaded tag/thesis collections don't make the
-    # unit-of-work re-issue (and mis-count) the association deletes we do by hand.
+    # Detach the ORM object so a stale identity-map entry can't try to manage the
+    # row we're deleting out from under it.
     db.expunge(asset)
-    for table in (group_assets, pseudo_etf_constituents, tag_assets, thesis_assets):
-        await db.execute(delete(table).where(table.c.asset_id == aid))
-    for model in (PriceHistory, Annotation, Note):
-        await db.execute(delete(model).where(model.asset_id == aid))
     await db.execute(delete(Asset).where(Asset.id == aid))
     await db.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.database import Base, get_db
@@ -13,6 +14,18 @@ TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
 engine = create_async_engine(TEST_DB_URL, echo=False)
 TestSession = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+# SQLite ignores foreign-key constraints (and so ON DELETE CASCADE) unless asked
+# per connection. Enable it so tests exercise the same cascade Postgres enforces
+# in production — letting hard_delete_asset rely on the DB cascade the FKs
+# already declare instead of hand-deleting every dependent table.
+@event.listens_for(engine.sync_engine, "connect")
+def _enable_sqlite_fk(dbapi_conn, _record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
 
 # Currencies to seed in tests — subunits + common test currencies
 _SEED_CURRENCIES = [
@@ -110,6 +123,26 @@ def _clear_thesis_perf_cache():
     from app.services import thesis_service
     thesis_service._thesis_perf_cache.clear()
     yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fundamentals_cache(monkeypatch):
+    """Keep the fundamentals cache from leaking across tests.
+
+    ``merge_fundamentals_*`` fire a background ``asyncio.create_task`` that hits
+    the real Yahoo client on a cache miss. Left to run, that fire-and-forget
+    task outlives the per-test event loop (``Task was destroyed but it is
+    pending``) and its result lands in a module-level cache the next test can
+    read — a nondeterministic cross-test coupling. Clear the module state and
+    stub the scheduler to a no-op; tests that care about the merge behaviour
+    patch the merge functions at their call sites instead."""
+    from app.services import fundamentals_cache
+    fundamentals_cache._fundamentals_cache.clear()
+    fundamentals_cache._pending_symbols.clear()
+    monkeypatch.setattr(fundamentals_cache, "_schedule_background_fetch", lambda *_a, **_k: None)
+    yield
+    fundamentals_cache._fundamentals_cache.clear()
+    fundamentals_cache._pending_symbols.clear()
 
 
 @pytest.fixture

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -170,9 +170,10 @@ async def test_soft_delete_leaves_other_attachments(client, db):
 
 async def test_hard_delete_cascades(client, db):
     """#536: hard delete removes the asset and every attachment — group / pseudo-ETF
-    / thesis links, tag, note, annotation, prices — while the group / thesis /
-    pseudo-ETF entities themselves survive."""
-    from datetime import date
+    / thesis links, tag, note, annotation, prices, intraday bars — while the group /
+    thesis / pseudo-ETF entities themselves survive. Relies on the DB ON DELETE
+    CASCADE (tests enforce SQLite FK cascade, mirroring Postgres)."""
+    from datetime import date, datetime, timezone
 
     from sqlalchemy import func, select
 
@@ -180,6 +181,7 @@ async def test_hard_delete_cascades(client, db):
         Annotation,
         Asset,
         AssetType,
+        IntradayPrice,
         Note,
         PriceHistory,
         PseudoETF,
@@ -208,6 +210,9 @@ async def test_hard_delete_cascades(client, db):
     db.add(Note(asset_id=aid, content="thesis note"))
     db.add(Annotation(asset_id=aid, date=date(2026, 1, 1), title="entry"))
     db.add(PriceHistory(asset_id=aid, date=date(2026, 1, 1), open=1, high=1, low=1, close=1, volume=1))
+    db.add(IntradayPrice(
+        asset_id=aid, timestamp=datetime(2026, 1, 1, 15, 0, tzinfo=timezone.utc), price=1.0, volume=10,
+    ))
     await db.commit()
 
     tid = (await client.post("/api/theses", json={"name": "El Niño"})).json()["id"]
@@ -223,7 +228,7 @@ async def test_hard_delete_cascades(client, db):
         assert await count(Asset, Asset.id == aid) == 0
         for table in (group_assets, tag_assets, thesis_assets, pseudo_etf_constituents):
             assert await count(table, table.c.asset_id == aid) == 0
-        for model in (Note, Annotation, PriceHistory):
+        for model in (Note, Annotation, PriceHistory, IntradayPrice):
             assert await count(model, model.asset_id == aid) == 0
         # Parent entities survive the cascade.
         assert await count(PseudoETF, PseudoETF.id == petf.id) == 1


### PR DESCRIPTION
Fixes the one review finding deferred from #554 (#9), the proper way.

## Part 1 — test isolation (the prerequisite)
`merge_fundamentals_*` fire a fire-and-forget `asyncio.create_task` that hits the **real** Yahoo client on a cache miss. Left to run, the task outlives the per-test event loop (`Task was destroyed but it is pending`) and its result lands in a module-level cache the next test could read — a nondeterministic cross-test coupling. This is what made enabling FK enforcement flaky before.

New autouse fixture `_isolate_fundamentals_cache` clears `_fundamentals_cache`/`_pending_symbols` and stubs the scheduler to a no-op (tests that care about the merge behaviour already patch the merge functions at their call sites). Mirrors the existing `_clear_thesis_perf_cache` pattern.

## Part 2 — the #9 cleanup
- Enable `PRAGMA foreign_keys=ON` on the SQLite test engine so tests exercise the same `ON DELETE CASCADE` Postgres runs in production.
- Collapse `hard_delete_asset`'s manual per-table delete loop to a single `delete(Asset)` relying on the DB cascade (all 8 dependent FKs declare `ondelete="CASCADE"`).
- **Latent gap closed:** the manual loop never deleted **intraday bars** — they only cascaded on Postgres via the final delete, and would orphan in SQLite. The single delete cascades them everywhere; the cascade test now asserts it.

## Verification
- Full backend suite **724 passed**, run repeatedly — deterministic, no leaked-task warnings (previously the FK-on flake hit ~1/2 runs).
- `ruff check .` clean · `test_hard_delete_cascades` extended to cover `IntradayPrice`.

Backend-only, 3 files.

> Note: this branch targets `dev`; merging it will also fold #9 into the open `dev → main` promotion (#555).

🤖 Generated with [Claude Code](https://claude.com/claude-code)