### PR TITLE
fix(backend): hole heal drains feed-wide events in hours, not days

### DIFF
--- a/backend/app/services/price_heal.py
+++ b/backend/app/services/price_heal.py
@@ -131,21 +131,31 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
 
 # The hole scan is cheap (one DB query + calendar lookups) but each detected
 # hole costs a Yahoo range fetch, and holes either fill on the first try or
-# need Yahoo to backfill upstream — rescanning faster gains nothing.
+# need Yahoo to backfill upstream — rescanning faster gains nothing *for a
+# symbol that was attempted*. Deferred symbols were never attempted, so a
+# scan that hit the per-scan cap schedules the next one much sooner: the
+# retry cooldown below already keeps attempted-but-unfillable holes from
+# being re-hammered.
 HOLE_SCAN_INTERVAL_SECONDS = 6 * 60 * 60
+HOLE_BACKLOG_RESCAN_SECONDS = 30 * 60
 
 # A hole that survived a re-fetch is data Yahoo doesn't have (yet). Retry
 # daily — backfills typically land within a day or two — instead of every scan.
 HOLE_RETRY_COOLDOWN_SECONDS = 24 * 60 * 60
 
-# Bound per-scan fetches; wider breakage is a sync-level outage.
-MAX_HOLE_HEALS_PER_SCAN = 5
+# Bound per-scan fetches; wider breakage is a sync-level outage. Sized for a
+# feed-wide event (2026-08-05: Yahoo served NaN OHLC for one session across
+# dozens of European symbols at once) to drain in hours, not days.
+MAX_HOLE_HEALS_PER_SCAN = 10
 
 # Only scan the window that feeds the group snapshot + display periods; ancient
 # holes beyond it don't blank anything a user currently sees.
 HOLE_SCAN_WINDOW_DAYS = 120
 
 _last_hole_scan: float | None = None
+# Whether the last scan hit the per-scan cap and left symbols unattempted —
+# if so the next scan runs after the short backlog interval.
+_hole_backlog: bool = False
 # symbol → (last attempt, the exact holes attempted). A changed hole set is a
 # new problem and bypasses the cooldown.
 _hole_attempts: dict[str, tuple[float, frozenset[date]]] = {}
