### PR TITLE
feat(stats): data-quality donut counts tickers, not bars

### DIFF
--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -25,6 +25,10 @@ class DataHealthResponse(BaseModel):
         description="Scheduled session bars in the scan window across all covered symbols "
         "(denominator for a completeness percentage)"
     )
+    covered_symbols: int = Field(
+        description="Symbols the coverage scan can check (grouped, with a resolvable venue "
+        "calendar) — denominator for the affected-symbol count"
+    )
     next_scan_in_seconds: int = Field(
         description="Approximate seconds until the next self-heal scan is eligible to run"
     )

--- a/backend/app/services/stats_service.py
+++ b/backend/app/services/stats_service.py
@@ -126,6 +126,7 @@ async def collect_data_health(db: AsyncSession) -> DataHealthResponse:
         ],
         total_missing_sessions=sum(len(holes) for _, holes in with_holes),
         expected_session_bars=sum(n for _, n, _ in coverage),
+        covered_symbols=len(coverage),
         next_scan_in_seconds=next_hole_scan_in_seconds(),
         heals_per_scan=MAX_HOLE_HEALS_PER_SCAN,
         scan_window_days=HOLE_SCAN_WINDOW_DAYS,

--- a/backend/tests/integration/test_system.py
+++ b/backend/tests/integration/test_system.py
@@ -29,6 +29,7 @@ async def test_data_health_clean(client, db):
     data = resp.json()
     assert data["hole_symbols"] == []
     assert data["total_missing_sessions"] == 0
+    assert data["covered_symbols"] == 1
     assert data["next_scan_in_seconds"] == 0  # never scanned yet
     assert data["heals_per_scan"] == price_heal.MAX_HOLE_HEALS_PER_SCAN
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -339,6 +339,8 @@ export interface DataHealth {
   total_missing_sessions: number
   /** Scheduled session bars in the scan window — completeness denominator */
   expected_session_bars: number
+  /** Symbols the coverage scan can check — affected-count denominator */
+  covered_symbols: number
   next_scan_in_seconds: number
   heals_per_scan: number
   scan_window_days: number

--- a/frontend/src/pages/stats.tsx
+++ b/frontend/src/pages/stats.tsx
@@ -91,10 +91,9 @@ function StatTile({ label, value, detail }: { label: string; value: ReactNode; d
 }
 
 /**
- * Session-bar completeness donut + self-heal status. The percentage is
- * stored-vs-scheduled session bars over the heal's scan window; symbols
- * listed under it show a blank σ-Move until the background heal repairs
- * them.
+ * Ticker-health donut + self-heal status: of the tickers the coverage scan
+ * can check, how many currently have missing session bars (and therefore a
+ * blank σ-Move). Bar-level completeness stays as a secondary line.
  */
 function DataQualityCard() {
   const { data, isPending, isError } = useDataHealth()
@@ -112,12 +111,12 @@ function DataQualityCard() {
     )
   }
 
-  const expected = data.expected_session_bars
+  const covered = data.covered_symbols
+  const affected = data.hole_symbols.length
   const missing = data.total_missing_sessions
-  const pct = expected > 0 ? ((expected - missing) / expected) * 100 : 100
-  // Never show a rounded "100%" while bars are missing.
-  const pctLabel = missing > 0 ? Math.min(pct, 99.9).toFixed(1) : "100"
-  const healthy = missing === 0
+  const expected = data.expected_session_bars
+  const pct = covered > 0 ? ((covered - affected) / covered) * 100 : 100
+  const healthy = affected === 0
 
   return (
     <Card>
@@ -129,33 +128,36 @@ function DataQualityCard() {
           className="relative h-36 w-36 shrink-0 rounded-full"
           style={{
             background: `conic-gradient(${healthy ? "#10b981" : "#f97316"} ${pct}%, ${
-              healthy ? "#10b981" : "rgba(249, 115, 22, 0.2)"
+              healthy ? "#10b981" : "rgba(249, 115, 22, 0.25)"
             } 0)`,
           }}
           role="img"
-          aria-label={`${pctLabel}% of expected session bars present`}
+          aria-label={`${covered - affected} of ${covered} tickers healthy`}
         >
           <div className="absolute inset-3 flex flex-col items-center justify-center rounded-full bg-card">
-            <span className="text-2xl font-bold tabular-nums">{pctLabel}%</span>
-            <span className="text-xs text-muted-foreground">complete</span>
+            <span className="text-2xl font-bold tabular-nums">
+              {num(covered - affected)}/{num(covered)}
+            </span>
+            <span className="text-xs text-muted-foreground">tickers healthy</span>
           </div>
         </div>
 
         <div className="space-y-2 text-sm">
           {healthy ? (
             <p>
-              All {num(expected)} expected session bars of the last {data.scan_window_days} days
-              are present. Nothing to heal.
+              All {num(covered)} tickers have their full {num(expected)} expected session bars
+              for the last {data.scan_window_days} days. Nothing to heal.
             </p>
           ) : (
             <>
               <p>
-                {num(expected - missing)} of {num(expected)} expected session bars present —{" "}
                 <span className="font-medium">
-                  {missing} missing across {data.hole_symbols.length}{" "}
-                  {data.hole_symbols.length === 1 ? "symbol" : "symbols"}
-                </span>
-                . Their σ-Move shows "—" until repaired.
+                  {affected} of {num(covered)} tickers {affected === 1 ? "is" : "are"} missing
+                  data
+                </span>{" "}
+                — {missing} session {missing === 1 ? "bar" : "bars"} in total (
+                {num(expected - missing)} of {num(expected)} expected bars present). Their
+                σ-Move shows "—" until repaired.
               </p>
               <p className="text-muted-foreground">
                 Self-heals automatically: next scan {formatEta(data.next_scan_in_seconds)}, up to{" "}


### PR DESCRIPTION
Follow-up to #588 per Jari: "11 missing across 10 symbols — I need a donut: x amount total tickers, and for today y amount is fucked."

- **Backend**: `DataHealthResponse` gains `covered_symbols` — how many tickers the coverage scan can check (grouped + resolvable venue calendar). One `len()` on the existing scan, no extra queries.
- **Frontend**: the Data Quality donut switches from bar-completeness (which rounds everything to "99.9%" and hides the story) to ticker health: filled = healthy tickers, orange slice = affected. Center reads **"68/78 tickers healthy"**. The lead line becomes "**10 of 78 tickers are missing data** — 11 session bars in total (4,899 of 4,910 expected bars present)". Bar-level completeness is demoted to the parenthetical; heal countdown + affected-symbol list unchanged.

Verification: 797 backend tests (clean-state test asserts the new field), eslint, tsc, production build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)