### PR TITLE
fix(backend): intraday_prices.id BIGINT — sequence exhausted on staging

### DIFF
--- a/backend/alembic/versions/0018_intraday_id_bigint.py
+++ b/backend/alembic/versions/0018_intraday_id_bigint.py
@@ -1,0 +1,35 @@
+"""Widen intraday_prices.id to BIGINT — the int32 sequence ran out
+
+The intraday upsert uses ON CONFLICT DO UPDATE, and PostgreSQL consumes a
+sequence value for every *attempted* row, conflicting or not. Each 60s sync
+re-upserts the whole day's 1m bars for every symbol (~20M nextvals/day), so
+the SERIAL sequence hit 2147483647 after ~3 months and every intraday sync
+failed with SequenceGeneratorLimitExceededError.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-08-05
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0018"
+down_revision: Union[str, None] = "0017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE intraday_prices ALTER COLUMN id TYPE BIGINT")
+    # SERIAL created the sequence AS integer, which is what capped it at
+    # int4 max; switching it to bigint also lifts its maxvalue accordingly.
+    op.execute("ALTER SEQUENCE intraday_prices_id_seq AS BIGINT")
+
+
+def downgrade() -> None:
+    # Not reversible in practice: the sequence is already past int4 max, so
+    # narrowing back would immediately re-break. Intentional no-op.
+    pass

--- a/backend/app/models/intraday.py
+++ b/backend/app/models/intraday.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Numeric, String, UniqueConstraint
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, Numeric, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -9,7 +9,12 @@ from app.database import Base
 class IntradayPrice(Base):
     __tablename__ = "intraday_prices"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    # BIGINT: the upsert burns a sequence value per attempted row (conflicts
+    # included), ~20M/day — int32 ran out after ~3 months (migration 0018).
+    # SQLite (tests) keeps INTEGER for rowid autoincrement.
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"), primary_key=True
+    )
     asset_id: Mapped[int] = mapped_column(ForeignKey("assets.id", ondelete="CASCADE"))
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     price: Mapped[float] = mapped_column(Numeric(12, 4, asdecimal=False))


### PR DESCRIPTION
## Summary

Staging logs show every 60s intraday sync failing with:

```
asyncpg.exceptions.SequenceGeneratorLimitExceededError:
nextval: reached maximum value of sequence "intraday_prices_id_seq" (2147483647)
```

Root cause: `intraday_prices.id` is a 32-bit `SERIAL`, and the upsert's `ON CONFLICT DO UPDATE` consumes a sequence value for **every attempted row, including conflicts**. Each 60-second sync re-upserts the whole day's 1m bars for every symbol — ~20M `nextval`s/day, so int4 max (2.15B) exhausted after ~3 months of uptime. Intraday bars (live day view) have been frozen since.

Fix: migration 0018 widens both the column and the sequence to BIGINT (`SERIAL` created the sequence `AS integer`, which is what imposed the cap — altering its type lifts the maxvalue). At the current burn rate, int8 lasts ~1.2M years. Model gets a SQLite `Integer` variant so test-suite autoincrement is unaffected. Downgrade is a deliberate no-op (the sequence is already past int4 max; narrowing would re-break instantly).

Applies automatically on deploy via the startup `alembic upgrade head`.

Not addressed here (deliberately): reducing the sequence burn itself (e.g. only upserting new bars). BIGINT makes the burn rate irrelevant, and the delta-upsert change is an optimization with its own testing surface.

## Test plan
- [x] `pytest` — 773 passed (SQLite variant keeps test autoincrement working)
- [x] `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)