### PR TITLE
fix(backend): gap-guard σ-Move denominator, deltas, and change_pct (#559 family)

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -128,7 +128,7 @@ def session_gap_days(index: pd.Index, session_dates: set[date] | None = None) ->
     return gaps
 
 
-def _ewma_daily_vol(closes: pd.Series, lam: float) -> pd.Series:
+def _ewma_daily_vol(closes: pd.Series, lam: float, gaps: pd.Series | None = None) -> pd.Series:
     """Forward EWMA volatility forecast (RiskMetrics zero-mean).
 
     Returns the sqrt of the EWMA variance built from returns *through each bar*
@@ -137,10 +137,20 @@ def _ewma_daily_vol(closes: pd.Series, lam: float) -> pd.Series:
     counterpart of the ``sigma_forecast`` inside :func:`volatility_normalized_return`;
     the value at the last bar is the forecast for the in-progress day, which the
     live snapshot uses to score today's move before its bar is written.
+
+    ``gaps`` (a :func:`session_gap_days` series) excludes gap-spanning returns
+    from the variance: a return across an N-session hole is √N-inflated, and
+    squaring it into the EWMA (λ=0.94 → ~11-day half-life) would overstate σ
+    for weeks after the gap — *understating* every subsequent σ-move. Dropped
+    (not zeroed) returns leave the variance carried across the gap; with
+    ``ignore_na=False`` the skipped position still ages the older observations,
+    approximating one extra decay step for the missing stretch.
     """
     returns = closes.pct_change()
+    if gaps is not None:
+        returns = returns.where(~(gaps > 1))
     # RiskMetrics zero-mean EWMA variance: sigma^2_t = lam*sigma^2_{t-1} + (1-lam)*r^2_{t-1}
-    ewma_var = (returns**2).ewm(alpha=1 - lam, adjust=False).mean()
+    ewma_var = (returns**2).ewm(alpha=1 - lam, adjust=False, ignore_na=False).mean()
     return np.sqrt(ewma_var).replace(0, float("nan"))
 
 
@@ -174,11 +184,13 @@ def volatility_normalized_return(
     case exchange holidays trip the guard too and conservatively blank the
     bar after a holiday.
     """
-    returns = closes.pct_change()
-    # Forecast vol from data through the previous day; guard flat series (0 -> NaN).
-    sigma_forecast = _ewma_daily_vol(closes, lam).shift(1)
     if gaps is None:
         gaps = session_gap_days(closes.index)
+    returns = closes.pct_change()
+    # Forecast vol from data through the previous day; guard flat series (0 -> NaN).
+    # The forecast gets the same gap series so gap-spanning returns can't
+    # contaminate the denominator either (they would understate later σ-moves).
+    sigma_forecast = _ewma_daily_vol(closes, lam, gaps).shift(1)
     return (returns / sigma_forecast).where(~(gaps > 1))
 
 
@@ -381,20 +393,6 @@ def _cmf_snapshot_derived(row: pd.Series) -> dict:
     return {"cmf_signal": None}
 
 
-def _vnr_post_compute(result: pd.DataFrame) -> None:
-    """Attach the forward EWMA vol forecast used to score an in-progress day.
-
-    ``vnr`` itself normalizes the *last completed* bar's return; ``vnr_sigma`` is
-    the vol (a return fraction) to divide a live intraday return by so the UI can
-    show today's σ-move before today's bar has been written to the DB. Flat
-    stretches yield NaN, which ``build_indicator_snapshot`` renders as None.
-
-    ``vnr_gap_sessions`` (the companion field flagging gap-suppressed bars) is
-    set by :func:`compute_indicators`, which owns the gap series.
-    """
-    result["vnr_sigma"] = _ewma_daily_vol(result["close"], VNR_LAMBDA)
-
-
 def _rvol_snapshot_derived(row: pd.Series) -> dict:
     """Derive a qualitative relative-volume state from the latest row."""
     val = row.get("rvol")
@@ -562,10 +560,11 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
     "vnr": IndicatorDef(
         func=volatility_normalized_return,
         params={"lam": VNR_LAMBDA},
+        # vnr_sigma and vnr_gap_sessions are gap-aware companions set directly
+        # by compute_indicators, which owns the session-gap series.
         output_fields=["vnr", "vnr_sigma", "vnr_gap_sessions"],
         decimals=2,
         warmup_periods=60,
-        post_compute=_vnr_post_compute,
         field_decimals={"vnr_sigma": 6, "vnr_gap_sessions": 0},
         needs_gaps=True,
     ),
@@ -602,7 +601,12 @@ def build_indicator_snapshot(indicators: pd.DataFrame) -> dict:
     prev_close = indicators.iloc[-2]["close"]
 
     change_pct = None
-    if prev_close and prev_close != 0:
+    # A gap-flagged latest bar means the previous *row* is not the previous
+    # *session* — the difference would be a multi-session move mislabelled as
+    # a 1-day change (schema documents change_pct as daily). Leave it None,
+    # matching the suppressed σ-Move beside it.
+    latest_is_gap = pd.notna(latest.get("vnr_gap_sessions"))
+    if prev_close and prev_close != 0 and not latest_is_gap:
         change_pct = round((latest["close"] - prev_close) / prev_close * 100, 2)
 
     result: dict = {
@@ -633,19 +637,28 @@ def _get_delta_fields() -> list[str]:
     return delta_fields
 
 
-def _compute_deltas(result: pd.DataFrame, window: int = 20) -> None:
+def _compute_deltas(result: pd.DataFrame, window: int = 20, gaps: pd.Series | None = None) -> None:
     """Add daily deltas and outlier sigma flags for selected indicator fields.
 
     For each target field:
       - {field}_delta = day-over-day difference
       - {field}_delta_sigma = |Δ| expressed in rolling σ units, only when
         the absolute delta exceeds mean + 2σ of the rolling window (else NaN).
+
+    ``gaps`` (a :func:`session_gap_days` series) blanks the delta on bars whose
+    previous stored bar is more than one session back — ``diff()`` there is a
+    multi-session move, which would both earn a fake outlier badge and inflate
+    the rolling σ baseline (suppressing genuine outliers for the next
+    ``window`` bars). The NaN also makes the rolling stats undersized for the
+    affected windows (``min_periods=window``), so no flag fires on bad data.
     """
     for field_name in _get_delta_fields():
         if field_name not in result.columns:
             continue
         series = result[field_name]
         delta = series.diff()
+        if gaps is not None:
+            delta = delta.where(~(gaps > 1))
         result[f"{field_name}_delta"] = delta
 
         abs_delta = delta.abs()
@@ -698,11 +711,15 @@ def compute_indicators(
         if defn.post_compute:
             defn.post_compute(result)
 
-    # Flag the bars the σ-Move gap guard suppressed with the gap width, so the
-    # UI can explain the blank (NaN everywhere else → None in responses).
+    # σ-Move companions, both gap-aware. vnr_sigma is the forward vol forecast
+    # the UI divides a live intraday return by (see _ewma_daily_vol — the gap
+    # series keeps hole-spanning returns out of the variance). vnr_gap_sessions
+    # flags the bars the gap guard suppressed with the gap width, so the UI can
+    # explain the blank (NaN everywhere else → None in responses).
+    result["vnr_sigma"] = _ewma_daily_vol(closes, VNR_LAMBDA, gap_series)
     result["vnr_gap_sessions"] = gap_series.where(gap_series > 1)
 
-    _compute_deltas(result)
+    _compute_deltas(result, gaps=gap_series)
 
     return result
 

--- a/backend/tests/services/test_indicators_volatility.py
+++ b/backend/tests/services/test_indicators_volatility.py
@@ -560,3 +560,68 @@ def test_vnr_hole_still_suppressed_with_sessions():
     result = compute_indicators(df, session_dates=sessions)
     assert pd.isna(result["vnr"].iloc[-1])
     assert result["vnr_gap_sessions"].iloc[-1] == 2
+
+
+# ---------------------------------------------------------------------------
+# Gap guard, part 2 — the denominator/delta/change_pct family (issue #559)
+# ---------------------------------------------------------------------------
+
+
+def _trending_gapped_df(n: int = 100, drop_offset: int = 10) -> pd.DataFrame:
+    """Steady +0.6%/session series with one interior session removed.
+
+    Every stored return is +0.6% except the gap bar, whose stored return spans
+    two sessions (~+1.21%) — the exact shape that used to contaminate the EWMA.
+    """
+    dates = pd.bdate_range("2024-01-01", periods=n)
+    closes = pd.Series([100.0 * (1.006 ** i) for i in range(n)], index=dates)
+    df = pd.DataFrame({
+        "open": closes, "high": closes, "low": closes, "close": closes,
+        "volume": 1_000_000,
+    })
+    return df.drop(df.index[n - drop_offset])
+
+
+def test_vnr_sigma_not_contaminated_by_gap_return():
+    """The EWMA vol forecast must exclude the gap-spanning return.
+
+    On a constant +0.6%/session series, sigma converges to exactly 0.006. The
+    two-session ~+1.21% return at the gap bar used to be squared into the
+    variance (inflating sigma ~9% with an 11-day half-life), which understated
+    every subsequent σ-move. With the gap guard, sigma stays at 0.006 and the
+    very next ordinary move scores ~1σ again.
+    """
+    result = compute_indicators(_trending_gapped_df())
+    gap_pos = 100 - 10  # bar after the hole, in the shortened frame
+    assert pd.notna(result["vnr_gap_sessions"].iloc[gap_pos])
+    # The gap bar itself stays suppressed…
+    assert pd.isna(result["vnr"].iloc[gap_pos])
+    # …the denominator is undisturbed at and after the gap…
+    assert result["vnr_sigma"].iloc[gap_pos] == pytest.approx(0.006, rel=1e-2)
+    assert result["vnr_sigma"].iloc[-1] == pytest.approx(0.006, rel=1e-2)
+    # …so the ordinary +0.6% move right after the gap scores ~1σ, not ~0.9σ.
+    assert result["vnr"].iloc[gap_pos + 1] == pytest.approx(1.0, abs=0.02)
+
+
+def test_deltas_blanked_on_gap_bar():
+    """diff() across a hole is a multi-session move — no delta, no fake outlier."""
+    result = compute_indicators(_trending_gapped_df())
+    gap_pos = 100 - 10  # bar after the hole, in the shortened frame
+    assert pd.notna(result["vnr_gap_sessions"].iloc[gap_pos])
+    for field in ("rsi_delta", "macd_delta", "macd_hist_delta"):
+        assert pd.isna(result[field].iloc[gap_pos]), field
+    # Ordinary bars still carry deltas.
+    assert pd.notna(result["rsi_delta"].iloc[-1])
+
+
+def test_snapshot_change_pct_suppressed_on_gap_bar():
+    """change_pct is documented as a 1-day change; a gap-flagged latest bar
+    would make it a multi-session move, so it must be None — matching the
+    suppressed σ-Move next to it."""
+    df = _trending_gapped_df(drop_offset=2)  # hole right before the last bar
+    snapshot = build_indicator_snapshot(compute_indicators(df))
+    assert snapshot["values"]["vnr"] is None
+    assert snapshot["change_pct"] is None
+    # Contiguous series still reports a change.
+    full = _make_price_df(100)
+    assert build_indicator_snapshot(compute_indicators(full))["change_pct"] is not None

--- a/claudedocs/pattern-adoption-survey.md
+++ b/claudedocs/pattern-adoption-survey.md
@@ -1,0 +1,180 @@
+# Pattern-adoption survey — where Symbol/Venue/session-exactness applies elsewhere
+
+Date: 2026-08-04. Context: after #559 (σ-Move √N gap inflation, PRs #560/#561) we
+introduced three patterns: `Symbol(str)` with ticker shape interpreted in one
+place, `Venue` facade with traits-as-data (`EXTENDED_HOURS`), and session-exact
+gap awareness replacing positional/heuristic time assumptions. Three parallel
+codebase surveys looked for other application sites. Findings, ranked.
+
+## A. Correctness bugs of the #559 class (session-exactness fixes real numbers)
+
+1. **`_ewma_daily_vol` denominator still eats gap returns** —
+   `backend/app/services/compute/indicators.py:131-144`. The vnr numerator is
+   gap-guarded but the EWMA variance is built from unfiltered `pct_change()`: a
+   3-session hole squares a √3-inflated return into the variance (λ=0.94 →
+   ~11-day half-life), so σ is inflated for weeks after a gap and every
+   subsequent σ-Move is **understated** — the app under-flags genuine events
+   after a data outage, and nothing renders blank to warn. Also contaminates
+   `vnr_sigma` → frontend `computeLiveVnr`. Fix: thread `gap_series` into
+   `_ewma_daily_vol`, drop (not zero) gap-spanning returns. This is issue #559
+   "fix 4", upgraded from minor to the top remaining item.
+
+2. **`build_indicator_snapshot` `change_pct` is positional** —
+   `indicators.py:598-606`. A multi-session return labelled "1-day change";
+   it's the DB fallback the group table shows exactly when the live quote is
+   absent (post-outage). Suppress/annotate using the last `gap_series` value.
+
+3. **`_compute_deltas` positional diff** — `indicators.py:636-659`. Across a
+   hole: fake ⚠ outlier badge on the gap bar (rsi_delta/macd_delta sigma), and
+   the inflated |Δ| sits in the 20-row rolling std, suppressing genuine outlier
+   flags for a month. Fix: NaN deltas where `gaps > 1` (rolling stats skip NaN).
+
+4. **`price_heal` has no interior-hole detection** — `price_heal.py:38-105`
+   only reconciles the trailing bar. `Symbol(sym).venue.session_dates(first,
+   last)` minus stored dates = exact missing-session list;
+   `sync_asset_prices_range` already exists to fill it. This would have
+   auto-repaired the original IWDA incident. (Issue #559 "fix 3".) Needs
+   negative-caching for holes Yahoo genuinely can't fill (reuse
+   `_earliest_date_cache` idea) and the "trust data over calendar" rule.
+
+5. **Frontend `weekdaysBetween` is holiday-blind** — `movement-stats.ts:42-52`.
+   Backend gap guard is now venue-exact; the frontend copy still excludes the
+   session after every exchange holiday from max daily gain/loss and
+   up/down/session counts (~10 sessions/yr, disproportionately high-vol
+   reopens). Fix without new computation: the asset-detail indicators already
+   carry per-bar `vnr_gap_sessions` — read that instead, delete
+   `weekdaysBetween`.
+
+6. **`computeLiveVnr`/`isStoredVnrStale` infer session identity from price
+   proximity** — `indicator-registry.ts:183,201-217,236-244`. 0.5% close-match
+   proxy (duplicated constant with `price_sync.py:20`): flat multi-session
+   stretch passes (wrong σ anchor), >0.5% overnight gap-up reads as stale
+   (blanks σ-Move on the most interesting days). Proper fix: backend-computed
+   `sessions_behind` int on the payload (Venue answers it definitionally);
+   retires two heuristics + the duplicated tolerance. Cheap interim: gate
+   `computeLiveVnr` on `vnr_gap_sessions == null` (currently only the DB
+   branch checks it).
+
+7. **`compute_performers` ranks assets over unaligned windows** —
+   `portfolio.py:65-104` (same shape in `pseudo_etf.calculate_performance:57`).
+   Calendar-day window start + first *stored* bar baseline → an asset with a
+   leading hole or venue closure is measured over a shorter window and ranked
+   head-to-head. Venue-exact "Nth session back" anchor, or flag materially
+   late baselines.
+
+## B. Heuristics the Venue schedule API replaces
+
+1. **`intraday.py:20-69` `_EXCHANGE_HOURS` + `_classify_session`** — 27-entry
+   hand-maintained tz→wall-clock table with ET fallback; wrong on half-days
+   (post bars filed as regular), holiday-blind, no "closed" value. Strictly
+   superseded by `Venue.phase()`. Needs a pre/regular/post ↔
+   premarket/open/aftermarket/closed name map at the DB boundary and a decision
+   for EU bars outside regular hours (currently pre/post, schedule says
+   closed). Deletes ~50 lines of venue data.
+2. **`main.py:155-188` `scheduled_intraday_sync`** — shuffles the portfolio and
+   quotes 15 random symbols every 60s to guess "is anything open" (~80% miss
+   chance for a 3-symbol Tokyo tail in a 200-symbol portfolio; 1,440 Yahoo
+   round-trips/day). Replace with `any(venue.phase() != "closed")` over the
+   portfolio's ~8 venues: deterministic, free, holiday-aware. Biggest
+   cost-saving item.
+3. **Weekend guards `main.py:130,157`** — `weekday() >= 5` skips crypto (24/7)
+   all weekend and runs all day on global holidays; server-local date is wrong
+   at tz edges (Monday 09:00 Tokyo = Sunday UTC). Same venue-phase one-liner.
+4. **SSE interval selection `quote_service.py:126-131`** — live `market_state`
+   only: empty quote batch during regular hours → 300s poll; all-closed →
+   fixed 300s sleep can oversleep an open by ~5min. Backstop:
+   `min(live_interval, schedule_interval)` + clamp sleep to `next_open`. Live
+   feed may only speed polling, never a calendar bug slowing it.
+5. **`drop_unsettled_last_bar` `price_sync.py:97-102`** — session-forming
+   decision hinges solely on quote `market_state`; quote fetch failure → the
+   unsettled bar gets stored (the state that blanks σ-Move). Backstop only when
+   `market_state is None` with `venue.phase() == "open"`; never override (halts
+   are the case where live beats schedule). High review cost — silent-data-loss
+   failure mode, heavily tested function.
+6. **Frontend `.stale-price` suppression is dead code** —
+   `table-row.tsx:114-120`: suppression reads `quote.market_state`, but the
+   flag only evaluates when there IS no quote → `isMarketClosed` is always
+   false → every DB-fallback row pulses, including Sundays with SSE down.
+   Needs a scheduled phase delivered to the client (field or tiny endpoint).
+7. **Per-venue refresh scheduling** — `config.py:6` + `main.py:200-221`: 23:00
+   UTC cron + hardcoded 8/16 UTC supplemental sweeps approximate "after each
+   venue's close + publish lag". Venue `next_close() + lag` (lag = sibling data
+   table to EXTENDED_HOURS) → N small per-venue syncs, no staleness window,
+   half-day aware. **High effort** (dynamic APScheduler jobs, DST); only if
+   per-venue staleness actually hurts.
+8. **`intraday.py:16,145,175` ET-anchored cutoffs for all venues** — read
+   window and cleanup boundaries wrong for Asian sessions; papered over by the
+   generous 2-day window. Low priority.
+
+## C. Consolidation: one venue table, one ticker parser
+
+Four venue tables exist, none sharing keys:
+`SUFFIX_CALENDARS` (suffix→calendar, 36) · `EXCHANGE_CURRENCY_MAP`
+(`yahoo/currency.py:9-62`, suffix→currency, 55, includes suffixes the calendar
+table lacks: .CO .AT .TA .SR .IC .IS .JK .BK .V .IL .TWO .QA) · euronext
+provider `MARKET_SUFFIX` (`euronext.py:26-45`, display-name→suffix, the inverse
+mapping) · `_EXCHANGE_HOURS` (intraday.py, tz→hours — deleted by B1).
+
+Suffix *parsing* is implemented 3×: `Symbol.calendar_name`,
+`currency_from_suffix` (`currency.py:65-74`), and the companion app's
+`fromSuffix` (`fibenchi-app/lib/market/yahoo/currency.ts:89-93`, a hand-synced
+copy of the backend table that will drift).
+
+Plan: one venue table with columns (suffix, calendar, currency, display names);
+`Venue` gains a `currency` trait; `Symbol.currency` replaces
+`currency_from_suffix` (suffixes without a calendar keep currency-only
+entries). Symbol construction sites (`euronext.py:142`, `xetra.py:85`
+f-string suffix literals) get a `Symbol.from_venue`-style constructor. The
+~25 scattered `.upper()` normalizations and the duplicated CSV parsing
+(`quote_service.py:27`, `routers/data.py:55`) fold into Symbol helpers.
+Companion-app duplication (currency table, YIELD_INDICES triplicate,
+"is index/is crypto" answered 3 different ways across the 3 codebases) is a
+candidate for the same schema-export treatment as CompanionConfig — later.
+
+## D. Kind-conditionals → trait tables
+
+- **`market_state` predicates: 6 sites, 5 different sets** —
+  `quote_service.py:96,126,128`, `main.py:180` (verbatim copy of
+  quote_service:96), `price_sync.py:26`, `table-row.tsx:119`; canonical 6-value
+  list exists only as a docstring (`schemas/quote.py:13`). Fix: one
+  `MARKET_STATES` trait table (`phase`, `active`, `session_forming`) — the
+  `phase` field is the join key to `Venue.phase()`, which is what makes the B4/
+  B5/B6 backstops one-liners. Frontend already has the right shape in
+  `market-state.ts` (presentation-only today) — extend it. **This is the
+  enabling change for most of section B.**
+- **UI period label pairs** duplicated in `group-page.tsx:225-227` and
+  `settings.tsx:92-94` — add `PERIOD_LABELS` beside `STANDARD_PERIODS`. Small.
+- **`euronext.py:74-107` `_resolve_market`** — duplicated fallback block +
+  two O(n) reverse scans; precompute one flat dict. Small, low priority.
+- **Asset-type branches (`format.ts:69,123`, `price-chart.tsx:41`,
+  `asset-detail/index.tsx:42`)** — verdict: skip. Dispersed one-liners at
+  point of use, 3-value enum, not growing. Not worth a traits table.
+- **Indicator descriptors (`indicator-descriptors.ts`)** — already the
+  pattern done right; use as the template. Same for `PERIOD_DAYS` mirrors
+  (network boundary, correctly commented) and Yahoo `PERIOD_MAP` (adapter,
+  not a duplicate).
+
+## Verified safe (checked, no action)
+
+Chart builders/time maps (date-keyed joins, not positional); `thesis.py`
+ffill-on-levels; rolling indicators consuming N rows (correct "last N
+sessions" semantics; TR/EFI shift(1) transient is negligible);
+`drop_unsettled_last_bar`'s iloc[-2] (identity check, not a return);
+pseudo-ETF quarterly rebalance trigger (first-row-of-quarter semantics hold
+across gaps). Pseudo-ETF cross-venue ffill understates dispersion on
+one-venue holidays — inherent to a composite, now *detectable* via
+`venue.is_session`, but probably acceptable.
+
+## Suggested sequencing
+
+1. **A1+A3 (+A2)** — finish the #559 family inside `compute_indicators` where
+   `gap_series` already exists (one PR).
+2. **A4** — interior-hole heal pass (one PR; auto-repairs future incidents).
+3. **D-market-states table** — enabler (small PR).
+4. **B2+B3 (+B4)** — scheduler gates + SSE backstop (one PR, immediate API-call
+   savings).
+5. **B1** — intraday phase classification via Venue (one PR).
+6. **C** — venue-table consolidation + `Symbol.currency` (one PR).
+7. Frontend session-identity items (A5, A6, B6) — gated on deciding how
+   phase/`sessions_behind` reaches the client (one design, then small PRs).
+8. B7 (per-venue cron) — only if staleness is an observed pain.


### PR DESCRIPTION
Re-created #562 after its base branch merged as #561 (GitHub closed the stacked PR instead of retargeting). Content identical — see #562 for the full description and review context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)