### PR TITLE
fix(backend): anchorless sync withholds a possible live partial bar

### DIFF
--- a/backend/app/services/market_calendar/venue.py
+++ b/backend/app/services/market_calendar/venue.py
@@ -81,6 +81,18 @@ class Venue:
             return None
         return d in sessions
 
+    def local_date(self, at: datetime | None = None) -> date | None:
+        """The venue's local calendar date at ``at`` (UTC now by default).
+
+        The most recent date a daily bar can possibly be *for* — a bar dated
+        this or later cannot be a settled prior session. Used by the anchorless
+        sync guard to spot a possibly-forming trailing bar without a quote.
+        """
+        try:
+            return _as_utc(at).tz_convert(self._cal.tz).date()
+        except Exception:
+            return None
+
     # -- schedule -----------------------------------------------------------
 
     def is_open(self, at: datetime | None = None) -> bool | None:

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -139,15 +139,19 @@ async def _quote_anchors(
 ) -> dict[str, Anchor]:
     """Fetch ``{symbol: (price, previous_close, market_state, session_date)}``.
 
-    Best-effort: a quote-fetch failure degrades to storing every bar (the prior
-    behaviour) rather than aborting the sync.
+    Best-effort: a quote-fetch failure degrades to the anchorless guard in
+    ``_drop_and_persist`` (store settled bars, withhold a possible live
+    partial) rather than aborting the sync.
     """
     if not symbols:
         return {}
     try:
         quotes = await provider.batch_fetch_quotes(symbols)
     except Exception:
