### PR TITLE
refactor(backend): typed quote payloads (#580)

### DIFF
--- a/backend/app/background_tasks/price_heal.py
+++ b/backend/app/background_tasks/price_heal.py
@@ -73,16 +73,14 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
     # Yahoo again for the same (price, previous_close, market_state) data.
     stale: list[tuple[str, Anchor]] = []
     for q in quotes:
-        sym = q.get("symbol")
-        if not sym:
-            continue
+        sym = q.symbol
         ref = by_symbol.get(sym)
         if ref is None:
             continue
         stored = latest.get(ref.id)
         if stored is None:  # no bars yet — initial fill is the sync's job
             continue
-        price, previous_close = q.get("price"), q.get("previous_close")
+        price, previous_close = q.price, q.previous_close
         if price is None and previous_close is None:  # dead quote, nothing to anchor on
             continue
         bar_date, bar_close = stored
@@ -92,7 +90,7 @@ async def heal_unreconciled_prices(db: AsyncSession) -> dict[str, int]:
             "%s: stored %s close %s reconciles with neither price %s nor previous_close %s",
             sym, bar_date, bar_close, price, previous_close,
         )
-        anchor: Anchor = (price, previous_close, q.get("market_state"), _as_date(q.get("session_date")))
+        anchor: Anchor = (price, previous_close, q.market_state, _as_date(q.session_date))
         stale.append((sym, anchor))
 
     if not stale:

--- a/backend/app/schemas/batch_data.py
+++ b/backend/app/schemas/batch_data.py
@@ -3,6 +3,7 @@
 from pydantic import BaseModel, Field
 
 from app.schemas.price import DatedOHLCV, IndicatorResponse
+from app.schemas.quote import Quote
 
 
 class SymbolBatchData(BaseModel):
@@ -13,11 +14,11 @@ class SymbolBatchData(BaseModel):
     the JSON rather than emitted as ``null``. ``error`` replaces the data
     fields when the symbol failed entirely.
 
-    ``quote`` and ``snapshot`` stay provider-shaped dicts for now — typing
-    them is tracked in #580.
+    ``snapshot`` stays a provider-shaped dict for now — typing it is
+    tracked in #580.
     """
 
-    quote: dict | None = Field(
+    quote: Quote | None = Field(
         default=None, description="Real-time quote: price, change, volume, market state."
     )
     snapshot: dict | None = Field(

--- a/backend/app/schemas/quote.py
+++ b/backend/app/schemas/quote.py
@@ -11,3 +11,35 @@ class QuoteResponse(BaseModel):
     avg_volume: int | None = Field(default=None, description="10-day average daily volume")
     currency: str = Field(default="USD", description="ISO 4217 currency code")
     market_state: str | None = Field(default=None, description="Market state: REGULAR, PRE, POST, PREPRE, POSTPOST, or CLOSED")
+
+
+class Quote(QuoteResponse):
+    """The full provider quote as parsed from Yahoo (``parse_quote_row``).
+
+    :class:`QuoteResponse` plus the internal reconciliation field — this is
+    what circulates through the app (price-sync anchors, price heal, the SSE
+    ``quotes`` event, ``SymbolBatchData.quote``). The REST ``GET /api/quotes``
+    boundary re-validates into plain ``QuoteResponse``, dropping
+    ``session_date``.
+
+    ``market_state`` stays a raw string on purpose: it's Yahoo's open-world
+    vocabulary, canonically interpreted by the ``app.domain.market_state``
+    trait table (unknown codes degrade conservatively there).
+    """
+
+    session_date: str | None = Field(
+        default=None,
+        description="Exchange-local ISO date of the quote's live session; "
+        "internal aid for price-sync's settled-bar reconciliation.",
+    )
+
+    @classmethod
+    def placeholder(cls, symbol: str) -> "Quote":
+        """Symbol-only placeholder for a degraded fetch (breaker open, Yahoo
+        returned garbage). Consumers can iterate it without crashing."""
+        return cls(symbol=symbol)
+
+    @property
+    def is_placeholder(self) -> bool:
+        """True when the quote carries no data beyond its symbol."""
+        return self == Quote(symbol=self.symbol)

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -41,9 +41,8 @@ async def query_batch_data(
         try:
             quotes = await get_price_provider().batch_fetch_quotes(symbols)
             for q in quotes:
-                sym = q.get("symbol")
-                if sym and sym in results:
-                    results[sym]["quote"] = q
+                if q.symbol in results:
+                    results[q.symbol]["quote"] = q
         except Exception:
             logger.exception("Batch quote fetch failed")
 

--- a/backend/app/services/price_providers/base.py
+++ b/backend/app/services/price_providers/base.py
@@ -5,6 +5,8 @@ from datetime import date
 
 import pandas as pd
 
+from app.schemas.quote import Quote
+
 
 class PriceProvider(ABC):
     """Provider interface for OHLCV price data, quotes, and currency info.
