### PR TITLE
refactor(backend): background jobs move to app/background_tasks with a task registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ The charting layer has four architectural tiers:
 
 On startup (`main.py` lifespan):
 1. `load_currency_cache(db)` — populates in-memory currency lookup to avoid per-request DB hits
-2. APScheduler starts with cron trigger from `REFRESH_CRON`
+2. APScheduler schedules everything in `app/background_tasks/` — jobs live in `jobs.py` and self-register via the `@background_task(id=..., trigger=...)` decorator (registry pattern, like `INDICATOR_REGISTRY`); adding a job never touches `main.py`. A trigger may be a factory returning `None` to disable just that job (e.g. malformed `REFRESH_CRON` disables `price_refresh` with a warning; everything else still runs).
 3. `scheduled_refresh()` job: `sync_all_prices` → `compute_and_cache_indicators` (pre-warms cache so first group page load is instant)
 
 ## Key Patterns

--- a/backend/app/background_tasks/__init__.py
+++ b/backend/app/background_tasks/__init__.py
@@ -1,0 +1,19 @@
+"""Background jobs and the registry that schedules them.
+
+``jobs`` self-register via the :func:`background_task` decorator at import;
+``main.py``'s lifespan iterates :func:`all_tasks` and hands each to
+APScheduler. Adding a job means writing it in ``jobs.py`` with the decorator
+— no ``main.py`` change.
+"""
+
+from app.background_tasks import jobs as _jobs  # noqa: F401 — registers the jobs
+from app.background_tasks.jobs import startup_warmup, warm_all_group_caches
+from app.background_tasks.registry import BackgroundTask, all_tasks, background_task
+
+__all__ = [
+    "BackgroundTask",
+    "all_tasks",
+    "background_task",
+    "startup_warmup",
+    "warm_all_group_caches",
+]