-        logger.warning("Quote fetch for settlement check failed; storing all bars", exc_info=True)
+        logger.warning(
+            "Quote fetch for settlement check failed; storing settled bars only",
+            exc_info=True,
+        )
         return {}
     return {
         q["symbol"]: (
@@ -157,6 +161,33 @@ async def _quote_anchors(
         for q in quotes
         if q.get("symbol")
     }
+
+
+def _drop_unanchored_trailing_bar(df: pd.DataFrame, ref: AssetRef) -> pd.DataFrame:
+    """Anchorless fallback for ``drop_unsettled_last_bar``: drop a trailing bar
+    that *could* be the current session's live partial.
+
+    Without a quote there is nothing to reconcile against, so the one bar that
+    can be partial — the trailing bar dated on the venue's current local date
+    (or later, for a stray future-dated row) — is not persisted. Every earlier
+    bar is a settled prior session and stores as usual. The withheld bar is
+    picked up by a later sync or heal once an anchor is available or the
+    session has long closed. Venue unknown → the server's own date, which can
+    only over-withhold by a few hours around midnight.
+    """
+    if df.empty:
+        return df
+    last_dt = df.index[-1]
+    last_date = last_dt.date() if hasattr(last_dt, "date") else last_dt
+    venue = getattr(ref, "venue", None)
+    today = (venue.local_date() if venue is not None else None) or date.today()
+    if last_date < today:
+        return df
+    logger.info(
+        "%s: withholding trailing %s bar (no quote anchor; may be a live partial)",
+        ref, df.index[-1],
+    )
+    return df.iloc[:-1]
 
 
 async def _drop_and_persist(
@@ -173,6 +204,13 @@ async def _drop_and_persist(
     kept bar so the settled data is authoritative.
     """
     price, previous_close, market_state, session_date = anchor
+    if price is None or previous_close is None:
+        # No anchor (quote batch failed / symbol missing from it). Failing
+        # fully open here once stored every open market's live partial as that
+        # session's close, portfolio-wide (#586). Persist the settled bars but
+        # withhold a trailing current-session bar — and never purge: without a
+        # quote, a stored later row can't be proven stale.
+        return await _upsert_prices(db, ref, _drop_unanchored_trailing_bar(df, ref))
     kept = drop_unsettled_last_bar(
         df, price, previous_close, market_state, symbol=ref, session_date=session_date,
     )

--- a/backend/tests/services/test_market_calendar.py
+++ b/backend/tests/services/test_market_calendar.py
@@ -117,6 +117,15 @@ def test_open_close_helpers():
     assert venue.next_close(at) == datetime(2024, 4, 3, 20, 0, tzinfo=timezone.utc)
 
 
+def test_local_date_is_venue_timezone_date():
+    """local_date answers in the venue's timezone, not the server's."""
+    # 2024-04-03 02:00 UTC: still Tuesday evening in New York, but already
+    # Wednesday morning in Seoul.
+    at = datetime(2024, 4, 3, 2, 0, tzinfo=timezone.utc)
+    assert AssetRef("AAPL").venue.local_date(at) == date(2024, 4, 2)
+    assert AssetRef("005930.KS").venue.local_date(at) == date(2024, 4, 3)
+
+
 def test_venues_are_cached_and_shared():
     """Symbols on the same venue share one Venue instance."""
     assert AssetRef("AAPL").venue is AssetRef("MSFT").venue

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -11,7 +11,9 @@ from app.domain import AssetRef
 from app.models import Asset, AssetType, PriceHistory
 from app.repositories.price_repo import PriceRepository
 from app.services.price_sync import (
+    _NO_ANCHOR,
     _drop_and_persist,
+    _drop_unanchored_trailing_bar,
     _upsert_prices,
     drop_unsettled_last_bar,
     sync_all_prices,
@@ -148,8 +150,12 @@ async def test_sync_range_to_today_drops_unsettled_bar(db):
     mock_prov.batch_fetch_quotes.assert_awaited_once()
 
 
-async def test_sync_range_to_today_without_quote_stores_all(db):
-    """Anchor unavailable → degrade to storing every bar (prior behavior)."""
+async def test_sync_range_to_today_without_quote_stores_settled_bars(db):
+    """Anchor unavailable → settled (historical) bars still store in full.
+
+    The anchorless guard (#586) only withholds a trailing bar dated on the
+    current session; this frame ends in Jan 2025, so nothing is withheld.
+    """
     asset = Asset(symbol="MT.AS", name="ArcelorMittal", type=AssetType.STOCK, currency="EUR")
     db.add(asset)
     await db.flush()
@@ -460,6 +466,79 @@ async def test_drop_unsettled_drops_forming_bar_on_session_date():
     )
     assert len(out) == len(df) - 1
     assert float(out.iloc[-1]["close"]) == 290.23
+
+
+# --- anchorless guard (#586): no quote → withhold a possible live partial ---
+#
+# Observed 2026-08-05 on staging: a failed quote batch during EU market hours
+# made every open-market symbol store its live forming bar as that session's
+# close. Without an anchor the trailing bar dated on the venue's current local
+# date is withheld; everything earlier is settled and stores as usual.
+
+def _df_ending(end, closes):
+    """OHLCV frame whose last bar is dated ``end`` (consecutive calendar days)."""
+    n = len(closes)
+    dates = pd.DatetimeIndex([pd.Timestamp(end) - pd.Timedelta(days=n - 1 - i)
+                              for i in range(n)])
+    return pd.DataFrame({
+        "open": closes,
+        "high": [c + 1 for c in closes],
+        "low": [c - 1 for c in closes],
+        "close": closes,
+        "volume": [1_000_000] * n,
+    }, index=dates)
+
+
+async def test_anchorless_withholds_current_session_bar():
+    """A trailing bar dated today (no venue → server date) is withheld."""
+    # A plain str ref has no venue, so the guard falls back to date.today().
+    df = _df_ending(date.today(), [100.0, 101.0, 102.0])
+    out = _drop_unanchored_trailing_bar(df, "NOVENUE")
+    assert len(out) == len(df) - 1
+    assert float(out.iloc[-1]["close"]) == 101.0
+
+
+async def test_anchorless_keeps_settled_bars():
+    """A frame ending before today is all settled — nothing withheld."""
+    # Two days back: behind "today" in every venue timezone, so the assertion
+    # can't flake around midnight for a venue-resolved ref either.
+    df = _df_ending(date.today() - pd.Timedelta(days=2), [100.0, 101.0, 102.0])
+    assert len(_drop_unanchored_trailing_bar(df, "NOVENUE")) == len(df)
+    assert len(_drop_unanchored_trailing_bar(df, AssetRef("AAPL"))) == len(df)
+
+
+async def test_anchorless_empty_frame():
+    assert _drop_unanchored_trailing_bar(pd.DataFrame(), "NOVENUE").empty
+
+
+async def test_anchorless_persist_withholds_and_never_purges(db):
+    """_drop_and_persist without an anchor drops today's bar from the upsert but
+    leaves stored rows alone — without a quote a later stored row can't be
+    proven stale, and purging on every quote outage would destroy verified data."""
+    asset = Asset(symbol="AAPL", name="Apple", type=AssetType.STOCK, currency="USD")
+    db.add(asset)
+    await db.flush()
+    # A stored row dated after everything the anchorless upsert will keep.
+    db.add(PriceHistory(asset_id=asset.id, date=date.today(),
+                        open=1, high=1, low=1, close=500.0, volume=0))
+    await db.commit()
+
+    # Bar dated the server's today is >= the venue-local (NY) date, so the
+    # withhold fires regardless of the hour the test runs at.
+    df = _df_ending(date.today(), [305.0, 290.23, 224.14])
+
+    captured = {}
+
+    async def _capture(*args):
+        captured["len"] = len(args[2])
+        return len(args[2])
+
+    with patch("app.services.price_sync._upsert_prices", side_effect=_capture):
+        await _drop_and_persist(db, AssetRef.of(asset), df, _NO_ANCHOR)
+
+    assert captured["len"] == 2  # today's bar withheld
+    latest = await PriceRepository(db).get_latest_closes([asset.id])
+    assert latest[asset.id][0] == date.today()  # stored row untouched
 
 
 # --- _drop_and_persist: purge an orphaned partial a re-sync can't upsert away ---


### PR DESCRIPTION
Closes #586.

## Problem

When the quote batch for the settlement check fails, `_quote_anchors` returns `{}` ("storing all bars") and every symbol persists with `_NO_ANCHOR` — which disables `drop_unsettled_last_bar` entirely. During the 2026-08-05 staging incident (Yahoo `curl (16)` spell overlapping the 08:00 UTC supplemental refresh, EU markets open), every open-market symbol stored its live forming bar as that session's close (e.g. `NEX.PA` stored 138.4 vs live 137.6 / prev 132.9), blanking σ-Move portfolio-wide and loading the reconcile heal for over an hour.

## Fix

Fail-open stays correct for settled history — a quote hiccup must not abort a refresh. The one bar that *can* be partial is the trailing bar dated on the venue's current session. Anchorless persists now:

- **withhold** a trailing bar dated on/after `Venue.local_date()` (new helper: today's date in the venue's timezone; falls back to the server date when the venue is unknown) — it gets stored by a later sync or heal once an anchor is available or the session has long closed;
- **store everything earlier** unchanged (settled prior sessions);
- **skip the purge** (`delete_prices_after`): without a quote a stored later row can't be proven stale, and purging on every outage would delete verified data.

## Tests

- `Venue.local_date` timezone behavior (NY vs Seoul at the same UTC instant)
- anchorless guard: withholds a today-dated trailing bar, keeps settled frames, empty frame no-op
- `_drop_and_persist` with `_NO_ANCHOR`: today's bar dropped from the upsert **and** a stored later row survives (no purge)
- existing "anchor unavailable stores historical bars" test updated to the new semantics

Full backend suite: 802 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)