@@ -39,11 +41,11 @@ class PriceProvider(ABC):
         """
 
     @abstractmethod
-    async def batch_fetch_quotes(self, symbols: list[str]) -> list[dict]:
+    async def batch_fetch_quotes(self, symbols: list[str]) -> list[Quote]:
         """Fetch current market quotes for multiple symbols.
 
-        Returns list of dicts with keys: symbol, price, previous_close,
-        change, change_percent, volume, avg_volume, currency, market_state.
+        Returns one :class:`~app.schemas.quote.Quote` per symbol; degraded
+        symbols come back as ``Quote.placeholder`` rather than being omitted.
         """
 
     @abstractmethod

--- a/backend/app/services/price_providers/yahoo.py
+++ b/backend/app/services/price_providers/yahoo.py
@@ -11,6 +11,7 @@ from datetime import date
 
 import pandas as pd
 
+from app.schemas.quote import Quote
 from app.services.price_providers.base import PriceProvider
 from app.services.yahoo import yahoo_client
 
@@ -35,7 +36,7 @@ class YahooPriceProvider(PriceProvider):
     ) -> dict[str, pd.DataFrame]:
         return await yahoo_client.batch_history(symbols, period=period)
 
-    async def batch_fetch_quotes(self, symbols: list[str]) -> list[dict]:
+    async def batch_fetch_quotes(self, symbols: list[str]) -> list[Quote]:
         return await yahoo_client.quotes(symbols)
 
     async def batch_fetch_currencies(self, symbols: list[str]) -> dict[str, str]:

--- a/backend/app/services/price_sync.py
+++ b/backend/app/services/price_sync.py
@@ -154,12 +154,8 @@ async def _quote_anchors(
         )
         return {}
     return {
-        q["symbol"]: (
-            q.get("price"), q.get("previous_close"),
-            q.get("market_state"), _as_date(q.get("session_date")),
-        )
+        q.symbol: (q.price, q.previous_close, q.market_state, _as_date(q.session_date))
         for q in quotes
-        if q.get("symbol")
     }
 
 

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -1,7 +1,6 @@
 """Quote business logic — REST + SSE stream generation."""
 
 import asyncio
-import json
 import logging
 import time as _time
 from collections.abc import Sequence
@@ -14,13 +13,15 @@ from app.domain.market_state import any_active, state_info
 from app.domain.phases import Phase
 from app.repositories.asset_repo import AssetRepository
 from app.schemas.intraday import IntradayBar
+from app.schemas.quote import Quote
 from app.services.intraday import get_intraday_bars
 from app.services.market_calendar import schedule_poll_hint
 from app.services.price_providers import get_price_provider
 
 logger = logging.getLogger(__name__)
 
-# Serializer for the SSE ``intraday`` event payload ({symbol: [bars]}).
+# Serializers for the SSE event payloads (both keyed by symbol).
+_quotes_payload_adapter = TypeAdapter(dict[str, Quote])
 _intraday_payload_adapter = TypeAdapter(dict[str, list[IntradayBar]])
 
 # Cache asset list to avoid opening a DB session every SSE iteration
@@ -69,7 +70,7 @@ def _poll_interval(market_states: set[str], symbols: Sequence[str], at=None) -> 
     return interval
 
 
-async def get_quotes(symbols: str) -> list[dict]:
+async def get_quotes(symbols: str) -> list[Quote]:
     symbol_list = [s.strip().upper() for s in symbols.split(",") if s.strip()]
     if not symbol_list:
         return []
@@ -86,7 +87,7 @@ async def quote_event_generator():
     Also pushes ``event: intraday`` with 1-minute bars for the live day view.
     First push sends full day data, subsequent pushes send only new bars (delta).
     """
