### PR TITLE
fix(backend): range syncs reaching today drop the unsettled trailing bar

### DIFF
--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -225,10 +225,22 @@ async def sync_asset_prices(
 async def sync_asset_prices_range(
     db: AsyncSession, asset: Asset, start: date, end: date
 ) -> int:
-    """Fetch and upsert price data for a date range. Returns number of rows upserted."""
+    """Fetch and upsert price data for a date range. Returns number of rows upserted.
+
+    A range that reaches today can include the current session's still-forming
+    bar, exactly like a period fetch — this path used to upsert it raw, so any
+    display/warmup backfill during market hours stored a live partial that
+    drifted from the quote and blanked σ-Move for the rest of the session.
+    Routing through the same anchor + drop + purge as ``sync_asset_prices``
+    closes that hole. Purely historical ranges (interior hole heals, bounded
+    backfills) skip the quote round-trip: every bar in them is settled.
+    """
     provider = get_price_provider()
     df = await provider.fetch_history(asset.symbol, start=start, end=end)
-    return await _upsert_prices(db, asset.id, df)
+    if end < date.today():
+        return await _upsert_prices(db, asset.id, df)
+    anchor = (await _quote_anchors(provider, [asset.symbol])).get(asset.symbol, _NO_ANCHOR)
+    return await _drop_and_persist(db, asset.id, df, anchor, asset.symbol)
 
 
 async def sync_all_prices(db: AsyncSession, period: str = "1y") -> dict[str, int]:

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -102,6 +102,73 @@ async def test_sync_range_passes_dates(db):
     assert count == 5
 
 
+async def test_sync_range_past_skips_quote_roundtrip(db):
+    """A purely historical range contains only settled bars — no anchor fetch."""
+    asset = Asset(symbol="RNG", name="Range", type=AssetType.STOCK, currency="USD")
+    db.add(asset)
+    await db.flush()
+
+    mock_prov = _mock_provider()
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", new_callable=AsyncMock, return_value=3):
+        await sync_asset_prices_range(db, asset, date(2025, 1, 1), date(2025, 6, 30))
+
+    mock_prov.batch_fetch_quotes.assert_not_awaited()
+
+
+async def test_sync_range_to_today_drops_unsettled_bar(db):
+    """A range reaching today goes through the same drop guard as period syncs.
+
+    Regression for the σ-Move blanking incident: a 1y detail-view backfill
+    during EU market hours stored the live partial bar raw, which then drifted
+    from the quote and blanked σ-Move for every affected symbol.
+    """
+    asset = Asset(symbol="MT.AS", name="ArcelorMittal", type=AssetType.STOCK, currency="EUR")
+    db.add(asset)
+    await db.flush()
+
+    # Last close is today's live partial; its predecessor equals previous_close.
+    df = _df_from_closes([60.0, 64.44, 63.10])
+    quotes = [{"symbol": "MT.AS", "price": 64.28, "previous_close": 64.44,
+               "market_state": "REGULAR"}]
+    mock_prov = _mock_provider(fetch_history=df, batch_fetch_quotes=quotes)
+
+    captured = {}
+
+    async def _capture(*args):
+        captured["len"] = len(args[-1])
+        return len(args[-1])
+
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", side_effect=_capture):
+        await sync_asset_prices_range(db, asset, date(2026, 1, 1), date.today())
+
+    assert captured["len"] == 2  # partial dropped
+    mock_prov.batch_fetch_quotes.assert_awaited_once()
+
+
+async def test_sync_range_to_today_without_quote_stores_all(db):
+    """Anchor unavailable → degrade to storing every bar (prior behavior)."""
+    asset = Asset(symbol="MT.AS", name="ArcelorMittal", type=AssetType.STOCK, currency="EUR")
+    db.add(asset)
+    await db.flush()
+
+    df = _df_from_closes([60.0, 64.44, 63.10])
+    mock_prov = _mock_provider(fetch_history=df, batch_fetch_quotes=[])
+
+    captured = {}
+
+    async def _capture(*args):
+        captured["len"] = len(args[-1])
+        return len(args[-1])
+
+    with patch("app.services.price_sync.get_price_provider", return_value=mock_prov), \
+         patch("app.services.price_sync._upsert_prices", side_effect=_capture):
+        await sync_asset_prices_range(db, asset, date(2026, 1, 1), date.today())
+
+    assert captured["len"] == 3
+
+
 # --- _upsert_prices ---
 
 async def test_upsert_empty_dataframe(db):


### PR DESCRIPTION
## Summary

Root cause of this morning's staging incident (every EU row showing "σ-Move unavailable — price data is behind the live quote").

**Diagnosis trail:** the DB showed `max(price_history.date) = today` for the blanked symbols *during their open session* — a stored live partial, i.e. the data was wrongly *ahead*, not behind. The access log showed `GET /api/assets/<sym>/detail?period=1y` for exactly those symbols: the 1y view triggers `_ensure_prices` → `sync_asset_prices_range(..., end=date.today())`, which upserted Yahoo's frame **raw** — no `drop_unsettled_last_bar`. The partial then drifted from the live quote, reconciled with neither `price` nor `previous_close`, and blanked σ-Move. US/Korean symbols were fetched too but their sessions were closed at fetch time (trailing bars settled), which is why only EU rows were hit. Pre-existing hole — surfaced today because yesterday's redeploys cleared the backfill-attempt cache, so the morning's page loads re-ran range backfills mid-session.

**Fix:** ranges that reach today route through the existing `_drop_and_persist` (anchor quote → `drop_unsettled_last_bar` → upsert → purge lingering partial rows). The purge also self-heals an already-poisoned row on the next range sync. Purely historical ranges (interior hole heals, bounded backfills) skip the quote round-trip since every bar in them is settled — the pre-existing past-range test pins that path unchanged.

The currently stored partials on staging will also clear on their own tonight: the scheduled syncs go through `_drop_and_persist`, which deletes rows past the last kept bar.

Sibling incident fix: #571 (intraday id sequence exhaustion, found in the same log review).

## Test plan
- [x] 3 new tests: range-to-today drops the partial (regression case, MT.AS closes from the incident), historical range skips the quote round-trip, missing anchor degrades to storing all bars
- [x] `pytest` — 776 passed; `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)