@@ -171,9 +181,10 @@ async def heal_interior_holes(db: AsyncSession, force: bool = False) -> dict[str
     Symbols without a resolvable venue calendar are skipped — without the
     session list a hole cannot be told apart from a holiday.
     """
-    global _last_hole_scan
+    global _last_hole_scan, _hole_backlog
     now = time.monotonic()
-    if not force and _last_hole_scan is not None and now - _last_hole_scan < HOLE_SCAN_INTERVAL_SECONDS:
+    interval = HOLE_BACKLOG_RESCAN_SECONDS if _hole_backlog else HOLE_SCAN_INTERVAL_SECONDS
+    if not force and _last_hole_scan is not None and now - _last_hole_scan < interval:
         return {}
     _last_hole_scan = now
 
@@ -213,14 +224,23 @@ async def heal_interior_holes(db: AsyncSession, force: bool = False) -> dict[str
         candidates.append((ref, holes, signature))
 
     if not candidates:
+        _hole_backlog = False
         return {}
+
+    # Newest hole first: a hole at yesterday's session blanks σ-Move *today*,
+    # while an old interior hole only dents historical charts — when the cap
+    # forces a choice, heal what the user is currently looking at.
+    candidates.sort(key=lambda c: max(c[1]), reverse=True)
 
     deferred = candidates[MAX_HOLE_HEALS_PER_SCAN:]
     candidates = candidates[:MAX_HOLE_HEALS_PER_SCAN]
+    _hole_backlog = bool(deferred)
     if deferred:
         logger.info(
-            "Hole heal: %d symbol(s) with interior holes; healing %d, deferring %d",
+            "Hole heal: %d symbol(s) with interior holes; healing %d, deferring %d "
+            "(next scan in %d min)",
             len(candidates) + len(deferred), len(candidates), len(deferred),
+            HOLE_BACKLOG_RESCAN_SECONDS // 60,
         )
 
     healed: dict[str, int] = {}

--- a/backend/tests/services/test_price_heal.py
+++ b/backend/tests/services/test_price_heal.py
@@ -193,9 +193,11 @@ from app.services.price_heal import find_interior_holes, heal_interior_holes  # 
 def _reset_hole_state():
     price_heal._hole_attempts.clear()
     price_heal._last_hole_scan = None
+    price_heal._hole_backlog = False
     yield
     price_heal._hole_attempts.clear()
     price_heal._last_hole_scan = None
+    price_heal._hole_backlog = False
 
 
 def test_find_interior_holes_strictly_inside():
@@ -212,12 +214,16 @@ def test_find_interior_holes_empty_inputs():
     assert find_interior_holes({date(2026, 8, 3)}, set()) == set()
 
 
-async def _seed_with_hole(db, symbol="AAPL"):
-    """Seed a US asset and delete one real mid-window session's bar."""
+async def _seed_with_hole(db, symbol="AAPL", frac=0.5):
+    """Seed a US asset and delete one real interior session's bar.
+
+    ``frac`` places the hole within the stored range (0 = oldest end,
+    1 = newest end); always strictly interior.
+    """
     asset = await seed_asset_with_prices(db, symbol, n_days=60)
     stored = {p.date for p in await PriceRepository(db).list_by_asset(asset.id)}
     sessions = sorted(AssetRef(symbol).venue.session_dates(min(stored), max(stored)))
-    hole = sessions[len(sessions) // 2]
+    hole = sessions[max(1, min(len(sessions) - 2, int(len(sessions) * frac)))]
     await db.execute(delete(PriceHistory).where(
         PriceHistory.asset_id == asset.id, PriceHistory.date == hole,
     ))
@@ -295,6 +301,52 @@ async def test_hole_heal_failure_does_not_abort_batch(db):
     assert healed.get("BBBB") == 1
     # The failed symbol still lands on cooldown so it isn't retried every scan.
     assert "AAAA" in price_heal._hole_attempts
+
+
+async def test_hole_heal_prioritizes_newest_holes(db):
+    """When the per-scan cap forces a choice, the symbol whose hole is most
+    recent goes first — a hole at yesterday's session blanks σ-Move *today*,
+    an old interior hole only dents historical charts."""
+    await _seed_with_hole(db, "OLDH", frac=0.2)
+    await _seed_with_hole(db, "NEWH", frac=0.8)
+    with (
+        patch.object(price_heal, "MAX_HOLE_HEALS_PER_SCAN", 1),
+        patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync,
+    ):
+        sync.return_value = 1
+        healed = await heal_interior_holes(db, force=True)
+    assert list(healed) == ["NEWH"]
+    assert price_heal._hole_backlog is True
+
+
+async def test_hole_heal_backlog_rescans_sooner(db):
+    """A capped scan leaves unattempted symbols; the next scan then runs after
+    the short backlog interval instead of the full one, and the backlog flag
+    clears once nothing is deferred (2026-08-05: a feed-wide NaN session hit
+    dozens of symbols at once — at the old fixed 6h cadence the tail waited
+    days)."""
+    await _seed_with_hole(db, "AAAA")
+    await _seed_with_hole(db, "BBBB")
+    with (
+        patch.object(price_heal, "MAX_HOLE_HEALS_PER_SCAN", 1),
+        patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync,
+    ):
+        sync.return_value = 1
+        first = await heal_interior_holes(db)
+        assert len(first) == 1
+        assert price_heal._hole_backlog is True
+
+        # Immediately after: still throttled, even in backlog mode.
+        assert await heal_interior_holes(db) == {}
+
+        # Past the backlog interval (but far inside the normal 6h one): the
+        # deferred symbol is attempted. The first symbol sits on the retry
+        # cooldown (its mocked "heal" filled nothing), so it doesn't recount.
+        price_heal._last_hole_scan -= price_heal.HOLE_BACKLOG_RESCAN_SECONDS + 1
+        second = await heal_interior_holes(db)
+        assert len(second) == 1
+        assert set(first) != set(second)
+        assert price_heal._hole_backlog is False
 
 
 async def test_hole_heal_skips_unknown_venue(db):


### PR DESCRIPTION
## The incident
Today Yahoo served NaN OHLC for the 2026-08-04 session across dozens of European symbols. The NaN-skip correctly refused to store garbage, leaving each symbol with a hole at *yesterday* — which the #559 gap guard then (correctly) answers by blanking σ-Move (`vnr=None, vnr_gap_sessions=2`, confirmed live on staging). The blanks were intermittent because the heal queue rotates and borderline symbols flicker at the 0.5% reconcile tolerance.

The machinery all behaved as designed — the problem is drain economics: the hole heal was sized for isolated holes (5 symbols/scan, one scan per 6h, candidates in asset-list order), so a feed-wide event takes **days** to clear, and a hole at yesterday (blanking today's σ-Move) gets no priority over a months-old cosmetic one.

## Changes (all in `price_heal.py`)
1. **Newest hole first** — candidates sort by most-recent hole date descending before the cap is applied.
2. **Backlog-aware cadence** — a scan that hit the cap and deferred symbols schedules the next scan after **30 min** instead of 6h. This fixes a latent conflation: the 6h interval's rationale ("re-scanning gains nothing, holes need upstream backfill") only holds for *attempted* symbols — and those are already protected by the 24h per-symbol retry cooldown. Deferred symbols were never attempted at all.
3. **Cap 5 → 10** per scan.

Worst case for ~40 poisoned symbols drops from ~2 days to ~1.5 hours, with recent holes healed in the first scans.

## Verification
- New: `test_hole_heal_prioritizes_newest_holes`, `test_hole_heal_backlog_rescans_sooner` (backlog throttle + flag-clear + cooldown interplay).
- Full suite: **787 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)