### PR TITLE
fix: overnight market states are not pre-market

### DIFF
--- a/backend/app/services/market_state.py
+++ b/backend/app/services/market_state.py
@@ -21,10 +21,11 @@ from dataclasses import dataclass
 class MarketStateInfo:
     # Scheduled-phase equivalent — the join key to Venue.phase().
     phase: str  # "premarket" | "open" | "aftermarket" | "closed"
-    # Quotes are worth polling in this state. Note POSTPOST ("after-hours has
-    # ended") is kept active — the historical behavior of every consumer —
-    # even though prices are settled by then; revisit deliberately, not as a
-    # refactor side effect.
+    # Quotes are worth polling in this state. PREPRE ("overnight, pre-market
+    # hasn't started") and POSTPOST ("after-hours has ended") are NOT active:
+    # nothing trades in either, and for European venues PREPRE lasts the whole
+    # night — polling fast there only burned API calls. (They historically
+    # counted as active; changed deliberately, see PR #568.)
     active: bool
     # The current session's daily bar is still building, so the trailing bar
     # Yahoo returns is a live partial (see drop_unsettled_last_bar).
@@ -32,11 +33,11 @@ class MarketStateInfo:
 
 
 MARKET_STATES: dict[str, MarketStateInfo] = {
-    "PREPRE": MarketStateInfo(phase="premarket", active=True, session_forming=False),
+    "PREPRE": MarketStateInfo(phase="closed", active=False, session_forming=False),
     "PRE": MarketStateInfo(phase="premarket", active=True, session_forming=False),
     "REGULAR": MarketStateInfo(phase="open", active=True, session_forming=True),
     "POST": MarketStateInfo(phase="aftermarket", active=True, session_forming=False),
-    "POSTPOST": MarketStateInfo(phase="closed", active=True, session_forming=False),
+    "POSTPOST": MarketStateInfo(phase="closed", active=False, session_forming=False),
     "CLOSED": MarketStateInfo(phase="closed", active=False, session_forming=False),
 }
 

--- a/backend/tests/services/test_market_state.py
+++ b/backend/tests/services/test_market_state.py
@@ -19,10 +19,15 @@ def test_covers_canonical_states():
     assert set(MARKET_STATES) == {"PREPRE", "PRE", "REGULAR", "POST", "POSTPOST", "CLOSED"}
 
 
-def test_active_set_matches_historical_predicates():
-    """quote_service/main.py both used {REGULAR, PRE, POST, PREPRE, POSTPOST}."""
+def test_active_states_are_the_trading_ones():
+    """Only states in which something can actually trade count as active.
+
+    PREPRE (overnight — lasts all night for European venues) and POSTPOST
+    (after-hours ended) are deliberately inactive so the SSE stream and
+    intraday gates idle instead of polling settled prices.
+    """
     active = {s for s, info in MARKET_STATES.items() if info.active}
-    assert active == {"REGULAR", "PRE", "POST", "PREPRE", "POSTPOST"}
+    assert active == {"REGULAR", "PRE", "POST"}
 
 
 def test_only_regular_forms_a_session():
@@ -34,10 +39,10 @@ def test_only_regular_forms_a_session():
 
 
 def test_settled_states_read_as_closed_phase():
-    """The frontend's stale-pulse suppression treated CLOSED and POSTPOST as
-    closed; phase encodes the same split."""
+    """Prices are settled in CLOSED, POSTPOST, and the overnight PREPRE —
+    the stale-price pulse must not fire in any of them."""
     closed = {s for s, info in MARKET_STATES.items() if info.phase == "closed"}
-    assert closed == {"CLOSED", "POSTPOST"}
+    assert closed == {"CLOSED", "POSTPOST", "PREPRE"}
 
 
 def test_phase_speaks_venue_vocabulary():
@@ -59,4 +64,6 @@ def test_unknown_states_are_conservative():
 def test_any_active():
     assert any_active({"CLOSED", "POST"}) is True
     assert any_active({"CLOSED"}) is False
+    # The overnight pair alone must not keep pollers awake.
+    assert any_active({"PREPRE", "POSTPOST"}) is False
     assert any_active(set()) is False

--- a/frontend/src/lib/market-state.ts
+++ b/frontend/src/lib/market-state.ts
@@ -10,19 +10,20 @@ export interface MarketStateInfo {
   label: string
   /**
    * Scheduled-phase equivalent — same vocabulary as the backend venue
-   * calendar's phase(). "closed" means prices are settled: POSTPOST is
-   * "after-hours has *ended*", so it is closed here even though its label
-   * still reads After-hours ("POSTMARKET" is not a thing Yahoo emits).
+   * calendar's phase(). "closed" means prices are settled. PREPRE is Yahoo's
+   * overnight state (POST→POSTPOST→PREPRE→PRE): for European venues it lasts
+   * the whole night, so it must not masquerade as pre-market. POSTPOST is
+   * "after-hours has *ended*" ("POSTMARKET" is not a thing Yahoo emits).
    */
   phase: "premarket" | "open" | "aftermarket" | "closed"
 }
 
 const MARKET_STATES: Record<string, MarketStateInfo> = {
   PRE: { dotColor: "bg-blue-500", label: "Pre-market", phase: "premarket" },
-  PREPRE: { dotColor: "bg-blue-500", label: "Pre-market", phase: "premarket" },
+  PREPRE: { dotColor: "bg-zinc-500", label: "Overnight", phase: "closed" },
   REGULAR: { dotColor: "bg-emerald-500", label: "Market open", phase: "open" },
   POST: { dotColor: "bg-orange-500", label: "After-hours", phase: "aftermarket" },
-  POSTPOST: { dotColor: "bg-orange-500", label: "After-hours", phase: "closed" },
+  POSTPOST: { dotColor: "bg-red-500", label: "Closed", phase: "closed" },
   CLOSED: { dotColor: "bg-red-500", label: "Closed", phase: "closed" },
 }
 


### PR DESCRIPTION
## Summary

Observed on dev at 01:30 CEST: IWDA.AS / EMIM.AS showing a blue "Pre-market" dot. Yahoo reports `PREPRE` overnight (`POST → POSTPOST → PREPRE → PRE`), and the presentation table conflated it with `PRE`. For European venues `PREPRE` lasts the whole night, so the dot claimed pre-market at 1 AM; the venue schedule correctly said closed with next open 09:00.

- **Presentation**: `PREPRE` → gray "Overnight" dot; `POSTPOST` → red "Closed" (it means after-hours *ended*, not running). Raw state codes remain the table keys so each can be styled distinctly.
- **Traits (both tables)**: `PREPRE`/`POSTPOST` flip to `active: false` — nothing trades in either state, so overnight SSE polling can drop to 300s and the intraday gates stop firing — and `PREPRE.phase` becomes `"closed"`, silencing the stale-price pulse at night. This is the deliberate decision the #567 comment explicitly deferred ("revisit deliberately, not as a refactor side effect").
- `session_forming` untouched (`REGULAR` only) — `drop_unsettled_last_bar` unchanged.

Note: with `DX-Y.NYB` in a group the SSE interval rarely idles anyway (it reports `REGULAR` nearly 24h), but the semantics are now right and the intraday sampling gate benefits regardless.

## Test plan
- [x] Trait tests updated: active == `{REGULAR, PRE, POST}`, closed-phase == `{CLOSED, POSTPOST, PREPRE}`, overnight pair alone doesn't wake pollers
- [x] `pytest` 771 passed, `ruff` clean, `eslint`/`tsc`/`vitest` (28) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)