--- a/backend/app/background_tasks/jobs.py
+++ b/backend/app/background_tasks/jobs.py
@@ -1,0 +1,207 @@
+"""The application's background jobs, moved out of ``main.py``.
+
+Each job registers itself with :func:`background_task`; ``main.py``'s
+lifespan schedules the registry wholesale. Job bodies own their DB sessions
+and swallow their own exceptions — a failing run logs and waits for the next
+trigger, never crashes the scheduler.
+"""
+
+import logging
+
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+from app.background_tasks.registry import background_task
+from app.config import settings as app_settings
+from app.database import async_session
+from app.services.compute.group import compute_and_cache_indicators
+from app.services.intraday import cleanup_old_intraday, fetch_and_store_intraday
+from app.services.market_calendar import any_venue_open
+from app.services.price_heal import heal_interior_holes, heal_unreconciled_prices
+from app.services.price_sync import sync_all_prices
+from app.services.symbol_sync_service import sync_all_enabled as sync_all_symbol_sources
+
+logger = logging.getLogger(__name__)
+
+
+async def warm_all_group_caches() -> int:
+    """Pre-compute indicator snapshots for every group so the first request
+    on any group page hits a warm cache. Returns the number of groups warmed.
+
+    Each group is warmed in its own DB session so a slow group doesn't hold
+    a connection longer than necessary. Failures on one group are logged
+    and do not stop subsequent groups.
+    """
+    from app.repositories.group_repo import GroupRepository
+
+    async with async_session() as db:
+        try:
+            groups = await GroupRepository(db).list_all()
+        except Exception:
+            logger.exception("Failed to load groups for cache warming")
+            return 0
+
+    warmed = 0
+    for group in groups:
+        async with async_session() as db:
+            try:
+                snapshot = await compute_and_cache_indicators(db, group_id=group.id)
+                if snapshot:
+                    warmed += 1
+            except Exception:
+                logger.exception(f"Cache warm failed for group {group.id} ({group.name})")
+    return warmed
+
+
+async def startup_warmup() -> None:
+    """Pre-compute indicator caches at startup.
+
+    Not a scheduled task — the lifespan runs it once as an asyncio task so
+    the API is reachable immediately while the cache builds. Fundamentals
+    lazy-fetch via :func:`merge_fundamentals_from_cache` so we don't burst
+    at Yahoo at boot.
+    """
+    logger.info("Starting background cache warmup...")
+    try:
+        warmed = await warm_all_group_caches()
+        if warmed:
+            logger.info(f"Startup warmup complete: {warmed} groups cached")
+    except Exception:
+        logger.exception("Startup indicator warmup failed (non-fatal)")
+
+
+def _refresh_trigger() -> CronTrigger | None:
+    """Primary refresh trigger from ``REFRESH_CRON`` (minute hour day month dow).
+
+    A malformed value disables only this job — loudly. (Previously the whole
+    scheduler block sat behind the 5-field check, so a bad cron silently
+    killed every background job, including ones that don't use it.)
+    """
+    parts = app_settings.refresh_cron.split()
+    if len(parts) != 5:
+        logger.warning(
+            "Malformed REFRESH_CRON %r (expected 5 fields) — the price_refresh job is "
+            "disabled; all other background jobs run normally",
+            app_settings.refresh_cron,
+        )
+        return None
+    return CronTrigger(
+        minute=parts[0], hour=parts[1], day=parts[2],
+        month=parts[3], day_of_week=parts[4],
+    )
+
+
+# Supplemental daytime refreshes. The primary run fires once at REFRESH_CRON
+# (23:00 UTC by default), but Yahoo publishes some markets' daily bars well
+# after their close — notably KRX (``.KS``), whose bar for a session isn't in
+# Yahoo's daily history until the *following* day. A single nightly run
+# therefore leaves Asian markets a full day stale (a stale σ-Move/change
+# sitting beside a live quote). Extra 08:00 and 16:00 UTC runs catch the
+# prior Asian session (published overnight) and any late Yahoo publish, so no
+# market stays stale longer than ~8h.
+@background_task("price_refresh", trigger=_refresh_trigger)
+@background_task("price_refresh_supplemental", trigger=CronTrigger(minute="0", hour="8,16"))
+async def scheduled_refresh():
+    """Refresh all asset prices, then warm the indicator cache."""
+    logger.info("Running scheduled price refresh...")
+    async with async_session() as db:
+        try:
+            counts = await sync_all_prices(db)
+            total = sum(counts.values())
+            logger.info(f"Refreshed {len(counts)} assets, {total} price points")
+        except Exception:
+            logger.exception("Scheduled refresh failed")
+            return
+
+    try:
+        warmed = await warm_all_group_caches()
+        if warmed:
+            logger.info(f"Pre-computed indicator caches for {warmed} groups")
+    except Exception:
+        logger.exception("Indicator pre-computation failed (non-fatal)")
+
+    # Clean up old intraday data (keep only last 2 days)
+    async with async_session() as db:
+        try:
+            deleted = await cleanup_old_intraday(db)
+            if deleted:
+                logger.info(f"Cleaned up {deleted} old intraday bars")
+        except Exception:
+            logger.exception("Intraday cleanup failed (non-fatal)")
+
+
+@background_task("symbol_directory_sync", trigger=CronTrigger(minute="0", hour="2", day_of_week="sun"))
+async def scheduled_symbol_sync():
+    """Weekly sync of all enabled symbol directory sources."""
+    logger.info("Running scheduled symbol directory sync...")
+    async with async_session() as db:
+        try:
+            counts = await sync_all_symbol_sources(db)
+            total = sum(counts.values())
+            logger.info(f"Symbol sync complete: {len(counts)} sources, {total} symbols")
+        except Exception:
+            logger.exception("Scheduled symbol sync failed")
+
+
+@background_task("intraday_sync", trigger=IntervalTrigger(seconds=60))
+async def scheduled_intraday_sync():
+    """Fetch 1m intraday bars for all grouped assets."""
+    from app.repositories.asset_repo import AssetRepository
+
+    async with async_session() as db:
+        try:
+            refs = await AssetRepository(db).list_in_any_group_refs()
+            if not refs:
+                return
+
+            # Venue-schedule gate. This replaces quoting 15 *random* symbols
+            # per tick to sniff for an active market — a Yahoo round-trip
+            # every 60s that could still miss the one open venue (3 Tokyo
+            # listings in a 200-symbol portfolio → ~80% miss). The calendar
+            # answer is deterministic, holiday-aware, and free.
+            if not any_venue_open(refs):
+                return
+
+            count = await fetch_and_store_intraday(db, refs)
+            if count:
+                logger.info(f"Intraday sync: {count} bars for {len(refs)} symbols")
+        except Exception:
+            logger.exception("Intraday sync failed")
+
+
+# Self-heal stragglers the scheduled refreshes missed: when a symbol's latest
+# stored bar reconciles with neither the live price nor the quote's previous
+# close (the state that blanks σ-Move), refresh just that symbol instead of
+# waiting for the next full run.
+@background_task("price_heal", trigger=IntervalTrigger(minutes=10))
+async def scheduled_price_heal():
+    """Refresh symbols whose stored bars contradict live quotes."""
+    async with async_session() as db:
+        # While every tracked venue is closed, quotes are frozen and no stored
+        # bar can newly diverge — skip the full portfolio quote scan. The venue
+        # schedule replaces the old weekday() proxy, which ran all day on
+        # global holidays, skipped crypto weekends, and used the server-local
+        # date (Monday morning in Tokyo is still Sunday here).
+        from app.repositories.asset_repo import AssetRepository
+
+        refs = await AssetRepository(db).list_in_any_group_refs()
+        if not refs or not any_venue_open(refs):
+            return
+        try:
+            healed = await heal_unreconciled_prices(db)
+            if healed:
+                logger.info(
+                    f"Price heal: refreshed {len(healed)} symbol(s): {', '.join(sorted(healed))}"
+                )
+        except Exception:
+            logger.exception("Price heal failed")
+        try:
+            # Mid-series holes (issue #559): self-throttled to one scan per
+            # HOLE_SCAN_INTERVAL, so piggybacking on this job costs nothing.
+            filled = await heal_interior_holes(db)
+            if filled:
+                logger.info(
+                    f"Hole heal: refreshed {len(filled)} symbol(s): {', '.join(sorted(filled))}"
+                )
+        except Exception:
+            logger.exception("Hole heal failed")