-    last_payload: dict[str, dict] = {}
+    last_payload: dict[str, Quote] = {}
     # Track last pushed intraday bar timestamp per symbol
     last_intraday_ts: dict[str, int] = {}
 
@@ -111,12 +112,12 @@ async def quote_event_generator():
             quotes = await get_price_provider().batch_fetch_quotes(list(refs))
 
             # Build keyed payload
-            full_payload: dict[str, dict] = {}
+            full_payload: dict[str, Quote] = {}
             market_states: set[str] = set()
             for q in quotes:
-                full_payload[q["symbol"]] = q
-                if q.get("market_state"):
-                    market_states.add(q["market_state"])
+                full_payload[q.symbol] = q
+                if q.market_state:
+                    market_states.add(q.market_state)
 
             # Compute delta: only symbols that changed since last push
             if last_payload:
@@ -130,7 +131,8 @@ async def quote_event_generator():
                 delta = full_payload
 
             if delta:
-                yield f"event: quotes\ndata: {json.dumps(delta)}\n\n"
+                data = _quotes_payload_adapter.dump_json(delta).decode()
+                yield f"event: quotes\ndata: {data}\n\n"
 
             last_payload = full_payload
 

--- a/backend/app/services/yahoo/_parsers.py
+++ b/backend/app/services/yahoo/_parsers.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pandas as pd
 
+from app.schemas.quote import Quote
 from app.services.yahoo.currency import resolve_currency
 
 logger = logging.getLogger(__name__)
