### PR TITLE
feat(backend): interior-hole heal pass (#559 fix 3)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,7 +36,7 @@ from app.routers import settings as settings_router
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
 from app.services.intraday import cleanup_old_intraday, fetch_and_store_intraday
-from app.services.price_heal import heal_unreconciled_prices
+from app.services.price_heal import heal_interior_holes, heal_unreconciled_prices
 from app.services.price_providers import init_price_provider
 from app.services.price_sync import sync_all_prices
 from app.services.symbol_sync_service import sync_all_enabled as sync_all_symbol_sources
@@ -138,6 +138,16 @@ async def scheduled_price_heal():
                 )
         except Exception:
             logger.exception("Price heal failed")
+        try:
+            # Mid-series holes (issue #559): self-throttled to one scan per
+            # HOLE_SCAN_INTERVAL, so piggybacking on this job costs nothing.
+            filled = await heal_interior_holes(db)
+            if filled:
+                logger.info(
+                    f"Hole heal: refreshed {len(filled)} symbol(s): {', '.join(sorted(filled))}"
+                )
+        except Exception:
+            logger.exception("Hole heal failed")
 
 
 async def scheduled_symbol_sync():

--- a/backend/app/services/price_heal.py
+++ b/backend/app/services/price_heal.py
@@ -1,25 +1,43 @@
-"""Self-heal stored daily bars that contradict the live quote.
+"""Self-heal stored daily bars that are wrong or missing.
 
-The frontend blanks σ-Move when an asset's latest stored close reconciles with
-neither the live price nor the quote's previous close (``isStoredVnrStale`` in
-``frontend/src/lib/indicator-registry.ts``). That state means the stored data
-is at least two sessions behind the quote — e.g. ``drop_unsettled_last_bar``
-discarded a lagging bar and every scheduled sync since missed the symbol, so
-once the quote's previous_close rolled at the next open, nothing reconciled.
+Two independent repair loops:
 