--- a/backend/app/background_tasks/registry.py
+++ b/backend/app/background_tasks/registry.py
@@ -1,0 +1,64 @@
+"""Background-task registry.
+
+Jobs declare themselves with the :func:`background_task` decorator (same
+pattern as ``INDICATOR_REGISTRY``); the app's lifespan schedules whatever is
+registered instead of hand-wiring each ``scheduler.add_job`` call.
+
+A task's trigger is either a ready APScheduler trigger or a zero-arg factory
+resolved at scheduling time. A factory may return ``None`` to disable just
+that task (after logging why) — this is the seam that fixes the old
+``main.py`` behaviour where one malformed ``REFRESH_CRON`` silently skipped
+*every* background job.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from apscheduler.triggers.base import BaseTrigger
+
+logger = logging.getLogger(__name__)
+
+TriggerFactory = Callable[[], "BaseTrigger | None"]
+
+
+@dataclass(frozen=True)
+class BackgroundTask:
+    """One scheduled job: its scheduler id, coroutine function, and trigger."""
+
+    id: str
+    func: Callable[[], Awaitable[None]]
+    trigger: BaseTrigger | TriggerFactory
+
+    def resolve_trigger(self) -> BaseTrigger | None:
+        """The trigger to schedule with, or None when the task is disabled
+        (the factory is expected to have logged the reason)."""
+        if isinstance(self.trigger, BaseTrigger):
+            return self.trigger
+        return self.trigger()
+
+
+_REGISTRY: dict[str, BackgroundTask] = {}
+
+
+def background_task(id: str, trigger: BaseTrigger | TriggerFactory):
+    """Register the decorated coroutine function as a scheduled job.
+
+    Stackable: the same function may be registered under several ids with
+    different triggers (the primary + supplemental price refreshes do this).
+    """
+
+    def decorator(func: Callable[[], Awaitable[None]]):
+        if id in _REGISTRY:
+            raise ValueError(f"Duplicate background task id: {id!r}")
+        _REGISTRY[id] = BackgroundTask(id=id, func=func, trigger=trigger)
+        return func
+
+    return decorator
+
+
+def all_tasks() -> list[BackgroundTask]:
+    """Every registered task, in registration order."""
+    return list(_REGISTRY.values())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,12 +4,11 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.cron import CronTrigger
-from apscheduler.triggers.interval import IntervalTrigger
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
+from app.background_tasks import all_tasks, startup_warmup
 from app.config import settings as app_settings
 from app.database import async_session, engine
 from app.routers import (
@@ -32,14 +31,8 @@ from app.routers import (
     thesis,
 )
 from app.routers import settings as settings_router
-from app.services.compute.group import compute_and_cache_indicators
 from app.services.currency_service import load_cache as load_currency_cache
-from app.services.intraday import cleanup_old_intraday, fetch_and_store_intraday
-from app.services.market_calendar import any_venue_open
-from app.services.price_heal import heal_interior_holes, heal_unreconciled_prices
 from app.services.price_providers import init_price_provider
-from app.services.price_sync import sync_all_prices
-from app.services.symbol_sync_service import sync_all_enabled as sync_all_symbol_sources
 
 # App loggers write through the root logger, which neither uvicorn nor docker
 # configures — so every logger.info() (price heal, hole heal, refresh
@@ -56,151 +49,6 @@ logger = logging.getLogger(__name__)
 scheduler = AsyncIOScheduler()
 
 
-async def warm_all_group_caches() -> int:
-    """Pre-compute indicator snapshots for every group so the first request
-    on any group page hits a warm cache. Returns the number of groups warmed.
-
-    Each group is warmed in its own DB session so a slow group doesn't hold
-    a connection longer than necessary. Failures on one group are logged
-    and do not stop subsequent groups.
-    """
-    from app.repositories.group_repo import GroupRepository
-
-    async with async_session() as db:
-        try:
-            groups = await GroupRepository(db).list_all()
-        except Exception:
-            logger.exception("Failed to load groups for cache warming")
-            return 0
-
-    warmed = 0
-    for group in groups:
-        async with async_session() as db:
-            try:
-                snapshot = await compute_and_cache_indicators(db, group_id=group.id)
-                if snapshot:
-                    warmed += 1
-            except Exception:
-                logger.exception(f"Cache warm failed for group {group.id} ({group.name})")
-    return warmed
-
-
-async def scheduled_refresh():
-    """Background job: refresh all asset prices, then warm indicator cache."""
-    logger.info("Running scheduled price refresh...")
-    async with async_session() as db:
-        try:
-            counts = await sync_all_prices(db)
-            total = sum(counts.values())
-            logger.info(f"Refreshed {len(counts)} assets, {total} price points")
-        except Exception:
-            logger.exception("Scheduled refresh failed")
-            return
-
-    try:
-        warmed = await warm_all_group_caches()
-        if warmed:
-            logger.info(f"Pre-computed indicator caches for {warmed} groups")
-    except Exception:
-        logger.exception("Indicator pre-computation failed (non-fatal)")
-
-    # Clean up old intraday data (keep only last 2 days)
-    async with async_session() as db:
-        try:
-            deleted = await cleanup_old_intraday(db)
-            if deleted:
-                logger.info(f"Cleaned up {deleted} old intraday bars")
-        except Exception:
-            logger.exception("Intraday cleanup failed (non-fatal)")
-
-
-async def _startup_warmup() -> None:
-    """Pre-compute indicator caches at startup.
-
-    Runs as a background task so the API is reachable immediately while
-    the cache builds. Fundamentals lazy-fetch via
-    :func:`merge_fundamentals_from_cache` so we don't burst at Yahoo at
-    boot.
-    """
-    logger.info("Starting background cache warmup...")
-    try:
-        warmed = await warm_all_group_caches()
-        if warmed:
-            logger.info(f"Startup warmup complete: {warmed} groups cached")
-    except Exception:
-        logger.exception("Startup indicator warmup failed (non-fatal)")
-
-
-async def scheduled_price_heal():
-    """Background job: refresh symbols whose stored bars contradict live quotes."""
-    async with async_session() as db:
-        # While every tracked venue is closed, quotes are frozen and no stored
-        # bar can newly diverge — skip the full portfolio quote scan. The venue
-        # schedule replaces the old weekday() proxy, which ran all day on
-        # global holidays, skipped crypto weekends, and used the server-local
-        # date (Monday morning in Tokyo is still Sunday here).
-        from app.repositories.asset_repo import AssetRepository
-
-        refs = await AssetRepository(db).list_in_any_group_refs()
-        if not refs or not any_venue_open(refs):
-            return
-        try:
-            healed = await heal_unreconciled_prices(db)
-            if healed:
-                logger.info(
-                    f"Price heal: refreshed {len(healed)} symbol(s): {', '.join(sorted(healed))}"
-                )
-        except Exception:
-            logger.exception("Price heal failed")
-        try:
-            # Mid-series holes (issue #559): self-throttled to one scan per
-            # HOLE_SCAN_INTERVAL, so piggybacking on this job costs nothing.
-            filled = await heal_interior_holes(db)
-            if filled:
-                logger.info(
-                    f"Hole heal: refreshed {len(filled)} symbol(s): {', '.join(sorted(filled))}"
-                )
-        except Exception:
-            logger.exception("Hole heal failed")
-
-
-async def scheduled_symbol_sync():
-    """Background job: sync all enabled symbol directory sources."""
-    logger.info("Running scheduled symbol directory sync...")
-    async with async_session() as db:
-        try:
-            counts = await sync_all_symbol_sources(db)
-            total = sum(counts.values())
-            logger.info(f"Symbol sync complete: {len(counts)} sources, {total} symbols")
-        except Exception:
-            logger.exception("Scheduled symbol sync failed")
-
-
-async def scheduled_intraday_sync():
-    """Background job: fetch 1m intraday bars for all grouped assets."""
-    from app.repositories.asset_repo import AssetRepository
-
-    async with async_session() as db:
-        try:
-            refs = await AssetRepository(db).list_in_any_group_refs()
-            if not refs:
-                return
-
-            # Venue-schedule gate. This replaces quoting 15 *random* symbols
-            # per tick to sniff for an active market — a Yahoo round-trip
-            # every 60s that could still miss the one open venue (3 Tokyo
-            # listings in a 200-symbol portfolio → ~80% miss). The calendar
-            # answer is deterministic, holiday-aware, and free.
-            if not any_venue_open(refs):
-                return
-
-            count = await fetch_and_store_intraday(db, refs)
-            if count:
-                logger.info(f"Intraday sync: {count} bars for {len(refs)} symbols")
-        except Exception:
-            logger.exception("Intraday sync failed")
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Initialize the price data provider (Yahoo, IBKR, etc.)
@@ -210,59 +58,23 @@ async def lifespan(app: FastAPI):
     async with async_session() as db:
         await load_currency_cache(db)
 
-    # Parse cron expression (minute hour day month dow)
-    parts = app_settings.refresh_cron.split()
-    if len(parts) == 5:
-        trigger = CronTrigger(
-            minute=parts[0], hour=parts[1], day=parts[2],
-            month=parts[3], day_of_week=parts[4],
-        )
-        scheduler.add_job(scheduled_refresh, trigger, id="price_refresh")
-
-        # Supplemental daytime refreshes. The primary run above fires once at
-        # REFRESH_CRON (23:00 UTC by default), but Yahoo publishes some markets'
-        # daily bars well after their close — notably KRX (``.KS``), whose bar
-        # for a session isn't in Yahoo's daily history until the *following* day.
-        # A single nightly run therefore leaves Asian markets a full day stale
-        # (a stale σ-Move/change sitting beside a live quote). Extra 08:00 and
-        # 16:00 UTC runs catch the prior Asian session (published overnight) and
-        # any late Yahoo publish, so no market stays stale longer than ~8h.
-        scheduler.add_job(
-            scheduled_refresh,
-            CronTrigger(minute="0", hour="8,16"),
-            id="price_refresh_supplemental",
-        )
-
-        # Weekly symbol directory sync (Sundays at 02:00)
-        scheduler.add_job(
-            scheduled_symbol_sync,
-            CronTrigger(minute="0", hour="2", day_of_week="sun"),
-            id="symbol_directory_sync",
-        )
-
-        # Intraday sync every 60 seconds
-        scheduler.add_job(
-            scheduled_intraday_sync,
-            IntervalTrigger(seconds=60),
-            id="intraday_sync",
-        )
-
-        # Self-heal stragglers the scheduled refreshes missed: when a symbol's
-        # latest stored bar reconciles with neither the live price nor the
-        # quote's previous close (the state that blanks σ-Move), refresh just
-        # that symbol instead of waiting for the next full run.
-        scheduler.add_job(
-            scheduled_price_heal,
-            IntervalTrigger(minutes=10),
-            id="price_heal",
-        )
-
-        scheduler.start()
-        logger.info(f"Scheduler started with cron: {app_settings.refresh_cron}")
+    # Schedule the registered background jobs (app/background_tasks/jobs.py).
+    # A task whose trigger factory returns None is disabled — it logged why —
+    # but never takes the others down with it.
+    for task in all_tasks():
+        trigger = task.resolve_trigger()
+        if trigger is None:
+            continue
+        scheduler.add_job(task.func, trigger, id=task.id)
+    scheduler.start()
+    logger.info(
+        f"Scheduler started with {len(scheduler.get_jobs())} background jobs "
+        f"(refresh cron: {app_settings.refresh_cron})"
+    )
 
     # Kick off cache warmup in the background — API is reachable immediately,
     # cache builds in parallel so the first group hit is warm.
-    warmup_task = asyncio.create_task(_startup_warmup())
+    warmup_task = asyncio.create_task(startup_warmup())
 
     yield
 

--- a/backend/tests/services/test_warm_caches.py
+++ b/backend/tests/services/test_warm_caches.py
@@ -1,10 +1,10 @@
-"""Tests for the startup/cron cache warmup helpers in app.main."""
+"""Tests for the startup/cron cache warmup helpers in app.background_tasks."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.main import warm_all_group_caches
+from app.background_tasks import warm_all_group_caches
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
@@ -16,8 +16,8 @@ def _make_group(gid: int, name: str = "G"):
     return g
 
 
