### PR TITLE
fix(backend): pad symbols Yahoo omits from chart responses instead of KeyError-ing the batch

### DIFF
--- a/backend/app/services/yahoo/_history.py
+++ b/backend/app/services/yahoo/_history.py
@@ -14,6 +14,29 @@ from app.services.yahoo.rate_limit import check_crumb
 logger = logging.getLogger(__name__)
 
 
+def padded_history_frame(ticker, data, params: dict, symbols: list[str]) -> pd.DataFrame:
+    """``Ticker._historical_data_to_dataframe`` minus the KeyError (#593).
+
+    yahooquery indexes ``data[symbol]`` for every requested symbol, so a
+    symbol Yahoo omitted *entirely* from the chart response — distinct from
+    the handled case of an error payload under the symbol's key — raises
+    KeyError and takes the whole batch down with it (staging 2026-08-05: an
+    omitted 2914.T aborted a full 82-symbol intraday sync; an omitted
+    IWDA.AS 500'd holdings-indicators). Padding the omitted symbols with an
+    empty payload makes yahooquery filter them like any other no-data
+    symbol, degrading one omission to one missing symbol.
+    """
+    if isinstance(data, dict):
+        missing = [s for s in symbols if s not in data]
+        if missing:
+            logger.warning(
+                "Yahoo chart response omitted %d/%d symbol(s): %s",
+                len(missing), len(symbols), ", ".join(sorted(missing)),
+            )
+            data = {**data, **{s: {} for s in missing}}
+    return ticker._historical_data_to_dataframe(data, params, True)
+
+
 class _HistoryMixin(_YahooBase):
     async def history(
         self,
@@ -31,11 +54,16 @@ class _HistoryMixin(_YahooBase):
         """
         def _fetch() -> pd.DataFrame:
             ticker = self._ticker(symbol)
-            if start and end:
-                df = ticker.history(start=str(start), end=str(end), interval=interval)
-            else:
-                normalized = PERIOD_MAP.get(period.lower(), period)
-                df = ticker.history(period=normalized, interval=interval)
+            try:
+                if start and end:
+                    df = ticker.history(start=str(start), end=str(end), interval=interval)
+                else:
+                    normalized = PERIOD_MAP.get(period.lower(), period)
+                    df = ticker.history(period=normalized, interval=interval)
+            except KeyError:
+                # Yahoo omitted the (only) symbol from its own chart response
+                # (#593) — for a single-symbol fetch that simply is "no data".
+                raise ValueError(f"No data found for {symbol}") from None
 
             if isinstance(df, dict):
                 # Yahoo returns a per-symbol dict on error; check for crumb
@@ -76,11 +104,16 @@ class _HistoryMixin(_YahooBase):
             # ``price`` which fans out per symbol via quoteSummary.
             price_data = ticker.quotes
             normalized = PERIOD_MAP.get(period.lower(), period)
-            hist = ticker.history(period=normalized, interval="1d")
+            # The chart endpoint is called directly (what ``ticker.history``
+            # does internally for a period fetch) so the raw response can be
+            # padded before frame-building — one symbol Yahoo omitted must
+            # degrade to that symbol missing, not a KeyError that costs the
+            # whole batch (#593).
+            params = {"range": normalized.lower(), "interval": "1d"}
+            data = ticker._get_data("chart", params)
+            check_crumb(data)
+            hist = padded_history_frame(ticker, data, params, symbols)
 
-            if isinstance(hist, dict):
-                check_crumb(hist)
-                return {}
             if hist.empty:
                 return {}
 

--- a/backend/app/services/yahoo/_intraday.py
+++ b/backend/app/services/yahoo/_intraday.py
@@ -6,6 +6,7 @@ import logging
 import pandas as pd
 
 from app.services.yahoo._base import _YahooBase
+from app.services.yahoo._history import padded_history_frame
 from app.services.yahoo.currency import resolve_currency
 from app.services.yahoo.rate_limit import check_crumb
 
@@ -40,8 +41,8 @@ class _IntradayMixin(_YahooBase):
                     if isinstance(sym_data, str):
                         logger.debug("Yahoo intraday error for %s: %s", sym, sym_data)
 
-            hist = ticker._historical_data_to_dataframe(data, params, adj_timezone=True)
-            if isinstance(hist, dict) or hist.empty:
+            hist = padded_history_frame(ticker, data, params, symbols)
+            if hist.empty:
                 return {}
 
             available = (

--- a/backend/tests/services/test_intraday.py
+++ b/backend/tests/services/test_intraday.py
@@ -1,6 +1,6 @@
 """Tests for intraday price fetching and session classification."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -161,6 +161,29 @@ class TestClientIntraday:
 
     async def test_empty_symbols_returns_empty(self):
         assert await yahoo_client.intraday([]) == {}
+
+    async def test_omitted_symbol_is_padded_not_keyerror(self):
+        """#593: a symbol absent from Yahoo's chart response is padded with an
+        empty payload before frame-building, so one omission can't abort the
+        whole batch (staging 2026-08-05: KeyError '2914.T' killed a full
+        82-symbol intraday sync)."""
+        ts_list = [datetime(2026, 2, 25, 15, 0, tzinfo=timezone.utc)]
+        hist = _make_hist_df("AAPL", ts_list, [100.0])
+
+        mock_ticker = MagicMock()
+        mock_ticker.price = {"AAPL": {"currency": "USD",
+                                      "exchangeTimezoneName": "America/New_York"}}
+        # Raw chart response contains AAPL but omits 2914.T entirely.
+        mock_ticker._get_data.return_value = {"AAPL": {"timestamp": [1]}}
+        mock_ticker._historical_data_to_dataframe.return_value = hist
+
+        with patch("app.services.yahoo.client.Ticker", return_value=mock_ticker):
+            result = await yahoo_client.intraday(["AAPL", "2914.T"])
+
+        assert "AAPL" in result
+        assert "2914.T" not in result
+        padded = mock_ticker._historical_data_to_dataframe.call_args[0][0]
+        assert padded["2914.T"] == {}
 
     async def test_applies_currency_divisor(self):
         """Subunit currencies (e.g. GBp) should divide prices."""

--- a/backend/tests/services/test_yahoo_history.py
+++ b/backend/tests/services/test_yahoo_history.py
@@ -190,6 +190,23 @@ class TestPeriodMap:
         assert PERIOD_MAP["1w"] == "5d"
 
 
+def _batch_ticker(symbols, df, quotes=None, data=None):
+    """Mock Ticker for the batch path: raw chart response + built frame.
+
+    ``batch_history`` calls the chart endpoint directly and builds the frame
+    via ``padded_history_frame`` (#593), so the mock provides ``_get_data``
+    (the raw per-symbol response — key presence is what padding checks) and
+    ``_historical_data_to_dataframe`` (the resulting frame).
+    """
+    ticker = MagicMock()
+    ticker._get_data.return_value = (
+        data if data is not None else {s: {"timestamp": [1]} for s in symbols}
+    )
+    ticker._historical_data_to_dataframe.return_value = df
+    ticker.quotes = quotes or {}
+    return ticker
+
+
 class TestBatchHistory:
     @patch("app.services.yahoo.client.Ticker")
     async def test_empty_symbols_returns_empty(self, mock_ticker_cls):
@@ -197,32 +214,26 @@ class TestBatchHistory:
 
     @patch("app.services.yahoo.client.Ticker")
     async def test_empty_history_returns_empty(self, mock_ticker_cls):
-        ticker = MagicMock()
-        ticker.history.return_value = pd.DataFrame()
-        ticker.quotes = {}
-        mock_ticker_cls.return_value = ticker
+        mock_ticker_cls.return_value = _batch_ticker(["AAPL"], pd.DataFrame())
 
         assert await yahoo_client.batch_history(["AAPL"]) == {}
 
     @patch("app.services.yahoo.client.Ticker")
-    async def test_dict_history_returns_empty(self, mock_ticker_cls):
-        ticker = MagicMock()
-        ticker.history.return_value = {"error": "no data"}
-        ticker.quotes = {}
-        mock_ticker_cls.return_value = ticker
+    async def test_error_payload_returns_empty(self, mock_ticker_cls):
+        """Per-symbol error strings build into an empty frame → {}."""
+        mock_ticker_cls.return_value = _batch_ticker(
+            ["AAPL"], pd.DataFrame(), data={"AAPL": "No data found"},
+        )
 
         assert await yahoo_client.batch_history(["AAPL"]) == {}
 
     @patch("app.services.yahoo.client.Ticker")
     async def test_returns_dataframes_per_symbol(self, mock_ticker_cls):
         df = _make_multi_index_df(["AAPL", "MSFT"], n=5)
-        ticker = MagicMock()
-        ticker.history.return_value = df
-        ticker.quotes = {
-            "AAPL": {"currency": "USD"},
-            "MSFT": {"currency": "USD"},
-        }
-        mock_ticker_cls.return_value = ticker
+        mock_ticker_cls.return_value = _batch_ticker(
+            ["AAPL", "MSFT"], df,
+            quotes={"AAPL": {"currency": "USD"}, "MSFT": {"currency": "USD"}},
+        )
 
         result = await yahoo_client.batch_history(["AAPL", "MSFT"])
         assert "AAPL" in result
@@ -237,10 +248,9 @@ class TestBatchHistory:
             {"open": [100], "high": [101], "low": [99], "close": [100.5], "volume": [1_000_000]},
             index=pd.MultiIndex.from_tuples([("AAPL", dates[0])], names=["symbol", "date"]),
         )
