### PR TITLE
refactor(backend): typed indicator snapshots (#580)

### DIFF
--- a/backend/app/routers/holdings.py
+++ b/backend/app/routers/holdings.py
@@ -21,4 +21,4 @@ async def get_holdings(symbol: str, db: AsyncSession = Depends(get_db)):
 async def get_holdings_indicators(symbol: str, db: AsyncSession = Depends(get_db)):
     """Return latest indicator snapshot for each of the ETF's top holdings."""
     snapshots = await holdings_service.get_holdings_indicators(db, symbol)
-    return [HoldingIndicatorResponse(**s) for s in snapshots]
+    return [HoldingIndicatorResponse.model_validate(s, from_attributes=True) for s in snapshots]

--- a/backend/app/routers/pseudo_etf_analysis.py
+++ b/backend/app/routers/pseudo_etf_analysis.py
@@ -52,9 +52,9 @@ async def get_constituent_indicators(etf_id: int, db: AsyncSession = Depends(get
     merge_fundamentals_into_batch(snapshots)
     return [
         ConstituentIndicatorResponse(
-            **s,
-            name=symbol_to_name.get(s["symbol"]),
-            weight_pct=weight_map.get(s["symbol"]),
+            **s.model_dump(),
+            name=symbol_to_name.get(s.symbol),
+            weight_pct=weight_map.get(s.symbol),
         )
         for s in snapshots
     ]

--- a/backend/app/schemas/batch_data.py
+++ b/backend/app/schemas/batch_data.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from app.schemas.price import DatedOHLCV, IndicatorResponse
+from app.schemas.price import CurrencyIndicatorSnapshot, DatedOHLCV, IndicatorResponse
 from app.schemas.quote import Quote
 
 
@@ -13,15 +13,14 @@ class SymbolBatchData(BaseModel):
     ``response_model_exclude_none=True``, so absent fields are dropped from
     the JSON rather than emitted as ``null``. ``error`` replaces the data
     fields when the symbol failed entirely.
-
-    ``snapshot`` stays a provider-shaped dict for now — typing it is
-    tracked in #580.
     """
 
     quote: Quote | None = Field(
         default=None, description="Real-time quote: price, change, volume, market state."
     )
-    snapshot: dict | None = Field(
+    # A SymbolIndicatorSnapshot is stored here; the declared type strips the
+    # redundant ``symbol`` on serialization (it's already the payload key).
+    snapshot: CurrencyIndicatorSnapshot | None = Field(
         default=None, description="Latest indicator values and derived signals."
     )
     prices: list[DatedOHLCV] | None = Field(

--- a/backend/app/schemas/price.py
+++ b/backend/app/schemas/price.py
@@ -61,7 +61,18 @@ class EtfHoldingsResponse(BaseModel):
 
 
 class IndicatorSnapshotBase(BaseModel):
-    """Shared indicator fields for holding and constituent snapshot responses."""
+    """The indicator snapshot — service-level object AND response shape.
+
+    Built by ``build_indicator_snapshot`` and cached by the compute layer;
+    the group/symbol indicator endpoints serve it as-is. ``values`` is an
+    open map on purpose: its keys are driven by ``INDICATOR_REGISTRY``
+    (output fields + ``snapshot_derived``) and the fundamentals cache merges
+    more keys in *after* construction — instances must therefore stay
+    mutable (no ``frozen=True``), and a closed per-field model would lie
+    about the payload. A degenerate snapshot (insufficient history) is an
+    all-default instance, not a missing entry.
+    """
+
     close: float | None = Field(default=None, description="Latest closing price")
     change_pct: float | None = Field(default=None, description="1-day percentage change")
     values: dict[str, float | str | None] = Field(
@@ -70,9 +81,25 @@ class IndicatorSnapshotBase(BaseModel):
     )
 
 
-class HoldingIndicatorResponse(IndicatorSnapshotBase):
-    symbol: str = Field(description="Holding ticker symbol")
+class CurrencyIndicatorSnapshot(IndicatorSnapshotBase):
+    """A snapshot with its display currency but no symbol — the batch data
+    endpoint's ``snapshot`` field, where the symbol is already the payload
+    key. Serializing a :class:`SymbolIndicatorSnapshot` through a field of
+    this type strips ``symbol`` (declared-type serialization)."""
+
     currency: str = Field(default="USD", description="ISO 4217 currency code")
+
+
+class SymbolIndicatorSnapshot(CurrencyIndicatorSnapshot):
+    """A snapshot bound to its symbol — the shape
+    ``compute_batch_indicator_snapshots`` returns (holdings, pseudo-ETF
+    constituents, batch data)."""
+
+    symbol: str = Field(description="Ticker symbol")
+
+
+class HoldingIndicatorResponse(SymbolIndicatorSnapshot):
+    """Per-holding indicator snapshot as served by the holdings endpoint."""
 
 
 class SparklinePointResponse(BaseModel):

--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -10,6 +10,7 @@ from app.models import PriceHistory
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
 from app.repositories.price_repo import PriceRepository
+from app.schemas.price import IndicatorSnapshotBase
 from app.services.compute.indicators import build_indicator_snapshot, compute_indicators
 from app.services.compute.utils import prices_to_df
 from app.services.fundamentals_cache import merge_fundamentals_from_cache
@@ -61,7 +62,7 @@ async def get_batch_sparklines(
 
 async def _compute_snapshots_for_refs(
     db: AsyncSession, refs: list[AssetRef],
-) -> dict[str, dict]:
+) -> dict[str, IndicatorSnapshotBase]:
     """Compute DB-backed indicator snapshots for the refs, with caching.
 
     The snapshot *values* depend purely on (symbols, latest price date), so the
@@ -92,11 +93,11 @@ async def _compute_snapshots_for_refs(
     for p in all_prices:
         grouped.setdefault(p.asset_id, []).append(p)
 
-    out: dict[str, dict] = {}
+    out: dict[str, IndicatorSnapshotBase] = {}
     for asset_id, ref in by_id.items():
         prices = grouped.get(asset_id, [])
         if len(prices) < 26:  # Need at least MACD slow period
-            out[ref.symbol] = {"values": {}}
+            out[ref.symbol] = IndicatorSnapshotBase()
             continue
 
         df = prices_to_df(prices)
@@ -109,6 +110,9 @@ async def _compute_snapshots_for_refs(
     # Merge cached fundamental metrics; background-fetch any misses
     merge_fundamentals_from_cache([ref.symbol for ref in by_id.values()], out)
 
+    # The cache hands out these model instances by reference, and the
+    # fundamentals merge mutates their ``values`` in place — snapshots must
+    # stay mutable (IndicatorSnapshotBase is deliberately not frozen).
     _indicator_cache.set_value(cache_key, out)
 
     return out
@@ -116,7 +120,7 @@ async def _compute_snapshots_for_refs(
 
 async def compute_and_cache_indicators(
     db: AsyncSession, group_id: int | None = None,
-) -> dict[str, dict]:
+) -> dict[str, IndicatorSnapshotBase]:
     """Compute indicator snapshots for assets in a group, with caching.
 
     If group_id is None, uses the default group.
@@ -131,7 +135,7 @@ async def compute_and_cache_indicators(
 
 async def compute_indicators_for_symbols(
     db: AsyncSession, symbols: list[str],
-) -> dict[str, dict]:
+) -> dict[str, IndicatorSnapshotBase]:
     """Compute indicator snapshots for specific tracked symbols (DB-backed).
 
     Mirrors the per-group snapshot shape but is addressable by symbol set rather

--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 
 from app.domain import AssetRef
+from app.schemas.price import IndicatorSnapshotBase, SymbolIndicatorSnapshot
 from app.services.price_providers import get_price_provider
 
 
@@ -589,13 +590,14 @@ def get_max_warmup_periods() -> int:
 # ---------------------------------------------------------------------------
 
 
-def build_indicator_snapshot(indicators: pd.DataFrame) -> dict:
-    """Build a dict of latest indicator values from a computed indicators DataFrame.
+def build_indicator_snapshot(indicators: pd.DataFrame) -> IndicatorSnapshotBase:
+    """Build the latest-values snapshot from a computed indicators DataFrame.
 
-    Returns close, change_pct, and all registry indicator fields (with derived fields).
+    Returns close, change_pct, and all registry indicator fields (with derived
+    fields) in ``values``. Insufficient history yields an all-default snapshot.
     """
     if indicators.empty or len(indicators) < 2:
-        return {}
+        return IndicatorSnapshotBase()
 
     latest = indicators.iloc[-1]
     prev_close = indicators.iloc[-2]["close"]
@@ -609,13 +611,8 @@ def build_indicator_snapshot(indicators: pd.DataFrame) -> dict:
     if prev_close and prev_close != 0 and not latest_is_gap:
         change_pct = round((latest["close"] - prev_close) / prev_close * 100, 2)
 
-    result: dict = {
-        "close": round(latest["close"], 2),
-        "change_pct": change_pct,
-    }
-
     # Collect all indicator values from registry
-    values: dict[str, float | None] = {}
+    values: dict[str, float | str | None] = {}
     for defn in INDICATOR_REGISTRY.values():
         for col in defn.output_fields:
             decimals = defn.field_decimals.get(col, defn.decimals)
@@ -623,8 +620,11 @@ def build_indicator_snapshot(indicators: pd.DataFrame) -> dict:
         if defn.snapshot_derived:
             values.update(defn.snapshot_derived(latest))
 
-    result["values"] = values
-    return result
+    return IndicatorSnapshotBase(
+        close=round(latest["close"], 2),
+        change_pct=change_pct,
+        values=values,
+    )
 
 
 def _get_delta_fields() -> list[str]:
@@ -726,14 +726,14 @@ def compute_indicators(
 
 async def compute_batch_indicator_snapshots(
     symbols: list[str],
-) -> list[dict]:
+) -> list[SymbolIndicatorSnapshot]:
     """Compute indicator snapshots for multiple symbols in batch.
 
     Fetches ~3 months of history and currencies via the configured price
     provider, then computes indicators and builds snapshots for each symbol.
 
-    Returns a list of dicts (one per symbol) with keys:
-    symbol, currency, and all build_indicator_snapshot fields.
+    Returns one :class:`SymbolIndicatorSnapshot` per symbol; symbols without
+    usable history get a default snapshot carrying just symbol/currency.
     """
     if not symbols:
         return []
@@ -742,18 +742,21 @@ async def compute_batch_indicator_snapshots(
     histories = await provider.batch_fetch_history(symbols, period="3mo")
     currencies = await provider.batch_fetch_currencies(symbols)
 
-    results = []
+    results: list[SymbolIndicatorSnapshot] = []
     for sym in symbols:
         currency = currencies.get(sym, "USD")
         df = histories.get(sym)
         if df is None or df.empty or len(df) < 2:
-            results.append({"symbol": sym, "currency": currency})
+            results.append(SymbolIndicatorSnapshot(symbol=sym, currency=currency))
             continue
 
         venue = AssetRef(sym).venue
         sessions = venue.session_dates_for_index(df.index) if venue else None
         snapshot = build_indicator_snapshot(compute_indicators(df, session_dates=sessions))
-        results.append({"symbol": sym, "currency": currency, **snapshot})
+        results.append(SymbolIndicatorSnapshot(
+            symbol=sym, currency=currency,
+            close=snapshot.close, change_pct=snapshot.change_pct, values=snapshot.values,
+        ))
 
     # Fundamentals are merged from cache by the caller (non-blocking).
     # See fundamentals_cache.merge_fundamentals_into_batch().

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -51,12 +51,9 @@ async def query_batch_data(
         try:
             snapshots = await compute_batch_indicator_snapshots(symbols)
             for snap in snapshots:
-                sym = snap.get("symbol")
-                if sym and sym in results:
-                    snap_data = {k: v for k, v in snap.items() if k != "symbol"}
-                    # Only include if we got actual computed data
-                    if snap_data.get("close") is not None:
-                        results[sym]["snapshot"] = snap_data
+                # Only include if we got actual computed data
+                if snap.symbol in results and snap.close is not None:
+                    results[snap.symbol]["snapshot"] = snap
         except Exception:
             logger.exception("Batch snapshot fetch failed")
 

--- a/backend/app/services/fundamentals_cache.py
+++ b/backend/app/services/fundamentals_cache.py
@@ -9,6 +9,7 @@ merged from cache when available.
 import asyncio
 import logging
 
+from app.schemas.price import IndicatorSnapshotBase, SymbolIndicatorSnapshot
 from app.services.yahoo import yahoo_client
 from app.utils import TTLCache
 
@@ -89,14 +90,14 @@ def _schedule_background_fetch(symbols: list[str]) -> None:
 
 def merge_fundamentals_from_cache(
     symbols: list[str],
-    target: dict[str, dict],
-    values_key: str = "values",
+    target: dict[str, IndicatorSnapshotBase],
 ) -> None:
-    """Merge cached fundamentals into target dict, scheduling background fetch for misses.
+    """Merge cached fundamentals into snapshots, scheduling background fetch for misses.
 
     For each symbol in target, if fundamentals are cached, merge them into
-    target[symbol][values_key].  Symbols without cache entries trigger a
-    background fetch so they'll be available on the next request.
+    ``target[symbol].values`` (in-place — the snapshots may already sit in
+    the indicator cache). Symbols without cache entries trigger a background
+    fetch so they'll be available on the next request.
     """
     cached = get_cached_fundamentals(symbols)
     uncached = []
@@ -105,7 +106,7 @@ def merge_fundamentals_from_cache(
         upper = sym.upper()
         fund = cached.get(upper)
         if fund and sym in target:
-            target[sym].setdefault(values_key, {}).update(fund)
+            target[sym].values.update(fund)
         elif upper not in cached:
             uncached.append(upper)
 
@@ -126,22 +127,20 @@ def merge_fundamentals_into_rows(symbol: str, rows: list) -> None:
         _schedule_background_fetch([upper])
 
 
-def merge_fundamentals_into_batch(results: list[dict]) -> None:
-    """Merge cached fundamentals into batch indicator snapshots.
+def merge_fundamentals_into_batch(results: list[SymbolIndicatorSnapshot]) -> None:
+    """Merge cached fundamentals into batch indicator snapshots (in place).
 
-    Each entry in results has a 'symbol' key. Schedules background fetch
-    for any symbols not in cache.
+    Schedules a background fetch for any symbols not in cache.
     """
-    symbols = [e["symbol"] for e in results if "symbol" in e]
-    cached = get_cached_fundamentals(symbols)
+    cached = get_cached_fundamentals([e.symbol for e in results])
     uncached = []
 
     for entry in results:
-        sym = entry.get("symbol", "").upper()
+        sym = entry.symbol.upper()
         fund = cached.get(sym)
         if fund:
-            entry.setdefault("values", {}).update(fund)
-        elif sym and sym not in cached:
+            entry.values.update(fund)
+        elif sym not in cached:
             uncached.append(sym)
 
     if uncached:

--- a/backend/app/services/holdings_service.py
+++ b/backend/app/services/holdings_service.py
@@ -3,6 +3,7 @@
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.schemas.price import SymbolIndicatorSnapshot
 from app.services.compute.indicators import compute_batch_indicator_snapshots
 from app.services.entity_lookups import get_asset
 from app.services.fundamentals_cache import merge_fundamentals_into_batch
@@ -20,7 +21,7 @@ async def get_holdings(db: AsyncSession, symbol: str) -> dict:
     return data
 
 
-async def get_holdings_indicators(db: AsyncSession, symbol: str) -> list[dict]:
+async def get_holdings_indicators(db: AsyncSession, symbol: str) -> list[SymbolIndicatorSnapshot]:
     """Return latest indicator snapshot for each of the ETF's top holdings."""
     asset = await get_asset(symbol, db)
     if asset.type.value != "etf":

--- a/backend/scripts/export_indicator_contract.py
+++ b/backend/scripts/export_indicator_contract.py
@@ -130,11 +130,10 @@ def _build_fixtures() -> dict:
     series = {f: [_clean(v) for v in computed[f]] for f in APP_SERIES_FIELDS}
 
     snap = build_indicator_snapshot(computed)
-    values = snap.get("values", {})
     snapshot = {
-        "close": snap.get("close"),
-        "changePct": snap.get("change_pct"),
-        "values": {f: values.get(f) for f in APP_SNAPSHOT_FIELDS},
+        "close": snap.close,
+        "changePct": snap.change_pct,
+        "values": {f: snap.values.get(f) for f in APP_SNAPSHOT_FIELDS},
     }
 
     return {"input": bars, "expected": {"series": series, "snapshot": snapshot}}

--- a/backend/tests/integration/test_data.py
+++ b/backend/tests/integration/test_data.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.schemas.quote import Quote
 from tests.helpers import make_yahoo_df, seed_asset_with_prices
+from app.schemas.price import SymbolIndicatorSnapshot
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
@@ -85,7 +86,7 @@ async def test_quote_multiple_symbols(client):
 
 async def test_snapshot_field(client):
     mock_snapshots = [
-        {"symbol": "AAPL", "close": 185.5, "change_pct": 0.65, "currency": "USD", "values": {"rsi": 62.3}},
+        SymbolIndicatorSnapshot(**{"symbol": "AAPL", "close": 185.5, "change_pct": 0.65, "currency": "USD", "values": {"rsi": 62.3}}),
     ]
     with patch("app.services.data_service.compute_batch_indicator_snapshots", new_callable=AsyncMock, return_value=mock_snapshots):
         resp = await client.get("/api/data?symbols=AAPL&fields=snapshot")
@@ -157,7 +158,7 @@ async def test_indicators_tracked_asset(client, db):
 async def test_default_fields(client):
     """Omitting fields parameter returns quote + snapshot."""
     mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50})]
-    mock_snapshots = [{"symbol": "AAPL", "close": 185.5, "values": {"rsi": 55.0}}]
+    mock_snapshots = [SymbolIndicatorSnapshot(**{"symbol": "AAPL", "close": 185.5, "values": {"rsi": 55.0}})]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
     with (
@@ -180,7 +181,7 @@ async def test_default_fields(client):
 async def test_all_fields(client, db):
     await seed_asset_with_prices(db, symbol="TEST")
     mock_quotes = [Quote(**{"symbol": "TEST", "price": 150.0})]
-    mock_snapshots = [{"symbol": "TEST", "close": 150.0, "values": {"rsi": 55.0}}]
+    mock_snapshots = [SymbolIndicatorSnapshot(**{"symbol": "TEST", "close": 150.0, "values": {"rsi": 55.0}})]
     mock_prov = MagicMock()
     mock_prov.batch_fetch_quotes = AsyncMock(return_value=mock_quotes)
     with (

--- a/backend/tests/integration/test_data.py
+++ b/backend/tests/integration/test_data.py
@@ -4,9 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.schemas.price import SymbolIndicatorSnapshot
 from app.schemas.quote import Quote
 from tests.helpers import make_yahoo_df, seed_asset_with_prices
-from app.schemas.price import SymbolIndicatorSnapshot
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 

--- a/backend/tests/integration/test_pseudo_etf_analysis.py
+++ b/backend/tests/integration/test_pseudo_etf_analysis.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.models import Asset, AssetType, PriceHistory
 from app.models.pseudo_etf import PseudoETF
+from app.schemas.price import SymbolIndicatorSnapshot
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
@@ -84,8 +85,8 @@ class TestGetConstituentIndicators:
     async def test_returns_indicator_data(self, mock_compute, mock_merge, client, db):
         etf = await _seed_pseudo_etf(db)
         mock_compute.return_value = [
-            {"symbol": "AAPL", "currency": "USD", "values": {"rsi": 55.0}},
-            {"symbol": "MSFT", "currency": "USD", "values": {"rsi": 48.0}},
+            SymbolIndicatorSnapshot(**{"symbol": "AAPL", "currency": "USD", "values": {"rsi": 55.0}}),
+            SymbolIndicatorSnapshot(**{"symbol": "MSFT", "currency": "USD", "values": {"rsi": 48.0}}),
         ]
 
         resp = await client.get(f"/api/pseudo-etfs/{etf.id}/constituents/indicators")
@@ -119,8 +120,8 @@ class TestGetConstituentIndicators:
     async def test_includes_weight_and_name(self, mock_compute, _mock_merge, client, db):
         etf = await _seed_pseudo_etf(db)
         mock_compute.return_value = [
-            {"symbol": "AAPL", "currency": "USD", "values": {"rsi": 55.0}},
-            {"symbol": "MSFT", "currency": "USD", "values": {"rsi": 48.0}},
+            SymbolIndicatorSnapshot(**{"symbol": "AAPL", "currency": "USD", "values": {"rsi": 55.0}}),
+            SymbolIndicatorSnapshot(**{"symbol": "MSFT", "currency": "USD", "values": {"rsi": 48.0}}),
         ]
 
         resp = await client.get(f"/api/pseudo-etfs/{etf.id}/constituents/indicators")

--- a/backend/tests/services/test_compute_group.py
+++ b/backend/tests/services/test_compute_group.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.domain import AssetRef
+from app.schemas.price import IndicatorSnapshotBase
 from app.services.compute.group import (
     _indicator_cache,
     compute_and_cache_indicators,
@@ -134,7 +135,7 @@ class TestComputeAndCacheIndicators:
 
         result = await compute_and_cache_indicators(db, group_id=1)
 
-        assert result["NEW"] == {"values": {}}
+        assert result["NEW"] == IndicatorSnapshotBase()
 
         _indicator_cache._data.clear()
 

--- a/backend/tests/services/test_holdings_service.py
+++ b/backend/tests/services/test_holdings_service.py
@@ -4,8 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.services.holdings_service import get_holdings, get_holdings_indicators
 from app.schemas.price import SymbolIndicatorSnapshot
+from app.services.holdings_service import get_holdings, get_holdings_indicators
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 

--- a/backend/tests/services/test_holdings_service.py
+++ b/backend/tests/services/test_holdings_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.services.holdings_service import get_holdings, get_holdings_indicators
+from app.schemas.price import SymbolIndicatorSnapshot
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
@@ -87,8 +88,8 @@ async def test_get_holdings_indicators_returns_snapshots(
     mock_get_asset.return_value = _make_etf_asset("SPY")
     mock_fetch.holdings = AsyncMock(); mock_fetch.holdings.return_value = _sample_holdings()
     snapshots = [
-        {"symbol": "AAPL", "currency": "USD", "close": 180.0, "change_pct": 1.0, "values": {"rsi": 55.0}},
-        {"symbol": "MSFT", "currency": "USD", "close": 400.0, "change_pct": 0.5, "values": {"rsi": 60.0}},
+        SymbolIndicatorSnapshot(**{"symbol": "AAPL", "currency": "USD", "close": 180.0, "change_pct": 1.0, "values": {"rsi": 55.0}}),
+        SymbolIndicatorSnapshot(**{"symbol": "MSFT", "currency": "USD", "close": 400.0, "change_pct": 0.5, "values": {"rsi": 60.0}}),
     ]
     mock_compute.return_value = snapshots
 

--- a/backend/tests/services/test_indicators_technical.py
+++ b/backend/tests/services/test_indicators_technical.py
@@ -108,9 +108,8 @@ def test_nefi_snapshot_crossover_signal():
     df = _make_price_df(300)
     indicators = compute_indicators(df)
     snapshot = build_indicator_snapshot(indicators)
-    assert "values" in snapshot
-    assert "nefi_signal" in snapshot["values"]
-    assert snapshot["values"]["nefi_signal"] in ("bullish", "bearish", None)
+    assert "nefi_signal" in snapshot.values
+    assert snapshot.values["nefi_signal"] in ("bullish", "bearish", None)
 
 
 def test_cmf_range():
@@ -167,9 +166,8 @@ def test_cmf_snapshot_derived():
     df = _make_price_df(200)
     indicators = compute_indicators(df)
     snapshot = build_indicator_snapshot(indicators)
-    assert "values" in snapshot
-    assert "cmf_signal" in snapshot["values"]
-    assert snapshot["values"]["cmf_signal"] in ("buying", "selling", None)
+    assert "cmf_signal" in snapshot.values
+    assert snapshot.values["cmf_signal"] in ("buying", "selling", None)
 
 
 def _make_volume_df(volumes: list[float]) -> pd.DataFrame:
@@ -233,8 +231,8 @@ def test_rvol_snapshot_derived():
     """RVOL snapshot should expose the numeric value and a qualitative state."""
     df = _make_volume_df([1_000_000.0] * 25 + [2_500_000.0])
     snapshot = build_indicator_snapshot(compute_indicators(df))
-    assert snapshot["values"]["rvol"] == pytest.approx(2.5)
-    assert snapshot["values"]["rvol_state"] == "high"
+    assert snapshot.values["rvol"] == pytest.approx(2.5)
+    assert snapshot.values["rvol_state"] == "high"
 
 
 def test_rvol_state_thresholds():

--- a/backend/tests/services/test_indicators_volatility.py
+++ b/backend/tests/services/test_indicators_volatility.py
@@ -150,10 +150,9 @@ def test_adx_snapshot_derived():
     df = _make_price_df(200)
     indicators = compute_indicators(df)
     snapshot = build_indicator_snapshot(indicators)
-    assert "values" in snapshot
-    assert "adx_trend" in snapshot["values"]
+    assert "adx_trend" in snapshot.values
     # Should be one of the valid classifications or None
-    assert snapshot["values"]["adx_trend"] in ("strong", "weak", "absent", None)
+    assert snapshot.values["adx_trend"] in ("strong", "weak", "absent", None)
 
 
 def test_atr_pct_in_snapshot():
@@ -161,10 +160,9 @@ def test_atr_pct_in_snapshot():
     df = _make_price_df(200)
     indicators = compute_indicators(df)
     snapshot = build_indicator_snapshot(indicators)
-    assert "values" in snapshot
-    assert "atr_pct" in snapshot["values"]
-    assert snapshot["values"]["atr_pct"] is not None
-    assert snapshot["values"]["atr_pct"] > 0
+    assert "atr_pct" in snapshot.values
+    assert snapshot.values["atr_pct"] is not None
+    assert snapshot.values["atr_pct"] > 0
 
 
 def test_atr_pct_calculation():
@@ -172,10 +170,10 @@ def test_atr_pct_calculation():
     df = _make_price_df(200)
     indicators = compute_indicators(df)
     snapshot = build_indicator_snapshot(indicators)
-    atr_val = snapshot["values"]["atr"]
-    close_val = snapshot["close"]
+    atr_val = snapshot.values["atr"]
+    close_val = snapshot.close
     expected = round(atr_val / close_val * 100, 2)
-    assert snapshot["values"]["atr_pct"] == expected
+    assert snapshot.values["atr_pct"] == expected
 
 
 def test_atr_pct_none_when_close_zero():
@@ -259,9 +257,8 @@ def test_chop_snapshot_derived():
     df = _make_price_df(200)
     indicators = compute_indicators(df)
     snapshot = build_indicator_snapshot(indicators)
-    assert "values" in snapshot
-    assert "chop_state" in snapshot["values"]
-    assert snapshot["values"]["chop_state"] in ("choppy", "trending", "neutral", None)
+    assert "chop_state" in snapshot.values
+    assert snapshot.values["chop_state"] in ("choppy", "trending", "neutral", None)
 
 
 def test_vnr_length():
@@ -291,8 +288,7 @@ def test_vnr_in_snapshot():
     """vnr should appear in snapshot values."""
     df = _make_price_df(200)
     snapshot = build_indicator_snapshot(compute_indicators(df))
-    assert "values" in snapshot
-    assert "vnr" in snapshot["values"]
+    assert "vnr" in snapshot.values
 
 
 def test_vnr_in_all_output_fields():
@@ -349,8 +345,8 @@ def test_vnr_sigma_in_snapshot():
     """The forward vol forecast is exposed so the UI can score an in-progress day."""
     df = _make_price_df(200)
     snapshot = build_indicator_snapshot(compute_indicators(df))
-    assert "vnr_sigma" in snapshot["values"]
-    assert snapshot["values"]["vnr_sigma"] > 0
+    assert "vnr_sigma" in snapshot.values
+    assert snapshot.values["vnr_sigma"] > 0
 
 
 def test_vnr_sigma_reconstructs_live_move():
@@ -363,7 +359,7 @@ def test_vnr_sigma_reconstructs_live_move():
     df = _make_price_df(200)
     # DB state = everything up to but excluding the final ("today") bar.
     db_snapshot = build_indicator_snapshot(compute_indicators(df.iloc[:-1]))
-    vnr_sigma = db_snapshot["values"]["vnr_sigma"]
+    vnr_sigma = db_snapshot.values["vnr_sigma"]
 
     closes = df["close"]
     today_return = closes.iloc[-1] / closes.iloc[-2] - 1
@@ -472,8 +468,8 @@ def test_vnr_regression_issue_559():
     result = compute_indicators(df)
     assert result["vnr_gap_sessions"].iloc[-1] == 2
     snapshot = build_indicator_snapshot(result)
-    assert snapshot["values"]["vnr"] is None
-    assert snapshot["values"]["vnr_gap_sessions"] == 2
+    assert snapshot.values["vnr"] is None
+    assert snapshot.values["vnr_gap_sessions"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -620,8 +616,8 @@ def test_snapshot_change_pct_suppressed_on_gap_bar():
     suppressed σ-Move next to it."""
     df = _trending_gapped_df(drop_offset=2)  # hole right before the last bar
     snapshot = build_indicator_snapshot(compute_indicators(df))
-    assert snapshot["values"]["vnr"] is None
-    assert snapshot["change_pct"] is None
+    assert snapshot.values["vnr"] is None
+    assert snapshot.change_pct is None
     # Contiguous series still reports a change.
     full = _make_price_df(100)
-    assert build_indicator_snapshot(compute_indicators(full))["change_pct"] is not None
+    assert build_indicator_snapshot(compute_indicators(full)).change_pct is not None

--- a/backend/tests/services/test_quote_service.py
+++ b/backend/tests/services/test_quote_service.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.domain import AssetRef
-from app.schemas.quote import Quote
 from app.schemas.intraday import IntradayBar
+from app.schemas.quote import Quote
 from app.services.quote_service import get_quotes, quote_event_generator
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")

--- a/backend/tests/services/test_quote_service.py
+++ b/backend/tests/services/test_quote_service.py
@@ -196,6 +196,9 @@ async def test_stream_adaptive_interval_regular():
         patch("app.services.quote_service.get_price_provider", return_value=mock_prov),
         patch("app.services.quote_service.asyncio.sleep", side_effect=mock_sleep),
         patch("app.services.quote_service.get_intraday_bars", new_callable=AsyncMock, return_value={}),
+        # Pin the venue schedule: the real hint is wall-clock dependent and
+        # caps the sleep to "seconds until the next bell" near an open.
+        patch("app.services.quote_service.schedule_poll_hint", return_value=("open", None)),
     ):
         MockRepo.return_value.list_in_any_group_refs = AsyncMock(return_value=[AssetRef("AAPL", 1)])
         async for _ in quote_event_generator():
@@ -226,6 +229,10 @@ async def test_stream_adaptive_interval_closed():
         patch("app.services.quote_service.get_price_provider", return_value=mock_prov),
         patch("app.services.quote_service.asyncio.sleep", side_effect=mock_sleep),
         patch("app.services.quote_service.get_intraday_bars", new_callable=AsyncMock, return_value={}),
+        # Pin the venue schedule: the real hint is wall-clock dependent and
+        # caps the sleep to "seconds until the next bell" near an open —
+        # this test failed for 5 real-world minutes before every NYSE open.
+        patch("app.services.quote_service.schedule_poll_hint", return_value=("closed", None)),
     ):
         MockRepo.return_value.list_in_any_group_refs = AsyncMock(return_value=[AssetRef("AAPL", 1)])
         async for _ in quote_event_generator():


### PR DESCRIPTION
Final checklist item of #580 — closes the tracking issue (auto-close lands on dev→main promotion, as with the rest of the train).

## Design: open `values`, typed shell

A rigid per-field model would be wrong here: `values` keys are driven by `INDICATOR_REGISTRY` (31 output fields + 8 `snapshot_derived`), the fundamentals cache merges 5 more keys in **post-construction into cached instances**, and the frontend reads everything by computed string key. So the existing `IndicatorSnapshotBase` (open `values: dict[str, float | str | None]`) is promoted from response-only into the service layer, and the model hierarchy grows two steps:

```
IndicatorSnapshotBase            close / change_pct / values
└─ CurrencyIndicatorSnapshot     + currency   (batch-data snapshot field)
   └─ SymbolIndicatorSnapshot    + symbol     (what compute_batch_indicator_snapshots returns)
```

## Changes

- `build_indicator_snapshot -> IndicatorSnapshotBase`; the three degenerate partial dict shapes (`{}`, `{"values": {}}`, symbol/currency-only) collapse into all-default instances.
- `compute_and_cache_indicators` / `compute_indicators_for_symbols` / the TTL cache carry `dict[str, IndicatorSnapshotBase]`. The cache hands out instances by reference and the fundamentals merge mutates `.values` in place — deliberately **no `frozen=True`**, with a comment at the cache site.
- `fundamentals_cache` mergers switch to attribute mutation (the dead `values_key` param is gone).
- `SymbolBatchData.snapshot: CurrencyIndicatorSnapshot` — a `SymbolIndicatorSnapshot` is stored and the declared type strips the redundant `symbol` on serialization, reproducing the old explicit dict-strip byte for byte. Closes the last `#580` note in `batch_data.py`.
- Routers: holdings validates via `model_validate(..., from_attributes=True)`; pseudo-ETF constituents build from `model_dump()` + `name`/`weight_pct`.
- `scripts/export_indicator_contract.py` reads attributes; key names unchanged so no contract regeneration is needed.

## Verification

- Full backend suite: **806 passed**. Snapshot mocks/asserts converted across 6 test files; integration tests pinning the JSON pass unchanged.
- Live smoke on all three boundaries: group indicators (`{close, change_pct, values}`), batch data snapshot (`{close, change_pct, currency, values}` — **no** `symbol`), holdings indicators (+ `symbol`). Identical to before.

## Flaky-test fix (pre-existing, surfaced today)

`test_stream_adaptive_interval_{regular,closed}` never pinned the wall clock; the venue poll hint caps the sleep to "seconds until the next bell", so the closed-market test failed for the 5 real-world minutes before every NYSE open (today's 13:27 UTC run: got 182, expected 300 — correct behavior, wrong test). Both now patch `schedule_poll_hint`.

## Note found along the way

`backend/indicator.contract.json` / `indicator.fixtures.json` are **stale relative to the current registry** — regenerating adds rvol (and friends) that shipped after the last export. Not touched in this PR (unrelated drift); worth a separate regeneration pass for the companion-app fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)