-@patch("app.main.compute_and_cache_indicators", new_callable=AsyncMock)
-@patch("app.main.async_session")
+@patch("app.background_tasks.jobs.compute_and_cache_indicators", new_callable=AsyncMock)
+@patch("app.background_tasks.jobs.async_session")
 @patch("app.repositories.group_repo.GroupRepository")
 async def test_warm_all_group_caches_iterates_every_group(
     MockGroupRepo, mock_async_session, mock_compute,
@@ -39,8 +39,8 @@ async def test_warm_all_group_caches_iterates_every_group(
     assert called_group_ids == [1, 2, 3]
 
 
-@patch("app.main.compute_and_cache_indicators", new_callable=AsyncMock)
-@patch("app.main.async_session")
+@patch("app.background_tasks.jobs.compute_and_cache_indicators", new_callable=AsyncMock)
+@patch("app.background_tasks.jobs.async_session")
 @patch("app.repositories.group_repo.GroupRepository")
 async def test_warm_all_group_caches_continues_on_per_group_failure(
     MockGroupRepo, mock_async_session, mock_compute,
@@ -61,8 +61,8 @@ async def test_warm_all_group_caches_continues_on_per_group_failure(
     assert mock_compute.await_count == 3
 
 
-@patch("app.main.compute_and_cache_indicators", new_callable=AsyncMock)
-@patch("app.main.async_session")
+@patch("app.background_tasks.jobs.compute_and_cache_indicators", new_callable=AsyncMock)
+@patch("app.background_tasks.jobs.async_session")
 @patch("app.repositories.group_repo.GroupRepository")
 async def test_warm_all_group_caches_handles_no_groups(
     MockGroupRepo, mock_async_session, mock_compute,

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,0 +1,55 @@
+"""Tests for the background-task registry and trigger resolution."""
+
+from unittest.mock import patch
+
+import pytest
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+from app.background_tasks import all_tasks
+from app.background_tasks.jobs import _refresh_trigger
+from app.background_tasks.registry import background_task
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestRegistry:
+    async def test_all_expected_jobs_registered(self):
+        ids = {t.id for t in all_tasks()}
+        assert ids == {
+            "price_refresh",
+            "price_refresh_supplemental",
+            "symbol_directory_sync",
+            "intraday_sync",
+            "price_heal",
+        }
+
+    async def test_duplicate_id_rejected(self):
+        with pytest.raises(ValueError, match="price_heal"):
+            @background_task("price_heal", trigger=IntervalTrigger(minutes=1))
+            async def _clashing():
+                pass
+
+    async def test_static_triggers_resolve_to_themselves(self):
+        by_id = {t.id: t for t in all_tasks()}
+        assert isinstance(by_id["intraday_sync"].resolve_trigger(), IntervalTrigger)
+        assert isinstance(by_id["price_refresh_supplemental"].resolve_trigger(), CronTrigger)
+
+
+class TestRefreshTrigger:
+    async def test_valid_cron_builds_trigger(self):
+        with patch("app.background_tasks.jobs.app_settings") as settings:
+            settings.refresh_cron = "0 23 * * *"
+            assert isinstance(_refresh_trigger(), CronTrigger)
+
+    async def test_malformed_cron_disables_only_this_job(self, caplog):
+        """A bad REFRESH_CRON must yield None (job skipped, loudly) — the other
+        registered tasks keep their own triggers. Previously it silently
+        disabled every background job."""
+        with patch("app.background_tasks.jobs.app_settings") as settings:
+            settings.refresh_cron = "not a cron"
+            assert _refresh_trigger() is None
+        assert any("REFRESH_CRON" in r.message for r in caplog.records)
+
+        others = [t for t in all_tasks() if t.id != "price_refresh"]
+        assert all(t.resolve_trigger() is not None for t in others)


### PR DESCRIPTION
Closes #578.

## The bug this fixes
`main.py`'s lifespan wrapped **all** `scheduler.add_job` calls in `if len(parts) == 5:` — a malformed `REFRESH_CRON` silently skipped every background job (intraday sync, price heal, symbol sync included), none of which depend on that cron. No log, no error; the app just quietly stopped syncing.

## Shape
- **`app/background_tasks/registry.py`** — `BackgroundTask` dataclass + `@background_task(id=..., trigger=...)` decorator (same registry pattern as `INDICATOR_REGISTRY`). A trigger is either a ready APScheduler trigger or a zero-arg factory; a factory returning `None` disables just that task, after logging why. The decorator is stackable — the primary + supplemental price refreshes register the same function under two ids.
- **`app/background_tasks/jobs.py`** — the five jobs moved verbatim out of `main.py`, each self-registering. `price_refresh`'s trigger is `_refresh_trigger()`: malformed `REFRESH_CRON` → warning + `None`.
- **`main.py`** — lifespan collapses to `for task in all_tasks(): scheduler.add_job(task.func, task.trigger…, id=task.id)`; the scheduler now always starts. 415 → ~230 lines.
- Adding a job no longer touches `main.py`: write it in `jobs.py` with the decorator.

## Verification
- New `tests/test_background_tasks.py`: expected job ids registered, duplicate-id rejection, static trigger resolution, and the regression case — malformed cron yields `None` for `price_refresh` only, every other task still resolves a trigger.
- `test_warm_caches.py` patch targets repointed to `app.background_tasks.jobs`.
- Full suite: **785 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)