### PR TITLE
refactor(backend): Phase + Session StrEnums in domain

### DIFF
--- a/backend/app/domain/__init__.py
+++ b/backend/app/domain/__init__.py
@@ -5,5 +5,6 @@ on this layer.
 
 from app.domain.assetref import AssetRef
 from app.domain.instrument import AssetKind, Instrument
+from app.domain.phases import Phase, Session
 
-__all__ = ["AssetKind", "AssetRef", "Instrument"]
+__all__ = ["AssetKind", "AssetRef", "Instrument", "Phase", "Session"]

--- a/backend/app/domain/market_state.py
+++ b/backend/app/domain/market_state.py
@@ -16,11 +16,13 @@ backstop when the feed is absent.
 
 from dataclasses import dataclass
 
+from app.domain.phases import Phase
+
 
 @dataclass(frozen=True)
 class MarketStateInfo:
     # Scheduled-phase equivalent — the join key to Venue.phase().
-    phase: str  # "premarket" | "open" | "aftermarket" | "closed"
+    phase: Phase
     # Quotes are worth polling in this state. PREPRE ("overnight, pre-market
     # hasn't started") and POSTPOST ("after-hours has ended") are NOT active:
     # nothing trades in either, and for European venues PREPRE lasts the whole
@@ -33,18 +35,18 @@ class MarketStateInfo:
 
 
 MARKET_STATES: dict[str, MarketStateInfo] = {
-    "PREPRE": MarketStateInfo(phase="closed", active=False, session_forming=False),
-    "PRE": MarketStateInfo(phase="premarket", active=True, session_forming=False),
-    "REGULAR": MarketStateInfo(phase="open", active=True, session_forming=True),
-    "POST": MarketStateInfo(phase="aftermarket", active=True, session_forming=False),
-    "POSTPOST": MarketStateInfo(phase="closed", active=False, session_forming=False),
-    "CLOSED": MarketStateInfo(phase="closed", active=False, session_forming=False),
+    "PREPRE": MarketStateInfo(phase=Phase.CLOSED, active=False, session_forming=False),
+    "PRE": MarketStateInfo(phase=Phase.PREMARKET, active=True, session_forming=False),
+    "REGULAR": MarketStateInfo(phase=Phase.OPEN, active=True, session_forming=True),
+    "POST": MarketStateInfo(phase=Phase.AFTERMARKET, active=True, session_forming=False),
+    "POSTPOST": MarketStateInfo(phase=Phase.CLOSED, active=False, session_forming=False),
+    "CLOSED": MarketStateInfo(phase=Phase.CLOSED, active=False, session_forming=False),
 }
 
 # Unknown/missing states get the most conservative reading: nothing moving,
 # nothing forming. Callers that want "unknown ≠ closed" semantics should test
 # for None themselves before consulting traits.
-_UNKNOWN = MarketStateInfo(phase="closed", active=False, session_forming=False)
+_UNKNOWN = MarketStateInfo(phase=Phase.CLOSED, active=False, session_forming=False)
 
 
 def state_info(state: str | None) -> MarketStateInfo:

--- a/backend/app/domain/phases.py
+++ b/backend/app/domain/phases.py
@@ -1,0 +1,41 @@
+"""App-owned trading-time vocabularies: :class:`Phase` and :class:`Session`.
+
+Two closed-world enums this codebase owns (unlike Yahoo's open-world
+``market_state`` codes, which stay raw strings interpreted by the
+``market_state`` trait table):
+
+- ``Phase`` — what a venue is scheduled to be doing at an instant. Spoken
+  by ``Venue.phase()`` and ``MarketStateInfo.phase`` (the join key between
+  the live feed and the schedule).
+- ``Session`` — the 3-value bucket an intraday bar is stored/served under
+  (``IntradayPrice.session``, the SSE ``intraday`` event, the frontend's
+  session-colored chart segments).
+
+Both are ``StrEnum``: members compare equal to their raw strings, so DB
+values, JSON payloads, and string-based tests are unaffected.
+"""
+
+from enum import StrEnum
+
+
+class Phase(StrEnum):
+    PREMARKET = "premarket"
+    OPEN = "open"
+    AFTERMARKET = "aftermarket"
+    CLOSED = "closed"
+
+
+class Session(StrEnum):
+    PRE = "pre"
+    REGULAR = "regular"
+    POST = "post"
+
+
+# CLOSED deliberately has no session: bars printed while a venue is closed
+# (auction/late prints) are filed to the nearer session boundary by
+# ``_classify_session`` rather than mapped mechanically.
+PHASE_TO_SESSION: dict[Phase, Session] = {
+    Phase.PREMARKET: Session.PRE,
+    Phase.OPEN: Session.REGULAR,
+    Phase.AFTERMARKET: Session.POST,
+}

