### PR TITLE
refactor(frontend): shared-primitive cleanups from the #535 review (ResizeObserver, crosshair hook, combo create)

### DIFF
--- a/frontend/src/components/chart/intraday-chart.tsx
+++ b/frontend/src/components/chart/intraday-chart.tsx
@@ -143,7 +143,7 @@ export const IntradayChart = memo(function IntradayChart({
     chartVersionRef.current += 1
     setChartVersion(chartVersionRef.current)
 
-    const detach = attachResizeAndCleanup(containerRef.current, chart)
+    const detach = attachResizeAndCleanup(containerRef.current, [chart])
 
     return () => {
       detach()

--- a/frontend/src/components/chart/sparkline.tsx
+++ b/frontend/src/components/chart/sparkline.tsx
@@ -52,7 +52,7 @@ export function SparklineChart({
 
     chart.timeScale().fitContent()
 
-    return attachResizeAndCleanup(containerRef.current, chart)
+    return attachResizeAndCleanup(containerRef.current, [chart])
   }, [batchData])
 
   if (!batchData) {

--- a/frontend/src/components/combo-create-input.tsx
+++ b/frontend/src/components/combo-create-input.tsx
@@ -11,12 +11,13 @@ export interface ComboItem {
 /**
  * A combobox that lists existing `{id,name,color}` entities (filtered by a
  * search box), shows the currently-selected ones as removable badges, and
- * offers a "create new" affordance via the `renderCreate` render-prop. Shared
- * by the tag and thesis inputs, which previously hand-rolled identical
- * click-outside / dropdown / row markup.
+ * offers a "create new" affordance via the `create` prop. Shared by the tag
+ * and thesis inputs, which previously hand-rolled identical click-outside /
+ * dropdown / row markup.
  *
  * Search is controlled by the caller (so create flows can read the typed text,
- * e.g. to seed a "New thesis" dialog name). Open state is owned internally.
+ * e.g. to seed a "New thesis" dialog name). Open state — including closing
+ * after select *and* after create — is owned internally.
  */
 export function ComboCreateInput<T extends ComboItem>({
   label,
@@ -27,7 +28,7 @@ export function ComboCreateInput<T extends ComboItem>({
   onRemove,
   options,
   onSelect,
-  renderCreate,
+  create,
 }: {
   label: string
   placeholder: string
@@ -39,8 +40,15 @@ export function ComboCreateInput<T extends ComboItem>({
   /** All candidate entities; filtered internally by search and not-already-current. */
   options: T[]
   onSelect: (item: T) => void
-  /** Create-new footer; receives the trimmed search and a fn to close the dropdown. */
-  renderCreate?: (search: string, close: () => void) => ReactNode
+  /** Create-new footer. The component renders the button and closes the
+   * dropdown itself once `onCreate` resolves (it stays open on rejection). */
+  create?: {
+    /** Button label for the trimmed search text. */
+    label: (search: string) => ReactNode
+    /** Extra content above the button (e.g. a colour picker). */
+    extras?: ReactNode
+    onCreate: (search: string) => void | Promise<unknown>
+  }
 }) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -105,7 +113,20 @@ export function ComboCreateInput<T extends ComboItem>({
                   {item.name}
                 </button>
               ))}
-              {search.trim() && !exactMatch && renderCreate?.(search.trim(), close)}
+              {search.trim() && !exactMatch && create && (
+                <div className={create.extras ? "border-t p-2 space-y-2" : "border-t p-1"}>
+                  {create.extras}
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent text-muted-foreground"
+                    onClick={() => {
+                      Promise.resolve(create.onCreate(search.trim())).then(close, () => {})
+                    }}
+                  >
+                    {create.label(search.trim())}
+                  </button>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/components/pseudo-etf/performance-overlay-chart.tsx
+++ b/frontend/src/components/pseudo-etf/performance-overlay-chart.tsx
@@ -45,7 +45,7 @@ export function PerformanceOverlayChart({
     return { total: last.value, rebased }
   }, [data, sortedSymbols, baseValue])
 
-  const { hoverRef, setHover, displayData } = useCrosshairHover<OverlayHover>(lastRebased)
+  const { hoverRef, subscribe, displayData } = useCrosshairHover<OverlayHover>(lastRebased)
 
   useEffect(() => {
     if (!ref.current || !data.length || !sortedSymbols.length) return
@@ -112,22 +112,9 @@ export function PerformanceOverlayChart({
     baseLine.setData(data.map((p) => ({ time: p.date, value: baseValue })))
     baseLineRef.current = baseLine
 
-    // Crosshair: snap to total line, update legend with per-symbol rebased values
-    let snapping = false
-    chart.subscribeCrosshairMove((param) => {
-      if (param.time) {
-        const h = hoverRef.current.get(String(param.time))
-        if (h) {
-          setHover(h)
-          if (!snapping) {
-            snapping = true
-            chart.setCrosshairPosition(h.total, param.time, totalSeries)
-            snapping = false
-          }
-        }
-      } else {
-        setHover(null)
-      }
+    // Crosshair: legend updates via the hook; snap the crosshair to the total line
+    subscribe(chart, (h, time) => {
+      chart.setCrosshairPosition(h.total, time, totalSeries)
     })
 
     chart.timeScale().fitContent()
@@ -139,7 +126,7 @@ export function PerformanceOverlayChart({
       totalSeriesRef.current = null
       baseLineRef.current = null
     }
-  }, [data, baseValue, sortedSymbols, symbolColorMap, startLifecycle, theme.dark, hoverRef, setHover])
+  }, [data, baseValue, sortedSymbols, symbolColorMap, startLifecycle, theme.dark, hoverRef, subscribe])
 
   // Apply baseLine + totalLine theme colors on theme change
   useEffect(() => {

--- a/frontend/src/components/tags/tag-input.tsx
+++ b/frontend/src/components/tags/tag-input.tsx
@@ -20,21 +20,6 @@ export function TagInput({
   const attachTag = useAttachTag()
   const detachTag = useDetachTag()
 
-  const handleCreate = (close: () => void) => {
-    const name = search.trim().toLowerCase()
-    if (!name) return
-    createTag.mutate(
-      { name, color: newColor },
-      {
-        onSuccess: (tag) => {
-          attachTag.mutate({ symbol, tagId: tag.id })
-          setSearch("")
-          close()
-        },
-      },
-    )
-  }
-
   return (
     <ComboCreateInput<TagBrief>
       label="Tags"
@@ -48,19 +33,20 @@ export function TagInput({
         attachTag.mutate({ symbol, tagId: t.id })
         setSearch("")
       }}
-      renderCreate={(s, close) => (
-        <div className="border-t p-2 space-y-2">
-          <ColorSwatchPicker value={newColor} onChange={setNewColor} size="sm" />
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent text-muted-foreground"
-            onClick={() => handleCreate(close)}
-          >
+      create={{
+        extras: <ColorSwatchPicker value={newColor} onChange={setNewColor} size="sm" />,
+        label: (s) => (
+          <>
             <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: newColor }} />
             Create &ldquo;{s}&rdquo;
-          </button>
-        </div>
-      )}
+          </>
+        ),
+        onCreate: (s) =>
+          createTag.mutateAsync({ name: s.toLowerCase(), color: newColor }).then((tag) => {
+            attachTag.mutate({ symbol, tagId: tag.id })
+            setSearch("")
+          }),
+      }}
     />
   )
 }

--- a/frontend/src/components/thesis/thesis-input.tsx
+++ b/frontend/src/components/thesis/thesis-input.tsx
@@ -29,20 +29,10 @@ export function ThesisInput({ assetId }: { assetId: number }) {
           addToThesis.mutate({ thesisId: t.id, assetId })
           setSearch("")
         }}
-        renderCreate={(s, close) => (
-          <div className="border-t p-1">
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent text-muted-foreground"
-              onClick={() => {
-                close()
-                setDialogOpen(true)
-              }}
-            >
-              + New thesis &ldquo;{s}&rdquo;&hellip;
-            </button>
-          </div>
-        )}
+        create={{
+          label: (s) => <>+ New thesis &ldquo;{s}&rdquo;&hellip;</>,
+          onCreate: () => setDialogOpen(true),
+        }}
       />
       <NewThesisDialog
         open={dialogOpen}

--- a/frontend/src/hooks/use-chart-lifecycle.ts
+++ b/frontend/src/hooks/use-chart-lifecycle.ts
@@ -3,25 +3,32 @@ import type { IChartApi } from "lightweight-charts"
 import { useChartTheme, chartThemeOptions, type ChartTheme } from "@/lib/chart-utils"
 
 /**
- * Observe `container` and push its width to `chart` on resize, refitting the
- * time scale; returns a cleanup that disconnects the observer and removes the
- * chart. The option-agnostic primitive used by the bespoke sparkline / intraday
- * charts, which opt out of the full themed lifecycle below.
+ * Observe `container` and push its width to every chart on resize (refitting
+ * the time scale unless `refit: false`); returns a cleanup that disconnects
+ * the observer and removes the charts. The option-agnostic primitive used by
+ * the bespoke sparkline / intraday charts, which opt out of the full themed
+ * lifecycle below, and by `startLifecycle` itself — the single ResizeObserver
+ * implementation both lifecycles share.
  */
 export function attachResizeAndCleanup(
   container: HTMLElement,
-  chart: IChartApi,
+  charts: IChartApi[],
+  { refit = true }: { refit?: boolean } = {},
 ): () => void {
   const resizeObserver = new ResizeObserver((entries) => {
     for (const entry of entries) {
-      chart.applyOptions({ width: entry.contentRect.width })
-      chart.timeScale().fitContent()
+      for (const chart of charts) {
+        chart.applyOptions({ width: entry.contentRect.width })
+        if (refit) chart.timeScale().fitContent()
+      }
     }
   })
   resizeObserver.observe(container)
   return () => {
     resizeObserver.disconnect()
-    chart.remove()
+    for (const chart of charts) {
+      chart.remove()
+    }
   }
 }
 
@@ -57,21 +64,10 @@ export function useChartLifecycle(
     const container = containerRef.current
     if (!container) return () => {}
 
-    const resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const w = entry.contentRect.width
-        for (const chart of charts) {
-          chart.applyOptions({ width: w })
-        }
-      }
-    })
-    resizeObserver.observe(container)
+    const detach = attachResizeAndCleanup(container, charts, { refit: false })
 
     return () => {
-      resizeObserver.disconnect()
-      for (const chart of charts) {
-        chart.remove()
-      }
+      detach()
       for (const ref of chartRefsRef.current) {
         ref.current = null
       }

--- a/frontend/src/hooks/use-crosshair-hover.ts
+++ b/frontend/src/hooks/use-crosshair-hover.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, type MutableRefObject } from "react"
-import type { IChartApi } from "lightweight-charts"
+import type { IChartApi, Time } from "lightweight-charts"
 
 /**
  * Crosshair-driven legend state for the pseudo-ETF breakdown charts. The chart
@@ -7,28 +7,40 @@ import type { IChartApi } from "lightweight-charts"
  * crosshair move the matching entry becomes the live hover value, falling back
  * to `latest` (the most recent point) when the cursor leaves the chart.
  *
- * Simple charts call `subscribe(chart)`; charts that also need to snap the
- * crosshair use `setHover` + `hoverRef` from their own handler instead.
+ * `subscribe(chart)` owns the whole crosshair subscription. Charts that also
+ * react to the resolved hover (e.g. snapping the crosshair onto a series) pass
+ * `onHover`; it runs inside the handler behind a re-entrancy guard, so a
+ * snap-triggered crosshair event can't recurse.
  */
 export function useCrosshairHover<H>(latest: H | null): {
   hoverRef: MutableRefObject<Map<string, H>>
-  setHover: (h: H | null) => void
-  subscribe: (chart: IChartApi) => void
+  subscribe: (chart: IChartApi, onHover?: (h: H, time: Time) => void) => void
   displayData: H | null
 } {
   const [hover, setHover] = useState<H | null>(null)
   const hoverRef = useRef(new Map<string, H>())
 
-  const subscribe = useCallback((chart: IChartApi) => {
-    chart.subscribeCrosshairMove((param) => {
-      if (param.time) {
-        const h = hoverRef.current.get(String(param.time))
-        if (h !== undefined) setHover(h)
-      } else {
-        setHover(null)
-      }
-    })
-  }, [])
+  const subscribe = useCallback(
+    (chart: IChartApi, onHover?: (h: H, time: Time) => void) => {
+      let reentrant = false
+      chart.subscribeCrosshairMove((param) => {
+        if (param.time) {
+          const h = hoverRef.current.get(String(param.time))
+          if (h !== undefined) {
+            setHover(h)
+            if (onHover && !reentrant) {
+              reentrant = true
+              onHover(h, param.time)
+              reentrant = false
+            }
+          }
+        } else {
+          setHover(null)
+        }
+      })
+    },
+    [],
+  )
 
-  return { hoverRef, setHover, subscribe, displayData: hover ?? latest }
+  return { hoverRef, subscribe, displayData: hover ?? latest }
 }


### PR DESCRIPTION
Closes #537, closes #538, closes #539 — the three tech-debt follow-ups filed from the #535 review, one commit each.

## #537 — one ResizeObserver implementation

`attachResizeAndCleanup` generalizes to `charts: IChartApi[]` with an optional `refit` flag (default `true`, matching the bespoke sparkline/intraday callers, which refit on resize). `startLifecycle` delegates to it with `refit: false` — preserving its existing no-refit behavior — and appends its ref-nulling to the returned cleanup. One observe → push-width → disconnect+remove implementation, two thin callers.

## #538 — `useCrosshairHover` owns the subscription for both callers

`subscribe(chart, onHover?)` now covers the snap case: `performance-overlay-chart` passes a snap callback (`chart.setCrosshairPosition(...)`) instead of re-implementing `subscribeCrosshairMove` + `hoverRef.get(String(time))` + `setHover` by hand. The `snapping` re-entrancy guard moves into the hook. `setHover` leaves the public surface; `hoverRef` stays — it's the data channel both charts populate in their create-effects, not a leak.

## #539 — `ComboCreateInput` owns close-on-create

The `renderCreate` render-prop leaked the internal `close()` and left close discipline to each caller. Replaced by a `create` prop:

```ts
create?: {
  label: (search: string) => ReactNode   // button label
  extras?: ReactNode                     // e.g. tag-input's colour picker
  onCreate: (search: string) => void | Promise<unknown>
}
```

The component renders the create button (whose markup/classes the two callers had duplicated verbatim) and closes the dropdown itself once `onCreate` resolves — staying open on rejection, matching the old close-on-success behavior. `tag-input` keeps async close-on-success via `mutateAsync`; `thesis-input` closes immediately before opening its dialog. Callers can no longer forget to close.

## Validation

`pnpm lint` and `pnpm build` (tsc + Vite) both clean in the frontend container. Behavior-preserving refactors — no visual changes intended (the create-footer wrapper classes are reproduced conditionally: `p-2 space-y-2` with extras, `p-1` without).

🤖 Generated with [Claude Code](https://claude.com/claude-code)