### PR TITLE
fix(backend): isolate per-symbol failures in price sync + heal loops

### DIFF
--- a/backend/app/services/price_heal.py
+++ b/backend/app/services/price_heal.py
@@ -99,4 +99,7 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
             healed[sym] = await sync_asset_prices(db, by_symbol[sym], period="1mo", anchor=anchor)
         except Exception:
             logger.warning("Price heal for %s failed", sym, exc_info=True)
+            # This loop shares one session across symbols; roll back a
+            # half-applied transaction so it can't poison the next heal.
+            await db.rollback()
     return healed

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -183,6 +183,28 @@ async def _drop_and_persist(
     return count
 
 
+async def _persist_symbol(
+    db: AsyncSession, asset_id: int, df: pd.DataFrame, anchor: Anchor, symbol: str,
+) -> int | None:
+    """Persist one symbol's frame, isolating its failure from the rest of the run.
+
+    ``sync_all_prices`` shares one session across every symbol, and each symbol
+    commits independently (``_drop_and_persist`` upserts then purges, both of
+    which commit). Without this guard a single symbol raising — a malformed frame
+    or a mid-transaction DB error — aborts the whole nightly refresh, leaving
+    every symbol after it stale until the next run. On failure we roll back so a
+    half-applied transaction can't poison the session for the following symbols
+    (only the failed symbol's uncommitted work is discarded; prior symbols have
+    already committed) and return ``None`` to skip it.
+    """
+    try:
+        return await _drop_and_persist(db, asset_id, df, anchor, symbol)
+    except Exception:
+        logger.warning("Persisting prices for %s failed; skipping", symbol, exc_info=True)
+        await db.rollback()
+        return None
+
+
 async def sync_asset_prices(
     db: AsyncSession, asset: Asset, period: str = "3mo", anchor: Anchor | None = None,
 ) -> int:
@@ -225,9 +247,9 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
     for sym, df in data.items():
         asset_id = asset_map.get(sym)
         if asset_id:
-            counts[sym] = await _drop_and_persist(
-                db, asset_id, df, anchors.get(sym, _NO_ANCHOR), sym,
-            )
+            count = await _persist_symbol(db, asset_id, df, anchors.get(sym, _NO_ANCHOR), sym)
+            if count is not None:
+                counts[sym] = count
 
     # The batch response silently omits symbols Yahoo hiccupped on; without a
     # retry those stay stale until the next scheduled run (up to a full day).
@@ -251,9 +273,9 @@ async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int
             if df is None or df.empty:
                 logger.warning("Retry fetch for %s returned no data", sym)
                 continue
-            counts[sym] = await _drop_and_persist(
-                db, asset_map[sym], df, anchors.get(sym, _NO_ANCHOR), sym,
-            )
+            count = await _persist_symbol(db, asset_map[sym], df, anchors.get(sym, _NO_ANCHOR), sym)
+            if count is not None:
+                counts[sym] = count
 
     return counts
 

--- a/backend/tests/services/test_price_heal.py
+++ b/backend/tests/services/test_price_heal.py
@@ -62,6 +62,37 @@ async def test_heal_refreshes_unreconciled_asset(db):
     )
 
 
+async def test_heal_failure_is_non_fatal_and_rolls_back(db):
+    """A heal that raises doesn't abort the others, and its half-applied
+    transaction is rolled back so the shared session stays usable for the
+    remaining symbols."""
+    good = await seed_asset_with_prices(db, "GOOD.OL", n_days=30)
+    bad = await seed_asset_with_prices(db, "BAD.OL", n_days=30)
+    good_close = await _latest_close(db, good)
+    bad_close = await _latest_close(db, bad)
+
+    # Both quotes sit two sessions ahead of the stored bar: nothing reconciles,
+    # so both are due for a heal.
+    provider = _provider_with_quotes([
+        _quote("GOOD.OL", good_close * 0.90, good_close * 0.95),
+        _quote("BAD.OL", bad_close * 0.90, bad_close * 0.95),
+    ])
+
+    async def fake_sync(_db, asset, **_kw):
+        if asset.symbol == "BAD.OL":
+            raise RuntimeError("boom")
+        return 22
+
+    with patch("app.services.price_heal.get_price_provider", return_value=provider), \
+         patch("app.services.price_heal.sync_asset_prices", side_effect=fake_sync), \
+         patch.object(db, "rollback", new_callable=AsyncMock) as mock_rollback:
+        healed = await heal_unreconciled_prices(db)
+
+    assert healed == {"GOOD.OL": 22}
+    assert "BAD.OL" not in healed
+    mock_rollback.assert_awaited_once()
+
+
 async def test_heal_skips_reconciling_assets(db):
     """Assets whose stored bar matches price or previous_close are left alone."""
     a1 = await seed_asset_with_prices(db, "PREV", n_days=30)

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -208,6 +208,34 @@ async def test_sync_all_retry_failure_is_non_fatal(db):
     assert counts == {"AAPL": 10}
 
 
