### PR TITLE
feat(backend): venue-schedule scheduler gates (survey B2/B3)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
-from datetime import date
 from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -36,7 +35,7 @@ from app.routers import settings as settings_router
 from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
 from app.services.intraday import cleanup_old_intraday, fetch_and_store_intraday
-from app.services.market_state import any_active
+from app.services.market_calendar import any_venue_open
 from app.services.price_heal import heal_interior_holes, heal_unreconciled_prices
 from app.services.price_providers import init_price_provider
 from app.services.price_sync import sync_all_prices
@@ -123,14 +122,17 @@ async def _startup_warmup() -> None:
 
 async def scheduled_price_heal():
     """Background job: refresh symbols whose stored bars contradict live quotes."""
-    # No market is open anywhere on the weekend, so quotes are frozen and no
-    # stored bar can newly diverge — skip the full portfolio quote+DB scan
-    # entirely (~288 no-op fetches/weekend). Weekdays always have some market
-    # open across the Asia/EU/US rotation, so this is the practical "all markets
-    # closed" gate. Mirrors the intraday sync's weekend guard.
-    if date.today().weekday() >= 5:
-        return
     async with async_session() as db:
+        # While every tracked venue is closed, quotes are frozen and no stored
+        # bar can newly diverge — skip the full portfolio quote scan. The venue
+        # schedule replaces the old weekday() proxy, which ran all day on
+        # global holidays, skipped crypto weekends, and used the server-local
+        # date (Monday morning in Tokyo is still Sunday here).
+        from app.repositories.asset_repo import AssetRepository
+
+        pairs = await AssetRepository(db).list_in_any_group_id_symbol_pairs()
+        if not pairs or not any_venue_open([sym for _, sym in pairs]):
+            return
         try:
             healed = await heal_unreconciled_prices(db)
             if healed:
@@ -165,11 +167,7 @@ async def scheduled_symbol_sync():
 
 async def scheduled_intraday_sync():
     """Background job: fetch 1m intraday bars for all grouped assets."""
-    if date.today().weekday() >= 5:
-        return
-
     from app.repositories.asset_repo import AssetRepository
-    from app.services.price_providers import get_price_provider
 
     async with async_session() as db:
         try:
@@ -180,15 +178,12 @@ async def scheduled_intraday_sync():
             symbols = [sym for _, sym in pairs]
             asset_map = {sym: aid for aid, sym in pairs}
 
-            # Sample across the list to detect market activity.
-            # Use a shuffled sample to avoid always picking the same symbols,
-            # which could miss active markets in different timezones.
-            import random
-            sample_size = min(15, len(symbols))
-            sample = random.sample(symbols, sample_size)
-            quotes = await get_price_provider().batch_fetch_quotes(sample)
-            market_states = {q.get("market_state") for q in quotes if q.get("market_state")}
-            if not any_active(market_states):
+            # Venue-schedule gate. This replaces quoting 15 *random* symbols
+            # per tick to sniff for an active market — a Yahoo round-trip
+            # every 60s that could still miss the one open venue (3 Tokyo
+            # listings in a 200-symbol portfolio → ~80% miss). The calendar
+            # answer is deterministic, holiday-aware, and free.
+            if not any_venue_open(symbols):
                 return
 
             count = await fetch_and_store_intraday(db, symbols, asset_map)

--- a/backend/app/services/market_calendar.py
+++ b/backend/app/services/market_calendar.py
@@ -311,3 +311,35 @@ class Symbol(str):
         """This ticker's trading venue, or None when it can't be resolved."""
         name = self.calendar_name
         return _venue_for(name) if name else None
+
+
+def any_venue_open(symbols, at: datetime | None = None) -> bool:
+    """Whether any symbol's venue is in a tradeable phase (incl. extended hours).
+
+    The scheduler gate: background jobs that only matter while something can
+    trade (intraday bar sync, price heal) ask this instead of weekday guesses
+    or sampling live quotes. Symbols sharing a venue are checked once — a big
+    portfolio collapses to a handful of cached Venue objects and zero API
+    calls.
+
+    Fail-open by design: an unresolvable venue or a failed schedule query
+    counts as tradeable. The gate exists to skip certainly-dead ticks, never
+    to block real work — a wrong True costs one harmless fetch, a wrong False
+    silently stalls data.
+    """
+    seen: set[str] = set()
+    for sym in symbols:
+        s = Symbol(sym)
+        name = s.calendar_name
+        if name is None:
+            return True  # unknown venue — trading can't be ruled out
+        if name in seen:
+            continue
+        seen.add(name)
+        venue = s.venue
+        if venue is None:
+            return True  # calendar failed to build — same fail-open rule
+        phase = venue.phase(at)
+        if phase is None or phase != "closed":
+            return True
+    return False

