### PR TITLE
fix(backend): root logging config — app INFO lines were invisible

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://fibenchi:fibenchi@db:5432/fibenchi"
     refresh_cron: str = "0 23 * * *"
     price_provider: str = "yahoo"
+    log_level: str = "INFO"
 
     model_config = {"env_prefix": ""}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,17 @@ from app.services.price_providers import init_price_provider
 from app.services.price_sync import sync_all_prices
 from app.services.symbol_sync_service import sync_all_enabled as sync_all_symbol_sources
 
+# App loggers write through the root logger, which neither uvicorn nor docker
+# configures — so every logger.info() (price heal, hole heal, refresh
+# summaries, dropped-bar notices) was silently discarded and only WARNING+
+# reached `docker logs`. That cost real diagnostic time in the 2026-08-05
+# incident. basicConfig is a no-op when handlers already exist (pytest, etc.),
+# and uvicorn's own loggers don't propagate to root, so nothing is duplicated.
+logging.basicConfig(
+    level=getattr(logging, app_settings.log_level.upper(), logging.INFO),
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
 logger = logging.getLogger(__name__)
 scheduler = AsyncIOScheduler()
 


### PR DESCRIPTION
## Summary

Third finding from today's incident review: the 12h `docker logs` slice contained **zero** operational log lines — no nightly "Refreshed N assets", no heal output — because the root logger is never configured. uvicorn only configures its own loggers, so every `logger.info()` in the app was discarded and only WARNING+ leaked through Python's lastResort handler. All the observability we've been building into the heal/sync paths (dropped-bar notices, hole-heal reports, refresh summaries) was going nowhere, and diagnosing this morning's σ-Move incident took longer for it.

One `logging.basicConfig` at app import: INFO by default, `LOG_LEVEL` env var override (new setting), timestamped format (`docker logs` otherwise has no timestamps without `-t`). Safe by construction: `basicConfig` is a no-op when handlers already exist (pytest), and uvicorn's loggers don't propagate to root, so access logs aren't duplicated.

Smoke-tested: `app.services.price_heal` INFO lines now emit as `2026-08-05 10:05:51,748 INFO app.services.price_heal: ...`.

Completes today's incident trio with #571 (intraday id sequence) and #572 (range-sync partial bars).

## Test plan
- [x] `pytest` — 773 passed; `ruff` clean
- [x] Manual smoke test of root handler/level and INFO emission

🤖 Generated with [Claude Code](https://claude.com/claude-code)