-Rather than waiting up to a day for the next scheduled sync, this job detects
-the broken invariant server-side and refreshes just the affected symbols.
+- ``heal_unreconciled_prices`` — the *trailing-bar* heal: the frontend blanks
+  σ-Move when an asset's latest stored close reconciles with neither the live
+  price nor the quote's previous close (``isStoredVnrStale`` in
+  ``frontend/src/lib/indicator-registry.ts``). That state means the stored
+  data is at least two sessions behind the quote — e.g.
+  ``drop_unsettled_last_bar`` discarded a lagging bar and every scheduled sync
+  since missed the symbol. Rather than waiting up to a day for the next
+  scheduled sync, this detects the broken invariant server-side and refreshes
+  just the affected symbols.
+
+- ``heal_interior_holes`` — the *mid-series* heal (issue #559 fix 3): a
+  scheduled session with no stored bar (upstream feed hole, NaN-skipped
+  upsert, failed nightly sync) silently blanks σ-Move on the bar after it and
+  degrades gap-aware indicators. The venue calendar makes such holes exactly
+  detectable — expected sessions minus stored dates — and Yahoo usually
+  backfills a missing session within a day or two, so a re-fetch of the hole
+  range repairs it automatically.
 """
 
 import logging
 import time
+from datetime import date, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.price_repo import PriceRepository
+from app.services.market_calendar import Symbol
 from app.services.price_providers import get_price_provider
-from app.services.price_sync import Anchor, _as_date, _reconciles, sync_asset_prices
+from app.services.price_sync import (
+    Anchor,
+    _as_date,
+    _reconciles,
+    sync_asset_prices,
+    sync_asset_prices_range,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,5 +119,127 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
             logger.warning("Price heal for %s failed", sym, exc_info=True)
             # This loop shares one session across symbols; roll back a
             # half-applied transaction so it can't poison the next heal.
+            await db.rollback()
+    return healed
+
+
+# ---------------------------------------------------------------------------
+# Interior-hole heal
+# ---------------------------------------------------------------------------
+
+# The hole scan is cheap (one DB query + calendar lookups) but each detected
+# hole costs a Yahoo range fetch, and holes either fill on the first try or
+# need Yahoo to backfill upstream — rescanning faster gains nothing.
+HOLE_SCAN_INTERVAL_SECONDS = 6 * 60 * 60
+
+# A hole that survived a re-fetch is data Yahoo doesn't have (yet). Retry
+# daily — backfills typically land within a day or two — instead of every scan.
+HOLE_RETRY_COOLDOWN_SECONDS = 24 * 60 * 60
+
+# Bound per-scan fetches; wider breakage is a sync-level outage.
+MAX_HOLE_HEALS_PER_SCAN = 5
+
+# Only scan the window that feeds the group snapshot + display periods; ancient
+# holes beyond it don't blank anything a user currently sees.
+HOLE_SCAN_WINDOW_DAYS = 120
+
+_last_hole_scan: float | None = None
+# symbol → (last attempt, the exact holes attempted). A changed hole set is a
+# new problem and bypasses the cooldown.
+_hole_attempts: dict[str, tuple[float, frozenset[date]]] = {}
+
+
+def find_interior_holes(stored: set[date], sessions: set[date]) -> set[date]:
+    """Scheduled sessions strictly inside the stored range with no stored bar.
+
+    Boundaries are excluded on purpose: a missing *leading* stretch is backfill
+    territory (`_ensure_prices`) and a missing *trailing* bar is the
+    reconciliation heal's job — this only finds mid-series holes.
+    """
+    if not stored or not sessions:
+        return set()
+    first, last = min(stored), max(stored)
+    return {d for d in sessions if first < d < last and d not in stored}
+
+
+async def heal_interior_holes(db: AsyncSession, force: bool = False) -> dict[str, int]:
+    """Detect and re-fetch mid-series session holes for grouped assets.
+
+    Returns ``{symbol: rows_upserted}`` for the symbols refreshed this scan.
+    Symbols without a resolvable venue calendar are skipped — without the
+    session list a hole cannot be told apart from a holiday.
+    """
+    global _last_hole_scan
+    now = time.monotonic()
+    if not force and _last_hole_scan is not None and now - _last_hole_scan < HOLE_SCAN_INTERVAL_SECONDS:
+        return {}
+    _last_hole_scan = now
+
+    assets = await AssetRepository(db).list_in_any_group()
+    if not assets:
+        return {}
+
+    window_start = date.today() - timedelta(days=HOLE_SCAN_WINDOW_DAYS)
+    all_prices = await PriceRepository(db).list_by_assets_since(
+        [a.id for a in assets], window_start
+    )
+    stored_by_asset: dict[int, set[date]] = {}
+    for p in all_prices:
+        stored_by_asset.setdefault(p.asset_id, set()).add(p.date)
+
+    candidates = []
+    for asset in assets:
+        stored = stored_by_asset.get(asset.id)
+        if not stored or len(stored) < 2:
+            continue  # initial fill is the sync's job
+        venue = Symbol(asset.symbol).venue
+        if venue is None:
+            continue
+        sessions = venue.session_dates(min(stored), max(stored))
+        if not sessions:
+            continue
+        holes = find_interior_holes(stored, sessions)
+        if not holes:
+            continue
+        signature = frozenset(holes)
+        last = _hole_attempts.get(asset.symbol)
+        if last and last[1] == signature and now - last[0] < HOLE_RETRY_COOLDOWN_SECONDS:
+            continue  # same holes, recently attempted — wait for Yahoo to backfill
+        candidates.append((asset, holes, signature))
+
+    if not candidates:
+        return {}
+
+    deferred = candidates[MAX_HOLE_HEALS_PER_SCAN:]
+    candidates = candidates[:MAX_HOLE_HEALS_PER_SCAN]
+    if deferred:
+        logger.info(
+            "Hole heal: %d symbol(s) with interior holes; healing %d, deferring %d",
+            len(candidates) + len(deferred), len(candidates), len(deferred),
+        )
+
+    healed: dict[str, int] = {}
+    for asset, holes, signature in candidates:
+        _hole_attempts[asset.symbol] = (now, signature)
+        try:
+            count = await sync_asset_prices_range(db, asset, min(holes), max(holes))
+            healed[asset.symbol] = count
+            refreshed = await PriceRepository(db).list_by_asset_since(asset.id, min(holes))
+            remaining = holes - {p.date for p in refreshed}
+            if remaining:
+                logger.info(
+                    "%s: %d of %d interior hole(s) persist after re-fetch "
+                    "(Yahoo may backfill later): %s",
+                    asset.symbol, len(remaining), len(holes),
+                    ", ".join(d.isoformat() for d in sorted(remaining)),
+                )
+            else:
+                logger.info(
+                    "%s: healed %d interior hole(s): %s",
+                    asset.symbol, len(holes),
+                    ", ".join(d.isoformat() for d in sorted(holes)),
+                )
+        except Exception:
+            logger.warning("Hole heal for %s failed", asset.symbol, exc_info=True)
             await db.rollback()
     return healed

--- a/backend/tests/services/test_price_heal.py
+++ b/backend/tests/services/test_price_heal.py
@@ -174,3 +174,111 @@ async def test_heal_caps_per_run_and_defers_rest(db):
     assert len(first) == MAX_HEALS_PER_RUN
     assert len(second) == 2  # deferred symbols healed next run, not lost
     assert mock_sync.await_count == n
+
+
+# ---------------------------------------------------------------------------
+# Interior-hole heal (issue #559 fix 3)
+# ---------------------------------------------------------------------------
+
+from datetime import date, timedelta  # noqa: E402
+
+from sqlalchemy import delete  # noqa: E402
+
+from app.models import PriceHistory  # noqa: E402
+from app.services.market_calendar import Symbol  # noqa: E402
+from app.services.price_heal import find_interior_holes, heal_interior_holes  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_hole_state():
+    price_heal._hole_attempts.clear()
+    price_heal._last_hole_scan = None
+    yield
+    price_heal._hole_attempts.clear()
+    price_heal._last_hole_scan = None
+
+
+def test_find_interior_holes_strictly_inside():
+    """Only mid-series misses count — leading/trailing gaps are other jobs'."""
+    d = date(2026, 8, 3)
+    stored = {d, d + timedelta(days=2), d + timedelta(days=4)}
+    sessions = {d + timedelta(days=i) for i in range(-2, 7)}
+    holes = find_interior_holes(stored, sessions)
+    assert holes == {d + timedelta(days=1), d + timedelta(days=3)}
+
+
+def test_find_interior_holes_empty_inputs():
+    assert find_interior_holes(set(), {date(2026, 8, 3)}) == set()
+    assert find_interior_holes({date(2026, 8, 3)}, set()) == set()
+
+
+async def _seed_with_hole(db, symbol="AAPL"):
+    """Seed a US asset and delete one real mid-window session's bar."""
+    asset = await seed_asset_with_prices(db, symbol, n_days=60)
+    stored = {p.date for p in await PriceRepository(db).list_by_asset(asset.id)}
+    sessions = sorted(Symbol(symbol).venue.session_dates(min(stored), max(stored)))
+    hole = sessions[len(sessions) // 2]
+    await db.execute(delete(PriceHistory).where(
+        PriceHistory.asset_id == asset.id, PriceHistory.date == hole,
+    ))
+    await db.commit()
+    return asset, hole
+
+
+async def test_hole_heal_detects_and_refetches(db):
+    """A deleted mid-series session is detected and its range re-fetched."""
+    asset, hole = await _seed_with_hole(db)
+    with patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync:
+        sync.return_value = 1
+        healed = await heal_interior_holes(db, force=True)
+    assert healed == {asset.symbol: 1}
+    sync.assert_awaited_once()
+    _, called_asset, start, end = sync.await_args.args
+    assert called_asset.id == asset.id
+    assert start == end == hole
+
+
+async def test_hole_heal_clean_series_no_fetch(db):
+    """Seeded weekday bars (holidays included as extra rows) yield no holes —
+    an exchange holiday must never be treated as missing data."""
+    await seed_asset_with_prices(db, "AAPL", n_days=60)
+    with patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync:
+        healed = await heal_interior_holes(db, force=True)
+    assert healed == {}
+    sync.assert_not_awaited()
+
+
+async def test_hole_heal_cooldown_same_holes(db):
+    """The same unfilled hole set is not re-fetched within the retry cooldown."""
+    await _seed_with_hole(db)
+    with patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync:
+        sync.return_value = 0
+        first = await heal_interior_holes(db, force=True)
+        second = await heal_interior_holes(db, force=True)
+    assert first and second == {}
+    sync.assert_awaited_once()
+
+
+async def test_hole_heal_scan_interval_throttles(db):
+    """Without force, a scan only runs once per HOLE_SCAN_INTERVAL_SECONDS."""
+    await _seed_with_hole(db)
+    with patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync:
+        sync.return_value = 1
+        first = await heal_interior_holes(db)
+        second = await heal_interior_holes(db)
+    assert first != {} and second == {}
+    sync.assert_awaited_once()
+
+
+async def test_hole_heal_skips_unknown_venue(db):
+    """No venue calendar → holes and holidays are indistinguishable → skip."""
+    asset = await seed_asset_with_prices(db, "FOO.XX", n_days=60)
+    stored = sorted({p.date for p in await PriceRepository(db).list_by_asset(asset.id)})
+    await db.execute(delete(PriceHistory).where(
+        PriceHistory.asset_id == asset.id, PriceHistory.date == stored[len(stored) // 2],
+    ))
+    await db.commit()
+    with patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync:
+        healed = await heal_interior_holes(db, force=True)
+    assert healed == {}
+    sync.assert_not_awaited()


### PR DESCRIPTION
## Summary

Stacked on #561 (retargets to `dev` when it merges; independent of #562). Survey item A4 from `claudedocs/pattern-adoption-survey.md`.

The existing heal only reconciles the *trailing* bar against the live quote — a hole in the middle of a series (upstream feed hole like the IWDA incident, NaN-skipped upsert, failed nightly sync) was never detected and permanently blanked σ-Move on the bar after it. The venue calendar makes such holes exactly computable:

```
venue.session_dates(first_stored, last_stored) − stored_dates = the holes
```

`heal_interior_holes` runs piggybacked on the 10-minute heal job, self-throttled to one scan per 6h (one batched DB query + cached calendars), and re-fetches `min(hole)..max(hole)` per affected symbol via the existing `sync_asset_prices_range`. **This would have auto-repaired the original #559 incident** — Yahoo backfilled 2026-08-03 upstream within days, but nothing ever re-asked.

Safety properties:
- **Holiday-proof by construction**: only venue-calendar sessions count as expected, and symbols with no resolvable venue are skipped entirely.
- **No hammering on unfillable holes**: a hole set that survives its re-fetch retries daily, not per scan; a changed hole set is a new problem and bypasses the cooldown; max 5 symbols per scan.
- **Boundaries excluded**: leading gaps stay `_ensure_prices` backfill territory, trailing bars stay the reconciliation heal's job.
- Persistent holes are logged with their dates, so a genuinely unfillable hole is visible instead of silent.

## Test plan
- [x] 6 new tests: pure hole-finder boundaries, detect+refetch against the real XNYS calendar (seeded series with one real session deleted), holiday-not-a-hole (seeded holiday bars produce no candidates), retry cooldown, scan-interval throttle, unknown-venue skip
- [x] `pytest` — 761 passed; `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)