### PR TITLE
refactor(backend): typed OHLCV response models for the batch data endpoint

### DIFF
--- a/backend/app/routers/data.py
+++ b/backend/app/routers/data.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.constants import PeriodType
 from app.database import get_db
+from app.schemas.batch_data import SymbolBatchData
 from app.services.data_service import ALLOWED_FIELDS, MAX_SYMBOLS, query_batch_data
 
 router = APIRouter(prefix="/api/data", tags=["data"])
@@ -14,6 +15,10 @@ router = APIRouter(prefix="/api/data", tags=["data"])
     "",
     summary="Batch data query for multiple symbols",
     response_description="Dict keyed by symbol with requested data fields, or per-symbol error.",
+    response_model=dict[str, SymbolBatchData],
+    # Only the requested fields appear per symbol; unset fields are dropped,
+    # not emitted as nulls.
+    response_model_exclude_none=True,
 )
 async def get_data(
     symbols: str = Query(

--- a/backend/app/schemas/batch_data.py
+++ b/backend/app/schemas/batch_data.py
@@ -1,0 +1,34 @@
+"""Response models for the batch data endpoint (``GET /api/data``)."""
+
+from pydantic import BaseModel, Field
+
+from app.schemas.price import DatedOHLCV, IndicatorResponse
+
+
+class SymbolBatchData(BaseModel):
+    """Per-symbol payload of the batch query.
+
+    Only the requested fields are set — the router serializes with
+    ``response_model_exclude_none=True``, so absent fields are dropped from
+    the JSON rather than emitted as ``null``. ``error`` replaces the data
+    fields when the symbol failed entirely.
+
+    ``quote`` and ``snapshot`` stay provider-shaped dicts for now — typing
+    them is tracked in #580.
+    """
+
+    quote: dict | None = Field(
+        default=None, description="Real-time quote: price, change, volume, market state."
+    )
+    snapshot: dict | None = Field(
+        default=None, description="Latest indicator values and derived signals."
+    )
+    prices: list[DatedOHLCV] | None = Field(
+        default=None, description="OHLCV price history for the requested period."
+    )
+    indicators: list[IndicatorResponse] | None = Field(
+        default=None, description="Full indicator time series for the requested period."
+    )
+    error: str | None = Field(
+        default=None, description="Why no data could be returned for this symbol."
+    )

--- a/backend/app/schemas/price.py
+++ b/backend/app/schemas/price.py
@@ -3,15 +3,30 @@ import datetime
 from pydantic import BaseModel, Field
 
 
-class PriceResponse(BaseModel):
-    date: datetime.date = Field(description="Trading date")
+class OHLCV(BaseModel):
+    """One bar of open/high/low/close/volume."""
+
     open: float = Field(description="Opening price")
     high: float = Field(description="Highest price of the day")
     low: float = Field(description="Lowest price of the day")
     close: float = Field(description="Closing price")
     volume: int = Field(description="Trading volume")
 
+
+class DatedOHLCV(OHLCV):
+    """An OHLCV bar bound to its trading date.
+
+    Validates from anything bar-shaped (``PriceHistory`` ORM rows,
+    ``PriceResponse`` models) via ``from_attributes``.
+    """
+
+    date: datetime.date = Field(description="Trading date")
+
     model_config = {"from_attributes": True}
+
+
+class PriceResponse(DatedOHLCV):
+    """A daily price bar as served by the price endpoints."""
 
 
 class IndicatorResponse(BaseModel):

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -1,12 +1,13 @@
 """Batch data query service — fetches quotes, snapshots, prices, and indicators for arbitrary symbols."""
 
 import logging
-from datetime import date
 
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Asset
+from app.schemas.batch_data import SymbolBatchData
+from app.schemas.price import DatedOHLCV
 from app.services import price_service
 from app.services.compute.indicators import compute_batch_indicator_snapshots
 from app.services.entity_lookups import find_asset
@@ -18,41 +19,16 @@ ALLOWED_FIELDS = frozenset({"quote", "snapshot", "prices", "indicators"})
 MAX_SYMBOLS = 50
 
 
-def _serialize_price(p) -> dict:
-    """Convert a PriceHistory ORM object or PriceResponse Pydantic model to a plain dict."""
-    if hasattr(p, "model_dump"):
-        d = p.model_dump()
-        if isinstance(d.get("date"), date):
-            d["date"] = d["date"].isoformat()
-        return d
-    return {
-        "date": p.date.isoformat() if isinstance(p.date, date) else str(p.date),
-        "open": round(float(p.open), 4),
-        "high": round(float(p.high), 4),
-        "low": round(float(p.low), 4),
-        "close": round(float(p.close), 4),
-        "volume": int(p.volume),
-    }
-
-
-def _serialize_indicator(row) -> dict:
-    """Convert an IndicatorResponse Pydantic model to a plain dict."""
-    d = row.model_dump()
-    if isinstance(d.get("date"), date):
-        d["date"] = d["date"].isoformat()
-    return d
-
-
 async def query_batch_data(
     db: AsyncSession,
     symbols: list[str],
     fields: set[str],
     period: str,
-) -> dict[str, dict]:
+) -> dict[str, SymbolBatchData]:
     """Fetch requested data fields for multiple symbols.
 
-    Returns a dict keyed by symbol. Each value is a dict with the requested
-    field data, or ``{"error": "..."}`` if the symbol failed entirely.
+    Returns :class:`SymbolBatchData` per symbol — the requested fields, or
+    ``error`` if the symbol failed entirely.
 
     Tracked assets (in DB) use cached prices; untracked symbols are fetched
     ephemerally from the configured price provider.
@@ -97,7 +73,7 @@ async def query_batch_data(
             if "prices" in fields and sym not in symbol_errors:
                 try:
                     raw = await price_service.get_prices(db, asset, sym, period)
-                    results[sym]["prices"] = [_serialize_price(p) for p in raw]
+                    results[sym]["prices"] = [DatedOHLCV.model_validate(p) for p in raw]
                 except HTTPException:
                     symbol_errors[sym] = f"No price data available for {sym}"
                 except Exception:
@@ -107,7 +83,7 @@ async def query_batch_data(
             if "indicators" in fields and sym not in symbol_errors:
                 try:
                     raw = await price_service.get_indicators(db, asset, sym, period)
-                    results[sym]["indicators"] = [_serialize_indicator(i) for i in raw]
+                    results[sym]["indicators"] = list(raw)  # already IndicatorResponse models
                 except HTTPException:
                     symbol_errors.setdefault(sym, f"No indicator data available for {sym}")
                 except Exception:
@@ -115,13 +91,13 @@ async def query_batch_data(
                     symbol_errors.setdefault(sym, f"Indicator fetch failed for {sym}")
 
     # Build final response
-    final: dict[str, dict] = {}
+    final: dict[str, SymbolBatchData] = {}
     for sym in symbols:
         if results[sym]:
-            final[sym] = results[sym]
+            final[sym] = SymbolBatchData(**results[sym])
         elif sym in symbol_errors:
-            final[sym] = {"error": symbol_errors[sym]}
+            final[sym] = SymbolBatchData(error=symbol_errors[sym])
         else:
-            final[sym] = {"error": f"No data available for {sym}"}
+            final[sym] = SymbolBatchData(error=f"No data available for {sym}")
 
     return final


### PR DESCRIPTION
Closes #579. First concrete slice of the dict-sweep tracking issue #580.

## Shape
- **`schemas/price.py`**: new `OHLCV` base (open/high/low/close/volume) and `DatedOHLCV(OHLCV)` adding `date` + `from_attributes` (validates ORM `PriceHistory` rows and `PriceResponse` models alike). `PriceResponse` now extends `DatedOHLCV`, so every price endpoint shares one bar definition.
- **`schemas/batch_data.py`**: `SymbolBatchData` — the per-symbol envelope (`quote`/`snapshot`/`prices`/`indicators`/`error`). `quote` and `snapshot` deliberately stay dicts for now; typing them is #580's quote/snapshot subsystems.
- **`data_service.py`**: `query_batch_data` returns `dict[str, SymbolBatchData]`; the hand-rolled `_serialize_price`/`_serialize_indicator` dict builders are deleted — Pydantic owns serialization.
- **`routers/data.py`**: `response_model=dict[str, SymbolBatchData]` with `response_model_exclude_none=True` (only requested fields appear, as before) — `/api/data` now has a real OpenAPI schema instead of a free-form dict.

## Behavior notes
- Wire format unchanged in shape (integration tests assert exact price-row keys and only-requested-fields; all pass unmodified).
- One value-level change: the ORM price path previously rounded OHLC to 4 decimals inside `_serialize_price`; the ephemeral path never did. Rounding is dropped — both paths now serialize the stored value as-is.

## Verification
Full backend suite: **780 passed**, ruff clean. `tests/integration/test_data.py` (the endpoint's contract tests) untouched and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)