--- a/backend/app/schemas/intraday.py
+++ b/backend/app/schemas/intraday.py
@@ -5,13 +5,9 @@ egress. The payload is ``{symbol: [IntradayBar, ...]}``; the frontend mirror
 is ``IntradayPoint`` in ``frontend/src/lib/types.ts``.
 """
 
-from typing import Literal
-
 from pydantic import BaseModel, Field
 
-# The 3-value session vocabulary stored on ``IntradayPrice.session`` and
-# consumed by the live day view's session-colored chart segments.
-Session = Literal["pre", "regular", "post"]
+from app.domain.phases import Session
 
 
 class IntradayBar(BaseModel):

--- a/backend/app/services/intraday.py
+++ b/backend/app/services/intraday.py
@@ -10,16 +10,14 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain import AssetRef
+from app.domain.phases import PHASE_TO_SESSION, Phase, Session
 from app.models.intraday import IntradayPrice
-from app.schemas.intraday import IntradayBar, Session
+from app.schemas.intraday import IntradayBar
 from app.services.yahoo import yahoo_client
 
 logger = logging.getLogger(__name__)
 
 ET = ZoneInfo("America/New_York")
-
-# Venue phase → the 3-value session vocabulary the intraday chart stores/reads.
-_PHASE_TO_SESSION: dict[str, Session] = {"premarket": "pre", "open": "regular", "aftermarket": "post"}
 
 
 def _classify_session(ts: datetime, ref: AssetRef, tz_name: str | None = None) -> Session:
@@ -42,14 +40,14 @@ def _classify_session(ts: datetime, ref: AssetRef, tz_name: str | None = None) -
     venue = ref.venue
     if venue is not None:
         phase = venue.phase(ts)
-        if phase in _PHASE_TO_SESSION:
-            return _PHASE_TO_SESSION[phase]
-        if phase == "closed":
+        if phase in PHASE_TO_SESSION:
+            return PHASE_TO_SESSION[phase]
+        if phase == Phase.CLOSED:
             prev_close = venue.previous_close(ts)
             next_open = venue.next_open(ts)
             if prev_close is not None and next_open is not None:
-                return "post" if ts - prev_close <= next_open - ts else "pre"
-            return "post"
+                return Session.POST if ts - prev_close <= next_open - ts else Session.PRE
+            return Session.POST
 
     if tz_name:
         try:
@@ -58,17 +56,17 @@ def _classify_session(ts: datetime, ref: AssetRef, tz_name: str | None = None) -
             local = None
         if local is not None:
             if local < time(9, 0):
-                return "pre"
+                return Session.PRE
             if local >= time(17, 30):
-                return "post"
-            return "regular"
+                return Session.POST
+            return Session.REGULAR
 
     local = ts.astimezone(ET).time()
     if local < time(9, 30):
-        return "pre"
+        return Session.PRE
     if local >= time(16, 0):
-        return "post"
-    return "regular"
+        return Session.POST
+    return Session.REGULAR
 
 
 async def fetch_and_store_intraday(

--- a/backend/app/services/market_calendar/schedule.py
+++ b/backend/app/services/market_calendar/schedule.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from app.domain.instrument import classify
+from app.domain.phases import Phase
 from app.services.market_calendar.venue import _as_utc, _venue_for
 
 
@@ -40,15 +41,20 @@ def any_venue_open(symbols, at: datetime | None = None) -> bool:
         if venue is None:
             return True  # calendar failed to build — same fail-open rule
         phase = venue.phase(at)
-        if phase is None or phase != "closed":
+        if phase is None or phase != Phase.CLOSED:
             return True
     return False
 
 
-_PHASE_RANK = {"closed": 0, "premarket": 1, "aftermarket": 1, "open": 2}
+_PHASE_RANK: dict[Phase, int] = {
+    Phase.CLOSED: 0,
+    Phase.PREMARKET: 1,
+    Phase.AFTERMARKET: 1,
+    Phase.OPEN: 2,
+}
 
 
-def schedule_poll_hint(symbols, at: datetime | None = None) -> tuple[str, float | None]:
+def schedule_poll_hint(symbols, at: datetime | None = None) -> tuple[Phase, float | None]:
     """The most-active scheduled phase across the symbols' venues, plus the
     seconds until the earliest upcoming regular open.
 