@@ -125,8 +126,8 @@ def normalize_date_index(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def parse_quote_row(sym: str, info: dict) -> dict:
-    """Build one quote dict from Yahoo's per-symbol price-info dict."""
+def parse_quote_row(sym: str, info: dict) -> Quote:
+    """Build one :class:`Quote` from Yahoo's per-symbol price-info dict."""
     currency, divisor = resolve_currency(info, sym)
 
     price = sanitize_float(info.get("regularMarketPrice"))
@@ -136,28 +137,29 @@ def parse_quote_row(sym: str, info: dict) -> dict:
     volume = info.get("regularMarketVolume")
     avg_volume = info.get("averageDailyVolume10Day")
 
-    return {
-        "symbol": sym,
-        "price": round(float(price) / divisor, 4) if price is not None else None,
-        "previous_close": round(float(prev_close) / divisor, 4) if prev_close is not None else None,
-        "change": round(float(change) / divisor, 4) if change is not None else None,
+    return Quote(
+        symbol=sym,
+        price=round(float(price) / divisor, 4) if price is not None else None,
+        previous_close=round(float(prev_close) / divisor, 4) if prev_close is not None else None,
+        change=round(float(change) / divisor, 4) if change is not None else None,
         # ``ticker.quotes`` (/v7/finance/quote) returns this already in
         # percent units (10.53 = 10.53%), unlike ``ticker.price`` which
         # returned a decimal (0.1053). No ×100 needed.
-        "change_percent": round(float(change_pct), 2) if change_pct is not None else None,
-        "volume": int(volume) if volume is not None else None,
-        "avg_volume": int(avg_volume) if avg_volume is not None else None,
-        "currency": currency,
-        "market_state": info.get("marketState"),
+        change_percent=round(float(change_pct), 2) if change_pct is not None else None,
+        volume=int(volume) if volume is not None else None,
+        avg_volume=int(avg_volume) if avg_volume is not None else None,
+        currency=currency,
+        market_state=info.get("marketState"),
         # Exchange-local session date (ISO str, best-effort). Internal reconciliation
-        # aid for price-sync; QuoteResponse ignores it, the SSE forwards it harmlessly.
-        "session_date": _quote_session_date(info),
-    }
+        # aid for price-sync; QuoteResponse drops it at the REST boundary, the SSE
+        # forwards it harmlessly.
+        session_date=_quote_session_date(info),
+    )
 
 
-def parse_quotes(symbols: list[str], price_data: dict) -> list[dict]:
+def parse_quotes(symbols: list[str], price_data: dict) -> list[Quote]:
     """Build the full quote list, logging unusual values."""
-    results: list[dict] = []
+    results: list[Quote] = []
     null_symbols: list[str] = []
     nan_fields: list[str] = []
 
@@ -165,7 +167,7 @@ def parse_quotes(symbols: list[str], price_data: dict) -> list[dict]:
         info = price_data.get(sym, {})
         if not isinstance(info, dict):
             logger.warning("Yahoo returned non-dict for %s: %s", sym, repr(info)[:200])
-            results.append({"symbol": sym})
+            results.append(Quote.placeholder(sym))
             continue
 
         if info.get("regularMarketPrice") is not None and sanitize_float(info["regularMarketPrice"]) is None:

--- a/backend/app/services/yahoo/_quotes.py
+++ b/backend/app/services/yahoo/_quotes.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 
+from app.schemas.quote import Quote
 from app.services.yahoo._base import _YahooBase
 from app.services.yahoo._parsers import parse_quotes
 from app.services.yahoo.currency import resolve_currency
@@ -12,13 +13,12 @@ logger = logging.getLogger(__name__)
 
 
 class _QuotesMixin(_YahooBase):
-    async def quotes(self, symbols: list[str]) -> list[dict]:
+    async def quotes(self, symbols: list[str]) -> list[Quote]:
         """Fetch real-time market quotes for ``symbols``.
 
-        Returns a list of dicts: ``symbol, price, previous_close, change,
-        change_percent, volume, avg_volume, currency, market_state``. When
-        the breaker is open or Yahoo blocks, returns symbol-only
-        placeholders so consumers can iterate without crashing.
+        Returns one :class:`Quote` per symbol. When the breaker is open or
+        Yahoo blocks, returns symbol-only placeholders
+        (``Quote.placeholder``) so consumers can iterate without crashing.
         """
         if not symbols:
             return []
@@ -28,7 +28,7 @@ class _QuotesMixin(_YahooBase):
         if cached is not None:
             return cached
 
-        def _fetch() -> list[dict]:
+        def _fetch() -> list[Quote]:
             ticker = self._ticker(symbols)
             # ``quotes`` hits the batched ``/v7/finance/quote?symbols=…``
             # endpoint (one HTTP call for all symbols), unlike ``price``
@@ -38,10 +38,10 @@ class _QuotesMixin(_YahooBase):
             return parse_quotes(symbols, data if isinstance(data, dict) else {})
 
         result = await asyncio.to_thread(
-            self._call, _fetch, lambda: [{"symbol": s} for s in symbols],
+            self._call, _fetch, lambda: [Quote.placeholder(s) for s in symbols],
         )
-        # Don't cache the empty fallback — we want a real result on the next try.
-        if any(set(r.keys()) != {"symbol"} for r in result):
+        # Don't cache a fully degraded batch — we want a real result next try.
+        if any(not q.is_placeholder for q in result):
             self._quote_cache.set_value(cache_key, result)
         return result
 

--- a/backend/tests/background_tasks/test_price_heal.py
+++ b/backend/tests/background_tasks/test_price_heal.py
@@ -12,6 +12,7 @@ import pytest
 from app.background_tasks import price_heal
 from app.background_tasks.price_heal import MAX_HEALS_PER_RUN, heal_unreconciled_prices
 from app.repositories.price_repo import PriceRepository
+from app.schemas.quote import Quote
 from tests.helpers import seed_asset_with_prices
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
@@ -31,10 +32,7 @@ def _provider_with_quotes(quotes):
 
 
 def _quote(symbol, price, prev, state="REGULAR"):
-    return {
-        "symbol": symbol, "price": price,
-        "previous_close": prev, "market_state": state,
-    }
+    return Quote(symbol=symbol, price=price, previous_close=prev, market_state=state)
 
 
 async def _latest_close(db, asset) -> float:

--- a/backend/tests/integration/test_data.py
+++ b/backend/tests/integration/test_data.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.schemas.quote import Quote
 from tests.helpers import make_yahoo_df, seed_asset_with_prices
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
@@ -48,7 +49,7 @@ async def test_invalid_period_422(client):
 
 
 async def test_quote_field(client):
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50, "change": 1.2}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50, "change": 1.2})]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
     with patch("app.services.data_service.get_price_provider", return_value=mock_prov):
