### PR TITLE
fix(backend): hole-heal failure no longer aborts the rest of the scan batch

### DIFF
--- a/backend/app/services/price_heal.py
+++ b/backend/app/services/price_heal.py
@@ -27,6 +27,7 @@ from datetime import date, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models import Asset
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.price_repo import PriceRepository
 from app.services.market_calendar import Symbol
@@ -205,7 +206,10 @@ async def heal_interior_holes(db: AsyncSession, force: bool = False) -> dict[str
         last = _hole_attempts.get(asset.symbol)
         if last and last[1] == signature and now - last[0] < HOLE_RETRY_COOLDOWN_SECONDS:
             continue  # same holes, recently attempted — wait for Yahoo to backfill
-        candidates.append((asset, holes, signature))
+        # Plain scalars, not the ORM object: a rollback in the heal loop below
+        # expires every instance in the session, and touching an expired
+        # attribute outside a greenlet context raises MissingGreenlet.
+        candidates.append((asset.id, asset.symbol, holes, signature))
 
     if not candidates:
         return {}
@@ -219,27 +223,38 @@ async def heal_interior_holes(db: AsyncSession, force: bool = False) -> dict[str
         )
 
     healed: dict[str, int] = {}
-    for asset, holes, signature in candidates:
-        _hole_attempts[asset.symbol] = (now, signature)
+    for asset_id, symbol, holes, signature in candidates:
+        _hole_attempts[symbol] = (now, signature)
         try:
+            # Re-get inside the try: a previous iteration's rollback expired
+            # the session, and Session.get refreshes an expired identity-map
+            # instance in a context where that IO is legal.
+            asset = await db.get(Asset, asset_id)
+            if asset is None:
+                continue  # deleted since the scan
             count = await sync_asset_prices_range(db, asset, min(holes), max(holes))
-            healed[asset.symbol] = count
-            refreshed = await PriceRepository(db).list_by_asset_since(asset.id, min(holes))
+            healed[symbol] = count
+            refreshed = await PriceRepository(db).list_by_asset_since(asset_id, min(holes))
             remaining = holes - {p.date for p in refreshed}
             if remaining:
                 logger.info(
                     "%s: %d of %d interior hole(s) persist after re-fetch "
                     "(Yahoo may backfill later): %s",
-                    asset.symbol, len(remaining), len(holes),
+                    symbol, len(remaining), len(holes),
                     ", ".join(d.isoformat() for d in sorted(remaining)),
                 )
             else:
                 logger.info(
                     "%s: healed %d interior hole(s): %s",
-                    asset.symbol, len(holes),
+                    symbol, len(holes),
                     ", ".join(d.isoformat() for d in sorted(holes)),
                 )
+        except ValueError as e:
+            # Expected: Yahoo has no history for the range (delisted symbol,
+            # feed gap). The cooldown above keeps it from retrying every scan.
+            logger.info("Hole heal for %s: %s", symbol, e)
+            await db.rollback()
         except Exception:
-            logger.warning("Hole heal for %s failed", asset.symbol, exc_info=True)
+            logger.warning("Hole heal for %s failed", symbol, exc_info=True)
             await db.rollback()
     return healed

--- a/backend/tests/services/test_price_heal.py
+++ b/backend/tests/services/test_price_heal.py
@@ -270,6 +270,33 @@ async def test_hole_heal_scan_interval_throttles(db):
     sync.assert_awaited_once()
 
 
+async def test_hole_heal_failure_does_not_abort_batch(db):
+    """One symbol's failed re-fetch must not kill the rest of the scan.
+
+    Staging regression (2026-08-05): AIFS.DE raised "No data found", the
+    rollback in the except path expired every ORM instance in the session,
+    and the next candidate's attribute access crashed the whole job with
+    MissingGreenlet — remaining candidates were never attempted.
+    """
+    await _seed_with_hole(db, "AAAA")
+    await _seed_with_hole(db, "BBBB")
+
+    async def sync_side_effect(db_, asset, start, end):
+        if asset.symbol == "AAAA":
+            raise ValueError("No data found for AAAA")
+        return 1
+
+    with patch.object(price_heal, "sync_asset_prices_range",
+                      new=AsyncMock(side_effect=sync_side_effect)) as sync:
+        healed = await heal_interior_holes(db, force=True)
+
+    assert sync.await_count == 2
+    assert "AAAA" not in healed
+    assert healed.get("BBBB") == 1
+    # The failed symbol still lands on cooldown so it isn't retried every scan.
+    assert "AAAA" in price_heal._hole_attempts
+
+
 async def test_hole_heal_skips_unknown_venue(db):
     """No venue calendar → holes and holidays are indistinguishable → skip."""
     asset = await seed_asset_with_prices(db, "FOO.XX", n_days=60)


### PR DESCRIPTION
First real-world run of the interior-hole heal (this morning's staging redeploy) surfaced a crash chain:

1. `AIFS.DE` re-fetch raised `ValueError: No data found` — expected for a symbol Yahoo has no history for.
2. The `except` path's `await db.rollback()` **expires every ORM instance in the session**.
3. The *next* candidate's `asset.symbol` access (outside the `try`, outside greenlet context) raised `sqlalchemy.exc.MissingGreenlet`, which bubbled up as "Hole heal failed" and dropped the remaining candidates of the batch.

## Fix
- Candidates carry plain `(asset_id, symbol)` scalars, captured while the session is live — no expired-attribute access is possible in the loop.
- The loop re-gets a fresh `Asset` via `Session.get` *inside* the `try`, where refreshing an expired identity-map instance is legal IO.
- `ValueError` (empty fetch: delisted symbol / feed gap) now logs one info line instead of a warning traceback; the existing 24h cooldown already prevents per-scan retries.

## Also visible in the same log, no action needed
- Migration 0019 applied cleanly; the new logging config works (this bug was only diagnosable because of it).
- The reconcile heal refreshed 10 symbols whose stored bars were poisoned live-partials from before #572 — the system cleaning up its own past mess.
- One transient `curl (16)` from Yahoo on an intraday sync; recovered on the next 60s tick.

## Verification
- New regression test `test_hole_heal_failure_does_not_abort_batch` (fails on the old code path).
- Full backend suite: **777 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)