-        ticker = MagicMock()
-        ticker.history.return_value = df
-        ticker.quotes = {"AAPL": {"currency": "USD"}}
-        mock_ticker_cls.return_value = ticker
+        mock_ticker_cls.return_value = _batch_ticker(
+            ["AAPL"], df, quotes={"AAPL": {"currency": "USD"}},
+        )
 
         result = await yahoo_client.batch_history(["AAPL"])
         assert result == {}
@@ -256,10 +266,9 @@ class TestBatchHistory:
                 [("AAPL", d) for d in dates], names=["symbol", "date"]
             ),
         )
-        ticker = MagicMock()
-        ticker.history.return_value = df
-        ticker.quotes = {"AAPL": {"currency": "USD"}}
-        mock_ticker_cls.return_value = ticker
+        mock_ticker_cls.return_value = _batch_ticker(
+            ["AAPL", "MISSING"], df, quotes={"AAPL": {"currency": "USD"}},
+        )
 
         result = await yahoo_client.batch_history(["AAPL", "MISSING"])
         assert "AAPL" in result
@@ -277,11 +286,46 @@ class TestBatchHistory:
                 [("HSBA.L", d) for d in dates], names=["symbol", "date"]
             ),
         )
-        ticker = MagicMock()
-        ticker.history.return_value = df
-        ticker.quotes = {"HSBA.L": {"currency": "GBp"}}
-        mock_ticker_cls.return_value = ticker
+        mock_ticker_cls.return_value = _batch_ticker(
+            ["HSBA.L"], df, quotes={"HSBA.L": {"currency": "GBp"}},
+        )
 
         result = await yahoo_client.batch_history(["HSBA.L"])
         assert "HSBA.L" in result
         assert result["HSBA.L"]["close"].iloc[0] == 150.50
