### PR TITLE
fix(stats): asset-mix buckets count tracked assets only

### DIFF
--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -60,8 +60,9 @@ class StatsResponse(BaseModel):
     assets_orphaned: int = Field(
         description="Ungrouped assets referenced by nothing — leftovers of removals"
     )
-    # Asset mix: one bucket per asset — ticker-shape classification
-    # (AssetRef.kind) refined by the stored Yahoo type for the stock/ETF split.
+    # Asset mix: one bucket per *tracked* asset (in ≥1 group) — sums to
+    # assets_tracked. Ticker-shape classification (AssetRef.kind) refined by
+    # the stored Yahoo type for the stock/ETF split.
     stocks: int = Field(description="Exchange-listed stocks")
     etfs: int = Field(description="ETFs")
     indexes: int = Field(description="Indexes")

--- a/backend/app/services/stats_service.py
+++ b/backend/app/services/stats_service.py
@@ -3,7 +3,7 @@
 from collections import Counter
 
 from fastapi import HTTPException
-from sqlalchemy import distinct, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.background_tasks.price_heal import (
@@ -55,12 +55,18 @@ def _mix_bucket(symbol: str, asset_type: AssetType) -> str:
 
 async def collect_stats(db: AsyncSession) -> StatsResponse:
     """Collection-size numbers: how much data the instance has accumulated."""
-    asset_rows = (await db.execute(select(Asset.symbol, Asset.type))).all()
-    mix = Counter(_mix_bucket(sym, typ) for sym, typ in asset_rows)
-
-    tracked = (
-        await db.execute(select(func.count(distinct(group_assets.c.asset_id))))
-    ).scalar_one()
+    # Mix buckets cover tracked assets only (in ≥1 group) so the breakdown
+    # bar sums to the "tracked" headline it sits under — orphans and
+    # thesis-kept rows are reported separately, not mixed in.
+    tracked_rows = (
+        await db.execute(
+            select(Asset.symbol, Asset.type)
+            .join(group_assets, group_assets.c.asset_id == Asset.id)
+            .distinct()
+        )
+    ).all()
+    mix = Counter(_mix_bucket(sym, typ) for sym, typ in tracked_rows)
+    tracked = len(tracked_rows)
 
     # Ungrouped assets split by *why* their row still exists: referenced by a
     # thesis or pseudo-ETF (the soft delete keeps these on purpose) vs
@@ -89,7 +95,7 @@ async def collect_stats(db: AsyncSession) -> StatsResponse:
     ).one()
 
     return StatsResponse(
-        assets_total=len(asset_rows),
+        assets_total=await _count(db, Asset),
         assets_tracked=tracked,
         assets_thesis_or_etf_only=ungrouped_referenced,
         assets_orphaned=ungrouped_orphaned,

--- a/backend/tests/integration/test_system.py
+++ b/backend/tests/integration/test_system.py
@@ -135,6 +135,8 @@ async def test_stats_splits_ungrouped_by_reason(client, db):
     assert data["assets_tracked"] == 1
     assert data["assets_thesis_or_etf_only"] == 1
     assert data["assets_orphaned"] == 1
+    # The mix bar sums to assets_tracked: ungrouped rows stay out of it.
+    assert data["stocks"] == 1
 
 
 async def test_orphans_listed_and_hard_deletable(client, db):


### PR DESCRIPTION
The Tracked-tickers card headline said 82 while its breakdown bar summed to 144 (staging): the mix Counter ran over every `Asset` row, orphans and thesis-kept rows included. The bar now buckets only assets in ≥1 group, so it sums to `assets_tracked`.

- `collect_stats`: mix over a distinct join against `group_assets`; `assets_tracked` derived from the same rows; `assets_total` from a plain count
- schema comment updated; test pins that ungrouped rows stay out of the mix

🤖 Generated with [Claude Code](https://claude.com/claude-code)