### PR TITLE
fix(backend): batch snapshots fetch warmup-covering history so NEFI fields populate

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -585,6 +585,21 @@ def get_max_warmup_periods() -> int:
     return max((d.warmup_periods for d in INDICATOR_REGISTRY.values()), default=0)
 
 
+def _batch_history_period() -> str:
+    """Smallest canonical fetch period whose calendar span covers WARMUP_DAYS.
+
+    The batch snapshot path fetches by provider period string, so the period
+    must cover the registry's largest warmup (NEFI's 200-bar volume baseline —
+    a shorter fetch leaves nefi_long/nefi_signal permanently null).
+    """
+    from app.constants import PERIOD_DAYS, WARMUP_DAYS
+
+    for period, days in sorted(PERIOD_DAYS.items(), key=lambda kv: kv[1]):
+        if days >= WARMUP_DAYS:
+            return period
+    return max(PERIOD_DAYS, key=lambda p: PERIOD_DAYS[p])
+
+
 # ---------------------------------------------------------------------------
 # Computation
 # ---------------------------------------------------------------------------
@@ -729,7 +744,8 @@ async def compute_batch_indicator_snapshots(
 ) -> list[SymbolIndicatorSnapshot]:
     """Compute indicator snapshots for multiple symbols in batch.
 
-    Fetches ~3 months of history and currencies via the configured price
+    Fetches enough history to cover indicator warmup (see
+    :func:`_batch_history_period`) and currencies via the configured price
     provider, then computes indicators and builds snapshots for each symbol.
 
     Returns one :class:`SymbolIndicatorSnapshot` per symbol; symbols without
@@ -739,7 +755,7 @@ async def compute_batch_indicator_snapshots(
         return []
 
     provider = get_price_provider()
-    histories = await provider.batch_fetch_history(symbols, period="3mo")
+    histories = await provider.batch_fetch_history(symbols, period=_batch_history_period())
     currencies = await provider.batch_fetch_currencies(symbols)
 
     results: list[SymbolIndicatorSnapshot] = []

--- a/backend/tests/services/test_indicators_core.py
+++ b/backend/tests/services/test_indicators_core.py
@@ -1,8 +1,20 @@
 """Registry-level indicator tests — cross-cutting machinery that exercises the
 whole INDICATOR_REGISTRY rather than any single indicator."""
 
-from app.services.compute.indicators import compute_indicators, get_all_output_fields
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.constants import PERIOD_DAYS, WARMUP_DAYS
+from app.services.compute.indicators import (
+    _batch_history_period,
+    compute_batch_indicator_snapshots,
+    compute_indicators,
+    get_all_output_fields,
+)
 from tests.helpers import make_price_df as _make_price_df
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 def test_compute_indicators_columns():
@@ -25,3 +37,33 @@ def test_atr_adx_in_all_output_fields():
     assert "adx" in fields
     assert "plus_di" in fields
     assert "minus_di" in fields
+
+
+def test_batch_history_period_covers_max_warmup():
+    """The batch fetch period must span the registry's largest warmup.
+
+    Regression for #601: a hardcoded "3mo" fetch (~63 bars) left NEFI's
+    200-bar volume baseline unfilled, so nefi_long/nefi_signal were null
+    on every live-fetch snapshot path.
+    """
+    assert PERIOD_DAYS[_batch_history_period()] >= WARMUP_DAYS
+
+
+async def test_batch_snapshots_fetch_enough_history_for_nefi():
+    """compute_batch_indicator_snapshots yields non-null NEFI fields given
+    warmup-covering history — and requests a period that provides it."""
+    provider = MagicMock()
+    provider.batch_fetch_history = AsyncMock(return_value={"AAPL": _make_price_df(250)})
+    provider.batch_fetch_currencies = AsyncMock(return_value={"AAPL": "USD"})
+
+    with patch(
+        "app.services.compute.indicators.get_price_provider", return_value=provider,
+    ):
+        results = await compute_batch_indicator_snapshots(["AAPL"])
+
+    requested_period = provider.batch_fetch_history.await_args.kwargs["period"]
+    assert PERIOD_DAYS[requested_period] >= WARMUP_DAYS
+
+    (snap,) = results
+    assert snap.values.get("nefi_long") is not None
+    assert snap.values.get("nefi_signal") is not None


### PR DESCRIPTION
## Summary
- `compute_batch_indicator_snapshots` hardcoded `period="3mo"` (~63 bars) while NEFI declares `long_vol=200` — its 200-bar rolling volume baseline never filled, so **`nefi_long`/`nefi_signal` were always null** on the live-fetch snapshot paths (ETF holdings indicators, pseudo-ETF constituent analysis).
- New `_batch_history_period()` picks the smallest canonical period covering `WARMUP_DAYS` (currently resolves to `2y`), so the fetch tracks the registry — a future warmup increase can't silently starve this path again.
- The DB-backed path was already fine: NEFI declares `warmup_periods=200`, so `WARMUP_DAYS` (200 × 2.3 = 460) covers it.

## Test plan
- [x] New regression tests: `_batch_history_period` covers `WARMUP_DAYS`; batch snapshots request a covering period and yield non-null `nefi_long`/`nefi_signal` given 250 bars
- [x] Full suite: 808 passed
- [x] `ruff check .` clean

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)