+
+
+class TestOmittedSymbolPadding:
+    """#593: a symbol Yahoo omits from its chart response entirely used to
+    KeyError inside yahooquery's frame builder and take the whole batch down
+    (staging 2026-08-05: 2914.T aborted an 82-symbol intraday sync; IWDA.AS
+    500'd holdings-indicators)."""
+
+    @patch("app.services.yahoo.client.Ticker")
+    async def test_batch_pads_omitted_symbol(self, mock_ticker_cls):
+        """The omitted symbol is padded into the raw response as an empty
+        payload, so yahooquery filters it instead of KeyError-ing."""
+        df = _make_multi_index_df(["AAPL"], n=5)
+        ticker = _batch_ticker(
+            ["AAPL", "2914.T"], df,
+            quotes={"AAPL": {"currency": "USD"}},
+            data={"AAPL": {"timestamp": [1]}},  # 2914.T absent entirely
+        )
+        mock_ticker_cls.return_value = ticker
+
+        result = await yahoo_client.batch_history(["AAPL", "2914.T"])
+
+        assert "AAPL" in result
+        assert "2914.T" not in result
+        padded = ticker._historical_data_to_dataframe.call_args[0][0]
+        assert padded["2914.T"] == {}
+
+    @patch("app.services.yahoo.client.Ticker")
+    async def test_single_history_omitted_symbol_is_no_data(self, mock_ticker_cls):
+        """A single-symbol fetch maps the KeyError to the normal no-data error."""
+        ticker = MagicMock()
+        ticker.history.side_effect = KeyError("IWDA.AS")
+        mock_ticker_cls.return_value = ticker
+
+        with pytest.raises(ValueError, match="No data found for IWDA.AS"):
+            await yahoo_client.history("IWDA.AS")


### PR DESCRIPTION
Closes #593.

## Problem

Yahoo has two per-symbol failure shapes in a batched chart response: an error payload under the symbol's key (handled) and the symbol being **omitted from the response entirely** — which crashed inside yahooquery's `_historical_data_to_dataframe` (`data[symbol]` → `KeyError`) before any of our per-symbol guards could run, taking the whole batch down. Observed on staging 2026-08-05: `KeyError: '2914.T'` aborted a full 82-symbol intraday sync; `KeyError: 'IWDA.AS'` 500'd `GET /api/assets/IWDA.AS/holdings/indicators`.

## Fix

New `padded_history_frame(ticker, data, params, symbols)` in `_history.py`: pads any requested symbol missing from the raw chart response with an empty payload, logs a warning naming the omissions, then hands the dict to yahooquery — which filters padded symbols like any other no-data symbol. One omission degrades to one missing symbol.

- **`batch_history`** now calls the chart endpoint directly (exactly what `ticker.history()` does internally for a period fetch) so it holds the raw response to pad. Side benefit: `check_crumb` now runs on the raw per-symbol dict — the old `isinstance(hist, dict)` branch was dead code with current yahooquery (history always returns a DataFrame), so crumb detection on this path actually works now.
- **`intraday`** already held the raw response; it now routes through the same helper.
- **`history()`** (single symbol) keeps `ticker.history()` and maps the `KeyError` to the existing `ValueError("No data found for …")` — an omitted only-symbol simply is no data.

## Tests

- batch: omitted symbol is padded (asserted on the dict passed to the frame builder), the present symbol survives
- intraday: same padding assertion via the mock `_get_data` response
- single history: `KeyError` → `"No data found"` `ValueError`
- existing batch tests rewired from mocking `ticker.history` to mocking `_get_data` + `_historical_data_to_dataframe` (the dict-shaped-history test became an error-payload test, matching real yahooquery behavior)

Full backend suite: 805 passed. Live smoke test of the rewired `batch_history` against real Yahoo (AAPL + IWDA.AS) returns correct frames with currency normalization intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)