### PR TITLE
fix(frontend): holdings-grid σ-Move decimals (#558) + market_state union type (#540)

### DIFF
--- a/frontend/src/components/holdings-grid/holding-row.tsx
+++ b/frontend/src/components/holdings-grid/holding-row.tsx
@@ -92,6 +92,7 @@ export function HoldingRow({
                     values={indicator?.values}
                     close={indicator?.close ?? null}
                     suffix={desc.suffix}
+                    decimals={desc.decimals}
                   />
                 </td>
               )

--- a/frontend/src/components/holdings-grid/holding-summary-cell.tsx
+++ b/frontend/src/components/holdings-grid/holding-summary-cell.tsx
@@ -8,6 +8,7 @@ export function HoldingSummaryCell({
   values,
   close,
   suffix,
+  decimals,
 }: {
   format: "numeric" | "compare_close" | "string_map"
   field: string
@@ -15,10 +16,11 @@ export function HoldingSummaryCell({
   values?: Record<string, number | string | null>
   close: number | null
   suffix?: string
+  decimals?: number
 }) {
   if (format === "numeric") {
     const val = getNumericValue(values, field)
-    return <IndicatorCell value={val != null ? `${val.toFixed(0)}${suffix ?? ""}` : null} />
+    return <IndicatorCell value={val != null ? `${val.toFixed(decimals ?? 0)}${suffix ?? ""}` : null} />
   }
 
   if (format === "compare_close") {

--- a/frontend/src/components/market-status-dot.tsx
+++ b/frontend/src/components/market-status-dot.tsx
@@ -4,13 +4,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
-import { marketState } from "@/lib/market-state"
+import { marketState, type MarketState } from "@/lib/market-state"
 
 export function MarketStatusDot({
   marketState: state,
   className,
 }: {
-  marketState: string | null | undefined
+  marketState: MarketState | null | undefined
   className?: string
 }) {
   const { dotColor, label } = marketState(state)

--- a/frontend/src/lib/market-state.ts
+++ b/frontend/src/lib/market-state.ts
@@ -18,18 +18,28 @@ export interface MarketStateInfo {
   phase: "premarket" | "open" | "aftermarket" | "closed"
 }
 
-const MARKET_STATES: Record<string, MarketStateInfo> = {
+const MARKET_STATES = {
   PRE: { dotColor: "bg-blue-500", label: "Pre-market", phase: "premarket" },
   PREPRE: { dotColor: "bg-zinc-500", label: "Overnight", phase: "closed" },
   REGULAR: { dotColor: "bg-emerald-500", label: "Market open", phase: "open" },
   POST: { dotColor: "bg-orange-500", label: "After-hours", phase: "aftermarket" },
   POSTPOST: { dotColor: "bg-red-500", label: "Closed", phase: "closed" },
   CLOSED: { dotColor: "bg-red-500", label: "Closed", phase: "closed" },
-}
+} as const satisfies Record<string, MarketStateInfo>
+
+/**
+ * The market-state vocabulary the backend emits (Yahoo's, hand-mirrored from
+ * `backend/app/schemas/quote.py` — no codegen). Comparing a MarketState
+ * against a string outside this union is a compile error, which is the point:
+ * a `=== "POSTMARKET"` typo can no longer type-check.
+ */
+export type MarketState = keyof typeof MARKET_STATES
 
 const DEFAULT_STATE: MarketStateInfo = { dotColor: "bg-red-500", label: "Closed", phase: "closed" }
 
-/** Resolve a raw market-state code to its dot colour + label (falls back to Closed). */
-export function marketState(state: string | null | undefined): MarketStateInfo {
+/** Resolve a market-state code to its dot colour + label (falls back to Closed). */
+export function marketState(state: MarketState | null | undefined): MarketStateInfo {
+  // Runtime guard stays: the API cast is unchecked, so a novel Yahoo state
+  // must still degrade to Closed instead of exploding.
   return (state && MARKET_STATES[state]) || DEFAULT_STATE
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,5 +1,7 @@
 // TypeScript types matching backend Pydantic schemas
 
+import type { MarketState } from "./market-state"
+
 export type AssetType = "stock" | "etf" | "index"
 
 export interface TagBrief {
@@ -307,7 +309,7 @@ export interface Quote {
   volume: number | null
   avg_volume: number | null
   currency: string
-  market_state: string | null
+  market_state: MarketState | null
 }
 
 export interface IntradayPoint {


### PR DESCRIPTION
Two small frontend issue knockouts, one commit each.

## #558 — holdings-grid σ-Move rendered as `-0σ"
`HoldingSummaryCell`'s numeric branch hardcoded `toFixed(0)` and the caller never passed the descriptor's `decimals`. Now threaded through:
- σ-Move: `-0σ` → `-0.18σ` (decimals: 2)
- RSI: unchanged (its descriptor declares decimals: 0)
- ATR / ATR%: gain 2 decimals, matching what the group table already shows

## #540 — `market_state` typed as a union, trait table compile-checked
- `MARKET_STATES` is now `as const satisfies Record<string, MarketStateInfo>`; `type MarketState = keyof typeof` exported
- `Quote.market_state` and the `MarketStatusDot` prop narrow `string → MarketState | null` — a `=== "POSTMARKET"`-style typo (the original #535 bug) is now a compile error
- `marketState()` keeps its runtime fallback to Closed since the API cast is unchecked

Per the issue's caveat: the union is a hand-maintained mirror of the backend vocabulary (`schemas/quote.py`), no codegen — noted in a comment at the definition.

## Verification
- `eslint` clean, `tsc --noEmit` clean, `vitest run` 28/28, `vite build` succeeds

Closes #558
Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)