@@ -62,8 +63,8 @@ async def test_quote_field(client):
 
 async def test_quote_multiple_symbols(client):
     mock_quotes = [
-        {"symbol": "AAPL", "price": 185.50},
-        {"symbol": "MSFT", "price": 420.00},
+        Quote(**{"symbol": "AAPL", "price": 185.50}),
+        Quote(**{"symbol": "MSFT", "price": 420.00}),
     ]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
@@ -155,7 +156,7 @@ async def test_indicators_tracked_asset(client, db):
 
 async def test_default_fields(client):
     """Omitting fields parameter returns quote + snapshot."""
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50})]
     mock_snapshots = [{"symbol": "AAPL", "close": 185.5, "values": {"rsi": 55.0}}]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
@@ -178,7 +179,7 @@ async def test_default_fields(client):
 
 async def test_all_fields(client, db):
     await seed_asset_with_prices(db, symbol="TEST")
-    mock_quotes = [{"symbol": "TEST", "price": 150.0}]
+    mock_quotes = [Quote(**{"symbol": "TEST", "price": 150.0})]
     mock_snapshots = [{"symbol": "TEST", "close": 150.0, "values": {"rsi": 55.0}}]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
@@ -202,7 +203,7 @@ async def test_all_fields(client, db):
 
 
 async def test_symbols_uppercase_normalization(client):
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50})]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
     with patch("app.services.data_service.get_price_provider", return_value=mock_prov):
@@ -233,8 +234,8 @@ async def test_mixed_tracked_untracked(client, db):
     """Request with both tracked and untracked symbols returns data for both."""
     await seed_asset_with_prices(db, symbol="TRACKED")
     mock_quotes = [
-        {"symbol": "TRACKED", "price": 150.0},
-        {"symbol": "UNTRACKED", "price": 200.0},
+        Quote(**{"symbol": "TRACKED", "price": 150.0}),
+        Quote(**{"symbol": "UNTRACKED", "price": 200.0}),
     ]
     mock_df = make_yahoo_df()
     mock_prov = MagicMock()
@@ -261,7 +262,7 @@ async def test_mixed_tracked_untracked(client, db):
 
 async def test_response_only_requested_fields(client):
     """Response should only contain the fields that were requested."""
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50})]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
     with patch("app.services.data_service.get_price_provider", return_value=mock_prov):

--- a/backend/tests/integration/test_quotes.py
+++ b/backend/tests/integration/test_quotes.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.schemas.quote import Quote
 from app.services.quote_service import _reset_asset_list_cache
 from tests.conftest import TestSession
 