@@ -60,9 +66,9 @@ def schedule_poll_hint(symbols, at: datetime | None = None) -> tuple[str, float 
     Unlike :func:`any_venue_open`, unresolvable symbols contribute nothing
     here rather than failing open: a wrong "open" would pin the fast poll
     forever, whereas contributing nothing merely falls back to the live-state
-    cadence. Returns ``("closed", None)`` when no venue resolves at all.
+    cadence. Returns ``(Phase.CLOSED, None)`` when no venue resolves at all.
     """
-    best = "closed"
+    best = Phase.CLOSED
     next_open_secs: float | None = None
     ts = _as_utc(at).to_pydatetime()
     seen: set[str] = set()

--- a/backend/app/services/market_calendar/venue.py
+++ b/backend/app/services/market_calendar/venue.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pandas as pd
 
+from app.domain.phases import Phase
 from app.services.market_calendar.listings import EXTENDED_HOURS, ExtendedHours
 
 logger = logging.getLogger(__name__)
@@ -117,19 +118,19 @@ class Venue:
         except Exception:
             return None
 
-    def phase(self, at: datetime | None = None) -> str | None:
-        """Trading phase at ``at``: "premarket" | "open" | "aftermarket" | "closed".
+    def phase(self, at: datetime | None = None) -> Phase | None:
+        """Trading :class:`Phase` at ``at``.
 
         Regular hours come from the calendar; the extended windows are the
         venue's ``ExtendedHours`` offsets around them. Venues without extended
-        hours only ever report "open"/"closed". This is the *scheduled* phase —
+        hours only ever report OPEN/CLOSED. This is the *scheduled* phase —
         the live authority for what a venue is actually doing right now is the
         quote feed's own market_state; use this for prediction and fallback.
         """
         ts = _as_utc(at)
         try:
             if self._cal.is_open_at_time(ts):
-                return "open"
+                return Phase.OPEN
             # previous_close is strictly exclusive: at the exact close instant
             # it returns the *prior* session's close, which would misfile the
             # first moment of aftermarket as closed. Nudging the query point
@@ -141,10 +142,10 @@ class Venue:
             return None
         if self.extended_hours is not None:
             if ts < prev_close + self.extended_hours.post_offset:
-                return "aftermarket"
+                return Phase.AFTERMARKET
             if ts >= nxt_open - self.extended_hours.pre_offset:
-                return "premarket"
-        return "closed"
+                return Phase.PREMARKET
+        return Phase.CLOSED
 
 
 # One Venue per calendar name, shared by every Symbol that resolves to it.

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -4,12 +4,14 @@ import asyncio
 import json
 import logging
 import time as _time
+from collections.abc import Sequence
 
 from pydantic import TypeAdapter
 
 from app.database import async_session
 from app.domain import AssetRef
 from app.domain.market_state import any_active, state_info
+from app.domain.phases import Phase
 from app.repositories.asset_repo import AssetRepository
 from app.schemas.intraday import IntradayBar
 from app.services.intraday import get_intraday_bars
@@ -32,7 +34,7 @@ def _reset_asset_list_cache() -> None:
     _asset_list_cache = (0.0, [])
 
 
-def _poll_interval(market_states: set[str], symbols: list[str], at=None) -> int:
+def _poll_interval(market_states: set[str], symbols: Sequence[str], at=None) -> int:
     """Seconds until the next quote poll.
 
     The live market states pick the cadence whenever they exist — they know
@@ -46,7 +48,7 @@ def _poll_interval(market_states: set[str], symbols: list[str], at=None) -> int:
     - an all-closed stream sleeps until the next opening bell instead of up
       to 5 minutes past it (one cheap poll at the bell discovers the flip).
     """
-    if any(state_info(s).phase == "open" for s in market_states):
+    if any(state_info(s).phase == Phase.OPEN for s in market_states):
         live = 15
     elif any_active(market_states):
         live = 60
@@ -58,7 +60,7 @@ def _poll_interval(market_states: set[str], symbols: list[str], at=None) -> int:
     if market_states:
         interval = live
     else:
-        scheduled = 15 if phase == "open" else 60 if phase in ("premarket", "aftermarket") else 300
+        scheduled = 15 if phase == Phase.OPEN else 60 if phase in (Phase.PREMARKET, Phase.AFTERMARKET) else 300
         interval = min(live, scheduled)
     if next_open_secs is not None:
         # Wake just after the earliest bell (floor 15s so a bell moments away


### PR DESCRIPTION
Stacked on #596 (it builds on `schemas/intraday.py`'s `Session`); will retarget to `dev` automatically when that merges.

Follow-up to Jari's observation on #596: the trading-time vocabulary was raw-stringed and duplicated —

- `premarket/open/aftermarket/closed` appeared as raw strings in `Venue.phase()`, `MarketStateInfo.phase`, `_PHASE_RANK` (`schedule.py`), `_poll_interval` (`quote_service.py`), and as the *keys* of `_PHASE_TO_SESSION`, with no canonical type anywhere.
- `pre/regular/post` was a `Literal` in `schemas/intraday.py` plus raw strings in `_classify_session`, with the phase→session mapping living under its own name in `services/intraday.py`.

## Change

New `app/domain/phases.py` (per the placement rule: pure vocabulary tables live in `domain/`):

- `Phase(StrEnum)` and `Session(StrEnum)` — the two closed-world vocabularies the app owns.
- `PHASE_TO_SESSION: dict[Phase, Session]` — the one canonical mapping (CLOSED intentionally unmapped; closed-phase prints are filed to the nearer boundary by `_classify_session`, as before).

All five phase sites and all session sites now speak the enums; `schemas/intraday.py` imports `Session` from domain. **Yahoo's `market_state` codes stay raw strings by design** — an open-world provider vocabulary whose canonical interpreter is the `market_state` trait table, where an unknown code must degrade conservatively (`_UNKNOWN`) rather than fail validation.

Drive-by: `_poll_interval` takes `Sequence[str]` (pre-existing pyright error — callers pass `list[AssetRef]`, invariant `list[str]` rejected it).

## Compatibility

`StrEnum` members compare equal to their raw strings and serialize as them, so DB values, SSE/JSON payloads, and every string-based test are byte-identical. Full backend suite: 806 passed, zero test edits — including the exact-JSON assert on the SSE `intraday` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)