--- a/backend/tests/services/test_market_calendar.py
+++ b/backend/tests/services/test_market_calendar.py
@@ -14,6 +14,7 @@ from app.services.market_calendar import (
     INDEX_CALENDARS,
     SUFFIX_CALENDARS,
     Symbol,
+    any_venue_open,
 )
 
 
@@ -166,3 +167,31 @@ def test_phase_venue_without_extended_hours():
     assert venue.phase(_utc(2024, 4, 3, 10, 0)) == "open"
     assert venue.phase(_utc(2024, 4, 3, 16, 0)) == "closed"  # 18:00 CEST
     assert venue.phase(_utc(2024, 4, 3, 6, 0)) == "closed"   # 08:00 CEST
+
+
+def test_any_venue_open_all_closed_weekend():
+    """Saturday noon UTC: neither New York nor Amsterdam trades."""
+    assert any_venue_open(["AAPL", "MSFT", "IWDA.AS"], _utc(2024, 4, 6, 12, 0)) is False
+
+
+def test_any_venue_open_crypto_keeps_weekend_alive():
+    """The 24/7 calendar makes a crypto pair defeat the weekend gate — the old
+    weekday() guard wrongly skipped crypto all weekend."""
+    assert any_venue_open(["AAPL", "BTC-USD"], _utc(2024, 4, 6, 12, 0)) is True
+
+
+def test_any_venue_open_extended_hours_count():
+    """US aftermarket (Wed 21:00 UTC) is a tradeable phase even with XAMS closed."""
+    assert any_venue_open(["IWDA.AS", "AAPL"], _utc(2024, 4, 3, 21, 0)) is True
+
+
+def test_any_venue_open_us_holiday():
+    """July 4 2024 (Thursday) 15:00 UTC — normally mid-session, but a holiday.
+    The old weekday() gate would have run the jobs all day."""
+    assert any_venue_open(["AAPL"], _utc(2024, 7, 4, 15, 0)) is False
+
+
+def test_any_venue_open_fails_open_on_unknown_venue():
+    """An unresolvable symbol must never let the gate block real work."""
+    assert any_venue_open(["FOO.XX"], _utc(2024, 4, 6, 12, 0)) is True
+    assert any_venue_open([], _utc(2024, 4, 6, 12, 0)) is False


### PR DESCRIPTION
## Summary

Survey items B2/B3 (`claudedocs/pattern-adoption-survey.md`): both background-job gates in `main.py` now ask the venue schedule instead of guessing.

**New:** `any_venue_open(symbols, at)` in `market_calendar.py` — dedupes the portfolio to its venues (a 200-symbol list collapses to a handful of cached `Venue` objects) and returns whether any is in a tradeable phase (regular or extended hours). Deterministic, holiday- and half-day-aware, zero API calls. **Fail-open**: unresolvable venues and failed schedule queries count as tradeable — the gate exists to skip certainly-dead ticks, never to block real work.

**`scheduled_intraday_sync`** — deletes the random-15-symbol quote probe (a Yahoo round-trip every 60s, ~1,440 calls/day, with an ~80% chance of missing a 3-symbol Tokyo tail in a 200-symbol portfolio) and the `weekday()` guard.

**`scheduled_price_heal`** — replaces the `weekday()` guard, which ran the full portfolio quote scan all day on global holidays, wrongly skipped crypto weekends, and used the server-local date (Monday 09:00 in Tokyo is still Sunday for the server).

Behavior deltas worth knowing:
- Crypto pairs now keep both jobs alive on weekends (previously hard-skipped) — correct, they trade.
- On global holidays both jobs now idle (previously ran uselessly all day).
- During a trading halt the venue phase still says "open" and the jobs run — intended: live quote state stays authoritative where it exists; the schedule only decides whether asking is worth it.
- Builds on #568: with PREPRE/POSTPOST inactive, overnight really is quiet now.

## Test plan
- [x] 6 new gate tests: weekend all-closed, crypto defeats weekend, US aftermarket counts, July 4 holiday gates a normal-hours Thursday, unknown venue fails open, empty list gates closed
- [x] `pytest` 776 passed, `ruff` clean (frontend untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)