@@ -13,7 +14,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 _MOCK_QUOTES = [
-    {
+    Quote(**{
         "symbol": "AAPL",
         "price": 185.50,
         "previous_close": 184.00,
@@ -21,8 +22,8 @@ _MOCK_QUOTES = [
         "change_percent": 0.82,
         "currency": "USD",
         "market_state": "REGULAR",
-    },
-    {
+    }),
+    Quote(**{
         "symbol": "MSFT",
         "price": 420.00,
         "previous_close": 418.50,
@@ -30,7 +31,7 @@ _MOCK_QUOTES = [
         "change_percent": 0.36,
         "currency": "USD",
         "market_state": "REGULAR",
-    },
+    }),
 ]
 
 

--- a/backend/tests/services/test_price_sync.py
+++ b/backend/tests/services/test_price_sync.py
@@ -10,6 +10,7 @@ import pytest
 from app.domain import AssetRef
 from app.models import Asset, AssetType, PriceHistory
 from app.repositories.price_repo import PriceRepository
+from app.schemas.quote import Quote
 from app.services.price_sync import (
     _NO_ANCHOR,
     _drop_and_persist,
@@ -132,8 +133,8 @@ async def test_sync_range_to_today_drops_unsettled_bar(db):
 
     # Last close is today's live partial; its predecessor equals previous_close.
     df = _df_from_closes([60.0, 64.44, 63.10])
-    quotes = [{"symbol": "MT.AS", "price": 64.28, "previous_close": 64.44,
-               "market_state": "REGULAR"}]
+    quotes = [Quote(**{"symbol": "MT.AS", "price": 64.28, "previous_close": 64.44,
+               "market_state": "REGULAR"})]
     mock_prov = _mock_provider(fetch_history=df, batch_fetch_quotes=quotes)
 
     captured = {}
@@ -386,8 +387,8 @@ async def test_sync_all_drops_unsettled_bar(db):
 
     # 3 bars; last (224.14) is today's partial, predecessor (290.23) == prev close.
     mock_data = {"IBM": _df_from_closes([305.0, 290.23, 224.14])}
-    quotes = [{"symbol": "IBM", "price": 220.84, "previous_close": 290.23,
-               "market_state": "REGULAR"}]
+    quotes = [Quote(**{"symbol": "IBM", "price": 220.84, "previous_close": 290.23,
+               "market_state": "REGULAR"})]
     mock_prov = _mock_provider(batch_fetch_history=mock_data, batch_fetch_quotes=quotes)
 
     captured = {}
@@ -414,8 +415,8 @@ async def test_sync_all_keeps_settled_bar(db):
 
     # Market closed (POSTPOST), last bar within tolerance of the settled close.
     mock_data = {"MT.AS": _df_from_closes([57.5, 58.04, 59.0])}
-    quotes = [{"symbol": "MT.AS", "price": 58.72, "previous_close": 58.04,
-               "market_state": "POSTPOST"}]
+    quotes = [Quote(**{"symbol": "MT.AS", "price": 58.72, "previous_close": 58.04,
+               "market_state": "POSTPOST"})]
     mock_prov = _mock_provider(batch_fetch_history=mock_data, batch_fetch_quotes=quotes)
 
     captured = {}

--- a/backend/tests/services/test_quote_service.py
+++ b/backend/tests/services/test_quote_service.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.domain import AssetRef
+from app.schemas.quote import Quote
 from app.schemas.intraday import IntradayBar
 from app.services.quote_service import get_quotes, quote_event_generator
 
@@ -24,7 +25,7 @@ def _mock_provider(quotes_return=None, quotes_side_effect=None):
 
 
 async def test_get_quotes_parses_symbols():
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50})]
     mock_prov = _mock_provider(quotes_return=mock_quotes)
     with patch("app.services.quote_service.get_price_provider", return_value=mock_prov):
         result = await get_quotes("AAPL,MSFT")
@@ -46,7 +47,7 @@ async def test_get_quotes_empty_returns_empty():
 async def test_stream_emits_full_payload_first():
     """First SSE event should contain all symbols (full payload)."""
     mock_quotes = [
-        {"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"},
+        Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"}),
     ]
 
     call_count = 0