+async def test_sync_all_main_loop_failure_is_non_fatal(db):
+    """A symbol raising during persist in the main batch loop doesn't abort the
+    rest of the run, and its half-applied transaction is rolled back so it can't
+    poison the symbols that follow it on the shared session."""
+    db.add_all([
+        Asset(symbol="BAD", name="Bad", type=AssetType.STOCK, currency="USD"),
+        Asset(symbol="GOOD", name="Good", type=AssetType.STOCK, currency="USD"),
+    ])
+    await db.commit()
+
+    async def fake_persist(_db, _asset_id, _df, _anchor, symbol):
+        if symbol == "BAD":
+            raise RuntimeError("boom")
+        return 10
+
+    # "BAD" is ordered before "GOOD" in the batch, so GOOD only syncs if the loop
+    # survives BAD's failure rather than aborting on it.
+    mock_prov = _mock_provider(batch_fetch_history={"BAD": _make_df(), "GOOD": _make_df()})
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._drop_and_persist", side_effect=fake_persist), \
+         patch.object(db, "rollback", new_callable=AsyncMock) as mock_rollback:
+        counts = await sync_all_prices(db, period="1y")
+
+    assert counts == {"GOOD": 10}
+    assert "BAD" not in counts
+    mock_rollback.assert_awaited_once()
+
+
 # --- drop_unsettled_last_bar (settlement reconciliation) ---
 #
 # The last stored bar must reconcile with the live quote or the frontend blanks


### PR DESCRIPTION
Addresses findings #2 and #3 from the final review of #555 (price-sync/heal reliability).

## Problem

`sync_all_prices` shares one `AsyncSession` across every symbol, and each symbol commits independently (`upsert_prices` and `delete_prices_after` each commit). But the **main batch loop** called `_drop_and_persist` unwrapped, while the retry loop right below it wrapped each symbol. So:

- **#2 — no per-symbol isolation:** one symbol raising (a malformed frame, or a mid-transaction DB error) aborted the whole nightly refresh, leaving every symbol after it stale until the next run — the exact gap that blanks σ-Move. The `main.py` scheduler wrapper kept the process alive, but that run was lost.
- **#3 — no rollback:** a caught mid-transaction DB error left the shared session in a needs-rollback state, cascading `PendingRollbackError` into every following symbol.

## Fix

- Add `_persist_symbol()`, wrapping `_drop_and_persist` per symbol: on failure it logs, `await db.rollback()` (only the failed symbol's uncommitted work is discarded — prior symbols already committed), and skips (`return None`).
- Route **both** the main loop and the missing-symbol retry loop through it.
- Apply the same `rollback()` to the price-**heal** loop, which shares a session the same way.

## Tests

Two regression tests (`test_sync_all_main_loop_failure_is_non_fatal`, `test_heal_failure_is_non_fatal_and_rolls_back`) order a failing symbol **before** a good one to prove the loop survives, and assert `rollback` is awaited exactly once.

Full backend suite: **726 passed / 0 failed**, ruff clean. Diff +90/−6 (2 app files, 2 test files).

## Relative to #555

These are reliability-hardening, not release blockers. PR'd into `dev` first (per the branching workflow) so the #555 dev→main promotion picks them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)