### PR TITLE
fix(backend): hole heal pads fetch range past Yahoo's exclusive end

### DIFF
--- a/backend/app/background_tasks/price_heal.py
+++ b/backend/app/background_tasks/price_heal.py
@@ -278,8 +278,15 @@ async def heal_interior_holes(db: AsyncSession, force: bool = False) -> dict[str
     for ref, holes, signature in candidates:
         symbol = ref
         _hole_attempts[symbol] = (now, signature)
+        # Yahoo's range end is exclusive, so a fetch ending at max(holes)
+        # would never request the newest hole — pad one day past it. The
+        # start is padded back a few days so the range always contains
+        # sessions Yahoo *does* have bars for: a range covering only the
+        # missing day comes back empty and reads as "No data found".
+        fetch_start = min(holes) - timedelta(days=5)
+        fetch_end = max(holes) + timedelta(days=1)
         try:
-            count = await sync_asset_prices_range(db, ref, min(holes), max(holes))
+            count = await sync_asset_prices_range(db, ref, fetch_start, fetch_end)
             healed[symbol] = count
             refreshed = await PriceRepository(db).list_by_asset_since(ref.id, min(holes))
             remaining = holes - {p.date for p in refreshed}

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -227,6 +227,9 @@ async def sync_asset_prices_range(
 ) -> int:
     """Fetch and upsert price data for a date range. Returns number of rows upserted.
 
+    ``end`` is exclusive (Yahoo range semantics): a bar dated ``end`` itself
+    is not fetched — callers that need it must pass the day after.
+
     A range that reaches today can include the current session's still-forming
     bar, exactly like a period fetch — this path used to upsert it raw, so any
     display/warmup backfill during market hours stored a live partial that

--- a/backend/tests/background_tasks/test_price_heal.py
+++ b/backend/tests/background_tasks/test_price_heal.py
@@ -232,7 +232,11 @@ async def _seed_with_hole(db, symbol="AAPL", frac=0.5):
 
 
 async def test_hole_heal_detects_and_refetches(db):
-    """A deleted mid-series session is detected and its range re-fetched."""
+    """A deleted mid-series session is detected and re-fetched with a padded
+    range: Yahoo's exclusive ``end`` means the newest hole must sit strictly
+    inside the requested window (staging regression 2026-08-05: fetching
+    exactly ``min(holes)..max(holes)`` never requested the newest hole, and
+    single-hole symbols asked for an empty range — "No data found")."""
     asset, hole = await _seed_with_hole(db)
     with patch.object(price_heal, "sync_asset_prices_range", new_callable=AsyncMock) as sync:
         sync.return_value = 1
@@ -241,7 +245,8 @@ async def test_hole_heal_detects_and_refetches(db):
     sync.assert_awaited_once()
     _, called_asset, start, end = sync.await_args.args
     assert called_asset.id == asset.id
-    assert start == end == hole
+    assert start == hole - timedelta(days=5)
+    assert end == hole + timedelta(days=1)
 
 
 async def test_hole_heal_clean_series_no_fetch(db):


### PR DESCRIPTION
Staging logs (2026-08-05) showed the interior-hole heal burning all 10 slots per scan while repairing nothing:

```
Hole heal for AIFS.DE: No data found for AIFS.DE
Hole heal for BATT.L: No data found for BATT.L
CDA.PA: 2 of 2 interior hole(s) persist after re-fetch ...
```

Root cause: yahooquery's `history(start=…, end=…)` treats **end as exclusive**, and the heal fetched exactly `min(holes)..max(holes)`:

- a symbol missing only 2026-08-04 requested the empty range 08-04..08-04 → `ValueError("No data found")` → 24h cooldown, nothing repaired (38 of the 50 affected staging symbols)
- multi-hole symbols re-fetched every session **except their newest hole** — the one that blanks σ-Move today

Fix: pad the fetch window to `min(holes)-5d .. max(holes)+1d`. The +1 puts the newest hole inside the exclusive range; the −5 guarantees the request covers sessions Yahoo does have bars for, so an all-holes window can't read as "No data found". The exclusive-end contract is now documented on `sync_asset_prices_range` (the other callers pass `end=date.today()`, where exclusivity is intended — today's forming bar is the reconciliation heal's job).

Test updated to pin the padded range; full backend suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)