@@ -85,12 +86,12 @@ async def test_stream_emits_full_payload_first():
 async def test_stream_delta_only_changed():
     """After initial full payload, subsequent events only contain changed data."""
     quote_v1 = [
-        {"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"},
-        {"symbol": "MSFT", "price": 420.00, "market_state": "REGULAR"},
+        Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"}),
+        Quote(**{"symbol": "MSFT", "price": 420.00, "market_state": "REGULAR"}),
     ]
     quote_v2 = [
-        {"symbol": "AAPL", "price": 186.00, "market_state": "REGULAR"},  # changed
-        {"symbol": "MSFT", "price": 420.00, "market_state": "REGULAR"},  # unchanged
+        Quote(**{"symbol": "AAPL", "price": 186.00, "market_state": "REGULAR"}),  # changed
+        Quote(**{"symbol": "MSFT", "price": 420.00, "market_state": "REGULAR"}),  # unchanged
     ]
 
     call_count = 0
@@ -131,7 +132,7 @@ async def test_stream_delta_only_changed():
 async def test_stream_intraday_event_serializes_bars():
     """The ``intraday`` SSE event carries {symbol: [bar]} with the wire keys
     time/price/volume/session (the frontend's ``IntradayPoint`` mirror)."""
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"})]
     bars = {
         "AAPL": [
             IntradayBar(time=1771000000, price=185.5, volume=1200, session="regular"),
@@ -175,7 +176,7 @@ async def test_stream_intraday_event_serializes_bars():
 
 async def test_stream_adaptive_interval_regular():
     """During regular market hours, interval should be 15 seconds."""
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"})]
 
     sleep_intervals = []
     async def mock_sleep(seconds):
@@ -205,7 +206,7 @@ async def test_stream_adaptive_interval_regular():
 
 async def test_stream_adaptive_interval_closed():
     """When market is closed, interval should be 300 seconds."""
-    mock_quotes = [{"symbol": "AAPL", "price": 185.50, "market_state": "CLOSED"}]
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "CLOSED"})]
 
     sleep_intervals = []
     async def mock_sleep(seconds):

--- a/backend/tests/services/test_yahoo_quotes.py
+++ b/backend/tests/services/test_yahoo_quotes.py
@@ -50,7 +50,7 @@ class TestSessionDate:
             "regularMarketPreviousClose": 99.0, "marketState": "REGULAR",
             "regularMarketTime": epoch, "exchangeTimezoneName": "America/New_York",
         })
-        assert row["session_date"] == "2024-01-02"
+        assert row.session_date == "2024-01-02"
 
 
 class TestSanitize:
@@ -93,21 +93,22 @@ class TestParseQuotes:
 
         assert len(results) == 1
         q = results[0]
-        assert q["symbol"] == "AAPL"
-        assert q["price"] == 185.50
-        assert q["previous_close"] == 184.0
-        assert q["change"] == 1.50
-        assert q["change_percent"] == 0.82
-        assert q["volume"] == 50_000_000
-        assert q["avg_volume"] == 55_000_000
-        assert q["currency"] == "USD"
-        assert q["market_state"] == "REGULAR"
+        assert q.symbol == "AAPL"
+        assert q.price == 185.50
+        assert q.previous_close == 184.0
+        assert q.change == 1.50
+        assert q.change_percent == 0.82
+        assert q.volume == 50_000_000
+        assert q.avg_volume == 55_000_000
+        assert q.currency == "USD"
+        assert q.market_state == "REGULAR"
 
-    def test_non_dict_info_returns_symbol_only(self):
+    def test_non_dict_info_returns_placeholder(self):
         price_data = {"AAPL": "No data found"}
         results = _parse_quotes(["AAPL"], price_data)
         assert len(results) == 1
-        assert results[0] == {"symbol": "AAPL"}
+        assert results[0].symbol == "AAPL"
+        assert results[0].is_placeholder
 
     def test_nan_values_sanitized(self):
         price_data = {
@@ -124,18 +125,18 @@ class TestParseQuotes:
         }
         results = _parse_quotes(["AAPL"], price_data)
         q = results[0]
