### PR TITLE
refactor(backend): intraday_prices (asset_id, timestamp) natural key

### DIFF
--- a/backend/alembic/versions/0019_intraday_natural_key.py
+++ b/backend/alembic/versions/0019_intraday_natural_key.py
@@ -1,0 +1,44 @@
+"""intraday_prices: (asset_id, timestamp) natural primary key, no surrogate id
+
+Follow-up to 0018: the surrogate id existed only to be a primary key, yet
+(asset_id, timestamp) is already the row's identity (it's the upsert's
+conflict target). Dropping the id removes the sequence entirely, making the
+sequence-exhaustion class of failure unrepresentable instead of merely
+postponed. The old unique constraint and secondary index are redundant with
+the new primary key and go with it.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-08-05
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0019"
+down_revision: Union[str, None] = "0018"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Dropping the column also drops its primary-key constraint and the
+    # owned sequence. The table holds ~2 days of bars, so the locks are brief.
+    op.execute("ALTER TABLE intraday_prices DROP COLUMN id")
+    op.execute("ALTER TABLE intraday_prices ADD PRIMARY KEY (asset_id, timestamp)")
+    op.execute("ALTER TABLE intraday_prices DROP CONSTRAINT uq_intraday_asset_ts")
+    op.execute("DROP INDEX IF EXISTS ix_intraday_asset_time")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE intraday_prices DROP CONSTRAINT intraday_prices_pkey")
+    op.execute("ALTER TABLE intraday_prices ADD COLUMN id BIGSERIAL PRIMARY KEY")
+    op.execute(
+        "ALTER TABLE intraday_prices "
+        "ADD CONSTRAINT uq_intraday_asset_ts UNIQUE (asset_id, timestamp)"
+    )
+    op.execute(
+        "CREATE INDEX ix_intraday_asset_time ON intraday_prices (asset_id, timestamp)"
+    )

--- a/backend/app/models/intraday.py
+++ b/backend/app/models/intraday.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, Numeric, String, UniqueConstraint
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -9,19 +9,14 @@ from app.database import Base
 class IntradayPrice(Base):
     __tablename__ = "intraday_prices"
 
-    # BIGINT: the upsert burns a sequence value per attempted row (conflicts
-    # included), ~20M/day — int32 ran out after ~3 months (migration 0018).
-    # SQLite (tests) keeps INTEGER for rowid autoincrement.
-    id: Mapped[int] = mapped_column(
-        BigInteger().with_variant(Integer, "sqlite"), primary_key=True
+    # Natural composite key — it's also the upsert's conflict target. There is
+    # deliberately no surrogate id: its sequence exhausted at int32 max because
+    # ON CONFLICT burns a value per attempted row (~20M/day; migrations
+    # 0018/0019). No id, no sequence, no way to exhaust it.
+    asset_id: Mapped[int] = mapped_column(
+        ForeignKey("assets.id", ondelete="CASCADE"), primary_key=True
     )
-    asset_id: Mapped[int] = mapped_column(ForeignKey("assets.id", ondelete="CASCADE"))
-    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), primary_key=True)
     price: Mapped[float] = mapped_column(Numeric(12, 4, asdecimal=False))
     volume: Mapped[int] = mapped_column(BigInteger, default=0)
     session: Mapped[str] = mapped_column(String(7), default="regular")  # pre/regular/post
-
-    __table_args__ = (
-        UniqueConstraint("asset_id", "timestamp", name="uq_intraday_asset_ts"),
-        Index("ix_intraday_asset_time", "asset_id", "timestamp"),
-    )

--- a/backend/app/services/intraday.py
+++ b/backend/app/services/intraday.py
@@ -118,7 +118,7 @@ async def fetch_and_store_intraday(
 
         stmt = pg_insert(IntradayPrice).values(rows)
         stmt = stmt.on_conflict_do_update(
-            constraint="uq_intraday_asset_ts",
+            index_elements=["asset_id", "timestamp"],
             set_={
                 "price": stmt.excluded.price,
                 "volume": stmt.excluded.volume,


### PR DESCRIPTION
## Summary

Follow-up to #571, making the sequence-exhaustion bug class *unrepresentable* rather than postponed: `(asset_id, timestamp)` is already the row's identity (it's literally the upsert's conflict target), so the surrogate `id` served no purpose except feeding the sequence that `ON CONFLICT` burned ~20M values/day.

Migration 0019:
- drops `id` (the owned sequence and old PK go with it)
- promotes `(asset_id, timestamp)` to primary key
- removes `uq_intraday_asset_ts` and `ix_intraday_asset_time` — both redundant with the new PK's index

Model becomes a clean composite-key table; the upsert switches from the retired constraint name to `index_elements=["asset_id", "timestamp"]`. Nothing reads `IntradayPrice.id` anywhere. Downgrade is implemented for completeness (recreates a BIGSERIAL id + the old constraints).

Table holds ~2 days of bars (~25k rows), so the migration's locks are momentary. Applies on deploy after 0018.

## Test plan
- [x] `pytest` — 776 passed (SQLite composite PK works for the test suite; integration tests construct `IntradayPrice` without an id already)
- [x] `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)