### PR TITLE
refactor: market-state trait table (survey enabler)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.routers import settings as settings_router
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
 from app.services.intraday import cleanup_old_intraday, fetch_and_store_intraday
+from app.services.market_state import any_active
 from app.services.price_heal import heal_unreconciled_prices
 from app.services.price_providers import init_price_provider
 from app.services.price_sync import sync_all_prices
@@ -177,8 +178,7 @@ async def scheduled_intraday_sync():
             sample = random.sample(symbols, sample_size)
             quotes = await get_price_provider().batch_fetch_quotes(sample)
             market_states = {q.get("market_state") for q in quotes if q.get("market_state")}
-            active_states = {"REGULAR", "PRE", "POST", "PREPRE", "POSTPOST"}
-            if not market_states & active_states:
+            if not any_active(market_states):
                 return
 
             count = await fetch_and_store_intraday(db, symbols, asset_map)

--- a/backend/app/services/market_state.py
+++ b/backend/app/services/market_state.py
@@ -1,0 +1,66 @@
+"""Yahoo quote ``market_state`` vocabulary as a trait table.
+
+Yahoo reports one of six states per symbol (documented on
+``app/schemas/quote.py``): ``PREPRE``/``PRE`` (before the open), ``REGULAR``
+(session running), ``POST``/``POSTPOST`` (after-hours running / ended), and
+``CLOSED``. Before this table existed, each consumer re-derived which states
+count as "active" with its own inline set — six sites, five different
+predicates. All predicates now come from here.
+
+``phase`` speaks the same vocabulary as ``Venue.phase()``
+(``app/services/market_calendar.py``), so a consumer can fall back from the
+live per-symbol state to the venue's scheduled phase with no translation:
+the live feed is the authority (it knows about halts), the schedule is the
+backstop when the feed is absent.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MarketStateInfo:
+    # Scheduled-phase equivalent — the join key to Venue.phase().
+    phase: str  # "premarket" | "open" | "aftermarket" | "closed"
+    # Quotes are worth polling in this state. Note POSTPOST ("after-hours has
+    # ended") is kept active — the historical behavior of every consumer —
+    # even though prices are settled by then; revisit deliberately, not as a
+    # refactor side effect.
+    active: bool
+    # The current session's daily bar is still building, so the trailing bar
+    # Yahoo returns is a live partial (see drop_unsettled_last_bar).
+    session_forming: bool
+
+
+MARKET_STATES: dict[str, MarketStateInfo] = {
+    "PREPRE": MarketStateInfo(phase="premarket", active=True, session_forming=False),
+    "PRE": MarketStateInfo(phase="premarket", active=True, session_forming=False),
+    "REGULAR": MarketStateInfo(phase="open", active=True, session_forming=True),
+    "POST": MarketStateInfo(phase="aftermarket", active=True, session_forming=False),
+    "POSTPOST": MarketStateInfo(phase="closed", active=True, session_forming=False),
+    "CLOSED": MarketStateInfo(phase="closed", active=False, session_forming=False),
+}
+
+# Unknown/missing states get the most conservative reading: nothing moving,
+# nothing forming. Callers that want "unknown ≠ closed" semantics should test
+# for None themselves before consulting traits.
+_UNKNOWN = MarketStateInfo(phase="closed", active=False, session_forming=False)
+
+
+def state_info(state: str | None) -> MarketStateInfo:
+    """Traits for a raw market-state code (unknown → conservative defaults)."""
+    if state is None:
+        return _UNKNOWN
+    return MARKET_STATES.get(state, _UNKNOWN)
+
+
+def is_active(state: str | None) -> bool:
+    return state_info(state).active
+
+
+def any_active(states) -> bool:
+    """Whether any of the given states counts as an active market."""
+    return any(is_active(s) for s in states)
+
+
+def is_session_forming(state: str | None) -> bool:
+    return state_info(state).session_forming

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import Asset
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.price_repo import PriceRepository
+from app.services.market_state import is_session_forming
 from app.services.price_providers import PriceProvider, get_price_provider
 
 logger = logging.getLogger(__name__)
@@ -19,11 +20,11 @@ logger = logging.getLogger(__name__)
 # with ``SESSION_MATCH_TOL`` in ``frontend/src/lib/indicator-registry.ts``.
 SESSION_MATCH_TOL = 0.005  # 0.5%
 
-# Market states in which the current session's daily bar is still forming, so
-# the trailing bar Yahoo returns is a live partial regardless of whether it
-# momentarily matches the live price. Other states (PRE/PREPRE before the open,
-# POST/POSTPOST/CLOSED after it) leave a settled daily bar we reconcile instead.
-_ACTIVE_SESSION_STATES = frozenset({"REGULAR"})
+# "Is the current session's daily bar still forming?" now comes from the
+# shared market-state trait table (is_session_forming): in REGULAR the trailing
+# bar Yahoo returns is a live partial regardless of whether it momentarily
+# matches the live price; every other state (PRE/PREPRE before the open,
+# POST/POSTPOST/CLOSED after it) leaves a settled daily bar we reconcile.
 
 
 def _reconciles(a: float | None, b: float | None, tol: float = SESSION_MATCH_TOL) -> bool:
@@ -94,7 +95,7 @@ def drop_unsettled_last_bar(
 
     # An open session's bar is always a live partial — drop it even though it
     # matches the live price right now, because it will drift as trading goes on.
-    if market_state in _ACTIVE_SESSION_STATES:
+    if is_session_forming(market_state):
         logger.debug(
             "%s: dropping trailing %s bar (session open; close=%s, live=%s)",
             symbol or "?", df.index[-1], last_close, price,

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -8,6 +8,7 @@ import time as _time
 from app.database import async_session
 from app.repositories.asset_repo import AssetRepository
 from app.services.intraday import get_intraday_bars
+from app.services.market_state import any_active, state_info
 from app.services.price_providers import get_price_provider
 
 logger = logging.getLogger(__name__)
@@ -93,8 +94,7 @@ async def quote_event_generator():
             last_payload = full_payload
 
             # Push intraday bars (full on first push, delta after)
-            active_states = {"REGULAR", "PRE", "POST", "PREPRE", "POSTPOST"}
-            has_active_market = bool(market_states & active_states)
+            has_active_market = any_active(market_states)
 
             # Always push intraday on first iteration or when markets are active
             if has_active_market or not last_intraday_ts:
@@ -122,10 +122,11 @@ async def quote_event_generator():
                         if bars:
                             last_intraday_ts[sym] = max(b["time"] for b in bars)
 
-            # Adapt interval based on market state
-            if "REGULAR" in market_states:
+            # Adapt interval based on market state: fast while any session runs,
+            # medium in extended hours, slow when everything is closed.
+            if any(state_info(s).phase == "open" for s in market_states):
                 interval = 15
-            elif market_states & {"PRE", "POST", "PREPRE", "POSTPOST"}:
+            elif any_active(market_states):
                 interval = 60
             else:
                 interval = 300

--- a/backend/tests/services/test_market_state.py
+++ b/backend/tests/services/test_market_state.py
@@ -1,0 +1,62 @@
+"""Tests for the market-state trait table.
+
+The table replaced five inline predicates over Yahoo's six-value market_state
+vocabulary; these tests pin the traits to the historical behavior of those
+sites so the consolidation stays a pure refactor.
+"""
+
+from app.services.market_state import (
+    MARKET_STATES,
+    any_active,
+    is_active,
+    is_session_forming,
+    state_info,
+)
+
+
+def test_covers_canonical_states():
+    """Exactly the six states Yahoo emits (documented on schemas/quote.py)."""
+    assert set(MARKET_STATES) == {"PREPRE", "PRE", "REGULAR", "POST", "POSTPOST", "CLOSED"}
+
+
+def test_active_set_matches_historical_predicates():
+    """quote_service/main.py both used {REGULAR, PRE, POST, PREPRE, POSTPOST}."""
+    active = {s for s, info in MARKET_STATES.items() if info.active}
+    assert active == {"REGULAR", "PRE", "POST", "PREPRE", "POSTPOST"}
+
+
+def test_only_regular_forms_a_session():
+    """price_sync's _ACTIVE_SESSION_STATES was {REGULAR}."""
+    forming = {s for s, info in MARKET_STATES.items() if info.session_forming}
+    assert forming == {"REGULAR"}
+    assert is_session_forming("REGULAR") is True
+    assert is_session_forming("POST") is False
+
+
+def test_settled_states_read_as_closed_phase():
+    """The frontend's stale-pulse suppression treated CLOSED and POSTPOST as
+    closed; phase encodes the same split."""
+    closed = {s for s, info in MARKET_STATES.items() if info.phase == "closed"}
+    assert closed == {"CLOSED", "POSTPOST"}
+
+
+def test_phase_speaks_venue_vocabulary():
+    """phase is the join key to Venue.phase() — same four values."""
+    assert {info.phase for info in MARKET_STATES.values()} <= {
+        "premarket", "open", "aftermarket", "closed",
+    }
+
+
+def test_unknown_states_are_conservative():
+    for state in (None, "POSTMARKET", ""):
+        info = state_info(state)
+        assert info.active is False
+        assert info.session_forming is False
+        assert info.phase == "closed"
+    assert is_active("NONSENSE") is False
+
+
+def test_any_active():
+    assert any_active({"CLOSED", "POST"}) is True
+    assert any_active({"CLOSED"}) is False
+    assert any_active(set()) is False