-        assert q["price"] is None
-        assert q["change"] is None
-        assert q["change_percent"] is None
+        assert q.price is None
+        assert q.change is None
+        assert q.change_percent is None
 
     def test_missing_symbol_in_price_data(self):
         results = _parse_quotes(["AAPL"], {})
 
         assert len(results) == 1
         q = results[0]
-        assert q["symbol"] == "AAPL"
-        assert q["price"] is None
-        assert q["currency"] == "USD"
+        assert q.symbol == "AAPL"
+        assert q.price is None
+        assert q.currency == "USD"
 
     def test_currency_normalization_gbp(self):
         price_data = {
@@ -152,10 +153,10 @@ class TestParseQuotes:
         }
         results = _parse_quotes(["HSBA.L"], price_data)
         q = results[0]
-        assert q["currency"] == "GBP"
-        assert q["price"] == 65.0
-        assert q["previous_close"] == 64.0
-        assert q["change"] == 1.0
+        assert q.currency == "GBP"
+        assert q.price == 65.0
+        assert q.previous_close == 64.0
+        assert q.change == 1.0
 
     def test_multiple_symbols(self):
         price_data = {
@@ -174,8 +175,8 @@ class TestParseQuotes:
         }
         results = _parse_quotes(["AAPL", "MSFT"], price_data)
         assert len(results) == 2
-        assert results[0]["symbol"] == "AAPL"
-        assert results[1]["symbol"] == "MSFT"
+        assert results[0].symbol == "AAPL"
+        assert results[1].symbol == "MSFT"
 
 
 class TestCrumbRejected:
@@ -228,7 +229,7 @@ class TestQuotes:
 
         result = await yahoo_client.quotes(["AAPL"])
         assert len(result) == 1
-        assert result[0]["price"] == 185.0
+        assert result[0].price == 185.0
         assert mock_ticker_cls.call_count == 2
 
 


### PR DESCRIPTION
Third checklist item of #580: the quote dict becomes a `Quote` model end to end.

## Model

`Quote(QuoteResponse)` in `schemas/quote.py` — the existing REST response model plus the internal `session_date` reconciliation field. Placement per the layering discussion: the dict was the SSE wire payload verbatim, so it's a serialization contract and lives in `schemas/`. `market_state` deliberately stays a raw string (Yahoo's open-world vocabulary; the `domain/market_state` trait table is its canonical interpreter — same reasoning as #598).

## Flow changes

- `parse_quote_row -> Quote`, `parse_quotes -> list[Quote]` (`yahoo/_parsers.py`)
- `YahooClient.quotes -> list[Quote]`; the `{"symbol": sym}` sentinel becomes `Quote.placeholder()` + `is_placeholder`. The cache guard (`set(r.keys()) != {"symbol"}`) keys on the predicate now — **subtle improvement:** an all-null degraded batch (every field None) was previously cached as "real" because the keys existed; it now counts as placeholder and isn't cached, so the next poll retries.
- `PriceProvider.batch_fetch_quotes -> list[Quote]` (abstract contract now references the model instead of a stale key list that omitted `session_date`)
- `price_sync._quote_anchors` and `price_heal` switch to attribute access — no logic changes on the anchor paths from #591/#592; their tests pin the behavior.
- SSE `quotes` event serializes via `TypeAdapter(dict[str, Quote])`; delta detection compares model instances (Pydantic `__eq__`). One wire nuance: a degraded symbol now serializes as a full-null quote instead of a bare `{"symbol": ...}` — which actually *matches* the frontend `Quote` TS type better than the old shape.
- `SymbolBatchData.quote: Quote | None` — closes the first of the two `#580` notes in `batch_data.py`.

## Verification

- Full backend suite: 806 passed (quote mocks across 6 test files converted from dicts to `Quote(...)`; the sentinel test asserts `is_placeholder`).
- Live smoke: `GET /api/quotes` drops `session_date` exactly as before (QuoteResponse re-validation); `GET /api/data?fields=quote` keeps it, byte-identical key order.

Part of #580 — checklist item "quote payloads".

🤖 Generated with [Claude Code](https://claude.com/claude-code)