--- a/frontend/src/components/group-table/table-row.tsx
+++ b/frontend/src/components/group-table/table-row.tsx
@@ -20,6 +20,7 @@ import {
   computeLiveVnr,
   isStoredVnrStale,
 } from "@/lib/indicator-registry"
+import { marketState as marketStateInfo } from "@/lib/market-state"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useSettings } from "@/lib/settings"
 import { resolveIcon } from "@/lib/icon-utils"
@@ -113,10 +114,9 @@ export const TableRow = memo(function TableRow({
   const hasDbFallback = !hasLiveQuote && displayPrice != null
   // Suppress stale indicator when market is closed — DB prices are already current.
   // When no quote yet, market_state is unknown so we assume market hours (show stale).
+  // The POSTPOST-counts-as-closed knowledge lives in the shared trait table.
   const marketState = quote?.market_state
-  // "POSTPOST" = post-market session ended (prices settled); Yahoo never emits
-  // "POSTMARKET". "POST" is still active after-hours, so stale stays meaningful.
-  const isMarketClosed = marketState === "CLOSED" || marketState === "POSTPOST"
+  const isMarketClosed = marketState != null && marketStateInfo(marketState).phase === "closed"
   const showStale = hasDbFallback && !isMarketClosed
 
   const { settings } = useSettings()

--- a/frontend/src/lib/market-state.ts
+++ b/frontend/src/lib/market-state.ts
@@ -8,18 +8,25 @@ export interface MarketStateInfo {
   dotColor: string
   /** Human-readable label. */
   label: string
+  /**
+   * Scheduled-phase equivalent — same vocabulary as the backend venue
+   * calendar's phase(). "closed" means prices are settled: POSTPOST is
+   * "after-hours has *ended*", so it is closed here even though its label
+   * still reads After-hours ("POSTMARKET" is not a thing Yahoo emits).
+   */
+  phase: "premarket" | "open" | "aftermarket" | "closed"
 }
 
 const MARKET_STATES: Record<string, MarketStateInfo> = {
-  PRE: { dotColor: "bg-blue-500", label: "Pre-market" },
-  PREPRE: { dotColor: "bg-blue-500", label: "Pre-market" },
-  REGULAR: { dotColor: "bg-emerald-500", label: "Market open" },
-  POST: { dotColor: "bg-orange-500", label: "After-hours" },
-  POSTPOST: { dotColor: "bg-orange-500", label: "After-hours" },
-  CLOSED: { dotColor: "bg-red-500", label: "Closed" },
+  PRE: { dotColor: "bg-blue-500", label: "Pre-market", phase: "premarket" },
+  PREPRE: { dotColor: "bg-blue-500", label: "Pre-market", phase: "premarket" },
+  REGULAR: { dotColor: "bg-emerald-500", label: "Market open", phase: "open" },
+  POST: { dotColor: "bg-orange-500", label: "After-hours", phase: "aftermarket" },
+  POSTPOST: { dotColor: "bg-orange-500", label: "After-hours", phase: "closed" },
+  CLOSED: { dotColor: "bg-red-500", label: "Closed", phase: "closed" },
 }
 
-const DEFAULT_STATE: MarketStateInfo = { dotColor: "bg-red-500", label: "Closed" }
+const DEFAULT_STATE: MarketStateInfo = { dotColor: "bg-red-500", label: "Closed", phase: "closed" }
 
 /** Resolve a raw market-state code to its dot colour + label (falls back to Closed). */
 export function marketState(state: string | null | undefined): MarketStateInfo {


### PR DESCRIPTION
## Summary

Stacked on #561 (retargets to `dev` when it merges). Survey item D-1 from `claudedocs/pattern-adoption-survey.md` — the enabling change for the scheduler/SSE schedule-backstop items.

Six sites held five different inline predicates over Yahoo's six-value `market_state`. This consolidates them into trait tables on both sides of the wire:

- **Backend** — new `app/services/market_state.py`: `phase` (speaks `Venue.phase()`'s vocabulary, so "fall back to the scheduled phase when the quote feed is absent" becomes a one-liner in follow-ups), `active` (worth polling), `session_forming` (daily bar still building). Replaced sites: `quote_service` intraday-push gate + interval selection, `main.py` intraday sampling gate (was a verbatim copy-paste of the quote_service set), `price_sync._ACTIVE_SESSION_STATES`.
- **Frontend** — `lib/market-state.ts` (already the presentation table, built to stop exactly this drift) gains the same `phase` field; `table-row.tsx`'s `CLOSED || POSTPOST` comparison becomes `phase === "closed"`, moving the "POSTPOST means ended" knowledge out of a component comment into the table.

**Deliberately behavior-preserving**: tests pin each trait set to the exact historical predicate it replaced. That includes POSTPOST staying `active` for polling — arguably wrong (prices are settled), but flipping it should be its own decision, not a refactor side effect; the table now makes that a one-word change with a comment marking it.

## Test plan
- [x] New `test_market_state.py` pins: canonical six states, active set == historical `{REGULAR,PRE,POST,PREPRE,POSTPOST}`, session-forming == `{REGULAR}`, closed-phase == `{CLOSED,POSTPOST}`, unknown states conservative
- [x] `pytest` 761 passed, `ruff` clean, `eslint`/`tsc`/`vitest` (28) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)