### PR TITLE
feat(backend): GET /api/market/phases — scheduled phase per in-use venue calendar

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from app.routers import (
     groups,
     holdings,
     indicators,
+    market,
     note,
     portfolio,
     prices,
@@ -194,6 +195,7 @@ app.include_router(portfolio.router)
 app.include_router(prices.router)
 app.include_router(holdings.router)
 app.include_router(indicators.router)
+app.include_router(market.router)
 app.include_router(note.router)
 app.include_router(thesis.router)
 app.include_router(annotations.router)

--- a/backend/app/routers/market.py
+++ b/backend/app/routers/market.py
@@ -1,0 +1,23 @@
+"""Market schedule endpoints — venue phases from the trading calendars."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.market import CalendarPhase
+from app.services.market_phase_service import collect_market_phases
+
+router = APIRouter(prefix="/api/market", tags=["market"])
+
+
+@router.get(
+    "/phases",
+    summary="Scheduled phase per in-use venue calendar",
+    response_model=dict[str, CalendarPhase],
+)
+async def get_market_phases(db: AsyncSession = Depends(get_db)):
+    """Deterministic, calendar-derived phase (and next transition) for every
+    venue calendar used by grouped assets. Works even when the quote feed is
+    degraded; the SSE stream's live market_state should win when present.
+    """
+    return await collect_market_phases(db)

--- a/backend/app/schemas/market.py
+++ b/backend/app/schemas/market.py
@@ -1,0 +1,23 @@
+"""Response models for market schedule endpoints."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.domain.phases import Phase
+
+
+class CalendarPhase(BaseModel):
+    """Scheduled trading phase of one venue calendar.
+
+    Deterministic and quote-feed-independent: derived from the venue's
+    exchange calendar (half-day and holiday aware), so it keeps answering
+    when the live quote feed is degraded. The live ``market_state`` from the
+    SSE stream remains authoritative when present — it knows about halts.
+    """
+
+    phase: Phase = Field(description="Scheduled phase right now (premarket/open/aftermarket/closed)")
+    next_change_at: datetime | None = Field(
+        description="When the scheduled phase next changes (UTC); the venue's next bell "
+        "or extended-hours edge. None when the calendar can't answer."
+    )

--- a/backend/app/schemas/market.py
+++ b/backend/app/schemas/market.py
@@ -21,3 +21,8 @@ class CalendarPhase(BaseModel):
         description="When the scheduled phase next changes (UTC); the venue's next bell "
         "or extended-hours edge. None when the calendar can't answer."
     )
+    symbols: list[str] = Field(
+        description="Grouped symbols trading on this calendar — the symbol→venue mapping "
+        "lives backend-side (AssetRef), so clients get it here instead of re-deriving it "
+        "from ticker shapes."
+    )

--- a/backend/app/services/market_calendar/venue.py
+++ b/backend/app/services/market_calendar/venue.py
@@ -147,6 +147,47 @@ class Venue:
                 return Phase.PREMARKET
         return Phase.CLOSED
 
+    def next_phase_change(self, at: datetime | None = None) -> datetime | None:
+        """When :meth:`phase` will next report a different phase.
+
+        The boundaries mirror phase()'s exactly: close for OPEN, the
+        extended-hours edges for AFTERMARKET/PREMARKET, and the earlier of
+        premarket-start / open for CLOSED. None when the schedule can't be
+        answered (same fail-safe posture as everything else here).
+        """
+        ts = _as_utc(at)
+        phase = self.phase(ts)
+        if phase is None:
+            return None
+        try:
+            if phase is Phase.OPEN:
+                candidate = self._cal.next_close(ts)
+            else:
+                # Same one-minute nudge as phase(): at the exact close instant,
+                # previous_close must mean "the close that just happened".
+                prev_close = self._cal.previous_close(ts + pd.Timedelta(minutes=1))
+                nxt_open = self._cal.next_open(ts)
+                if phase is Phase.AFTERMARKET and self.extended_hours is not None:
+                    candidate = prev_close + self.extended_hours.post_offset
+                elif phase is Phase.PREMARKET:
+                    candidate = nxt_open
+                elif (
+                    # CLOSED: premarket start if this venue has one and it's
+                    # still ahead, else the opening bell.
+                    self.extended_hours is not None
+                    and ts < (pre_start := nxt_open - self.extended_hours.pre_offset)
+                ):
+                    candidate = pre_start
+                else:
+                    candidate = nxt_open
+        except Exception:
+            return None
+        # Always-open calendars (24/7 crypto) have a next_close that isn't a
+        # phase change at all — claiming one would be the schedule lying.
+        if self.phase(candidate) == phase:
+            return None
+        return candidate.to_pydatetime()
+
 
 # One Venue per calendar name, shared by every Symbol that resolves to it.
 _venues: dict[str, Venue | None] = {}

--- a/backend/app/services/market_phase_service.py
+++ b/backend/app/services/market_phase_service.py
@@ -17,18 +17,23 @@ async def collect_market_phases(db: AsyncSession) -> dict[str, CalendarPhase]:
     """
     refs = await AssetRepository(db).list_in_any_group_refs()
 
-    out: dict[str, CalendarPhase] = {}
-    seen: set[str] = set()
+    by_calendar: dict[str, list] = {}
     for ref in refs:
         name = ref.calendar_name
-        if name is None or name in seen:
-            continue
-        seen.add(name)
-        venue = ref.venue
+        if name is not None:
+            by_calendar.setdefault(name, []).append(ref)
+
+    out: dict[str, CalendarPhase] = {}
+    for name, cal_refs in by_calendar.items():
+        venue = cal_refs[0].venue
         if venue is None:
             continue
         phase = venue.phase()
         if phase is None:
             continue
-        out[name] = CalendarPhase(phase=phase, next_change_at=venue.next_phase_change())
+        out[name] = CalendarPhase(
+            phase=phase,
+            next_change_at=venue.next_phase_change(),
+            symbols=sorted(r.symbol for r in cal_refs),
+        )
     return out

--- a/backend/app/services/market_phase_service.py
+++ b/backend/app/services/market_phase_service.py
@@ -1,0 +1,34 @@
+"""Scheduled market phases for the venue calendars the portfolio actually uses."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.asset_repo import AssetRepository
+from app.schemas.market import CalendarPhase
+
+
+async def collect_market_phases(db: AsyncSession) -> dict[str, CalendarPhase]:
+    """Phase + next transition per in-use venue calendar.
+
+    "In use" = the calendars of assets in any group (the same roster the SSE
+    quote stream serves). Follows the market_calendar package's fail-safe
+    convention: a symbol with no resolvable calendar, or a calendar that
+    can't answer, is simply omitted — callers fall back to the live quote
+    feed's market_state for those.
+    """
+    refs = await AssetRepository(db).list_in_any_group_refs()
+
+    out: dict[str, CalendarPhase] = {}
+    seen: set[str] = set()
+    for ref in refs:
+        name = ref.calendar_name
+        if name is None or name in seen:
+            continue
+        seen.add(name)
+        venue = ref.venue
+        if venue is None:
+            continue
+        phase = venue.phase()
+        if phase is None:
+            continue
+        out[name] = CalendarPhase(phase=phase, next_change_at=venue.next_phase_change())
+    return out

--- a/backend/tests/integration/test_market.py
+++ b/backend/tests/integration/test_market.py
@@ -26,6 +26,8 @@ async def test_market_phases_lists_in_use_calendars(client, db):
     us = AssetRef("AAPL").calendar_name
     ams = AssetRef("IWDA.AS").calendar_name
     assert set(data) == {us, ams}
+    assert data[us]["symbols"] == ["AAPL", "MSFT"]
+    assert data[ams]["symbols"] == ["IWDA.AS"]
     for entry in data.values():
         assert entry["phase"] in PHASES
         if entry["next_change_at"] is not None:

--- a/backend/tests/integration/test_market.py
+++ b/backend/tests/integration/test_market.py
@@ -1,0 +1,49 @@
+"""Tests for GET /api/market/phases."""
+
+from datetime import datetime
+
+import pytest
+
+from app.domain import AssetRef
+from tests.helpers import seed_asset_with_prices
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+PHASES = {"premarket", "open", "aftermarket", "closed"}
+
+
+async def test_market_phases_lists_in_use_calendars(client, db):
+    """Grouped assets' calendars appear, deduped, with a valid phase."""
+    await seed_asset_with_prices(db, "AAPL", n_days=5)
+    await seed_asset_with_prices(db, "MSFT", n_days=5)  # same calendar — must dedupe
+    await seed_asset_with_prices(db, "IWDA.AS", n_days=5)
+    await db.commit()
+
+    resp = await client.get("/api/market/phases")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    us = AssetRef("AAPL").calendar_name
+    ams = AssetRef("IWDA.AS").calendar_name
+    assert set(data) == {us, ams}
+    for entry in data.values():
+        assert entry["phase"] in PHASES
+        if entry["next_change_at"] is not None:
+            # ISO datetime, parseable and tz-aware
+            assert datetime.fromisoformat(entry["next_change_at"]).tzinfo is not None
+
+
+async def test_market_phases_empty_without_grouped_assets(client):
+    resp = await client.get("/api/market/phases")
+    assert resp.status_code == 200
+    assert resp.json() == {}
+
+
+async def test_market_phases_skips_ungrouped_assets(client, db):
+    """Assets outside any group don't contribute their calendar."""
+    await seed_asset_with_prices(db, "AAPL", n_days=5, add_to_group=False)
+    await db.commit()
+
+    resp = await client.get("/api/market/phases")
+    assert resp.status_code == 200
+    assert resp.json() == {}

--- a/backend/tests/services/test_market_calendar.py
+++ b/backend/tests/services/test_market_calendar.py
@@ -202,6 +202,35 @@ def test_any_venue_open_us_holiday():
     assert any_venue_open(["AAPL"], _utc(2024, 7, 4, 15, 0)) is False
 
 
+def test_next_phase_change_us_regular_day():
+    """Each phase's next transition on Wednesday 2024-04-03 (regular 13:30–20:00 UTC)."""
+    venue = AssetRef("AAPL").venue
+    # Open → the closing bell.
+    assert venue.next_phase_change(_utc(2024, 4, 3, 15, 0)) == _utc(2024, 4, 3, 20, 0)
+    # Premarket → the opening bell.
+    assert venue.next_phase_change(_utc(2024, 4, 3, 12, 0)) == _utc(2024, 4, 3, 13, 30)
+    # Aftermarket → close + 4h (20:00 ET = 00:00 UTC next day).
+    assert venue.next_phase_change(_utc(2024, 4, 3, 21, 0)) == _utc(2024, 4, 4, 0, 0)
+    # Closed overnight → next premarket start (04:00 ET = 08:00 UTC).
+    assert venue.next_phase_change(_utc(2024, 4, 4, 1, 0)) == _utc(2024, 4, 4, 8, 0)
+
+
+def test_next_phase_change_venue_without_extended_hours():
+    """No extended session → closed transitions straight at the opening bell."""
+    venue = AssetRef("IWDA.AS").venue
+    # XAMS regular hours 09:00–17:30 CEST = 07:00–15:30 UTC in April.
+    assert venue.next_phase_change(_utc(2024, 4, 3, 16, 0)) == _utc(2024, 4, 4, 7, 0)
+    assert venue.next_phase_change(_utc(2024, 4, 3, 10, 0)) == _utc(2024, 4, 3, 15, 30)
+
+
+def test_next_phase_change_always_open_venue_has_none():
+    """A 24/7 calendar never changes phase — pretending midnight is a
+    transition would be the schedule lying."""
+    venue = AssetRef("BTC-USD").venue
+    assert venue.phase(_utc(2024, 4, 6, 12, 0)) == "open"
+    assert venue.next_phase_change(_utc(2024, 4, 6, 12, 0)) is None
+
+
 def test_any_venue_open_fails_open_on_unknown_venue():
     """An unresolvable symbol must never let the gate block real work."""
     assert any_venue_open(["FOO.XX"], _utc(2024, 4, 6, 12, 0)) is True


### PR DESCRIPTION
## Summary
- New endpoint returning `{calendar: {phase, next_change_at}}` for the venue calendars of grouped assets (same roster as the SSE stream). Backend prerequisite for the dense-board homepage (#604): a deterministic market-state fallback that keeps answering when the quote feed is degraded, plus the "next bell" for tile tooltips. Live `market_state` from SSE still wins when present — it knows about halts.
- `Venue.next_phase_change()`: computes when `phase()` next reports something different, mirroring its boundaries exactly (closing bell, extended-hours edges incl. the half-day-anchored windows, premarket start). Always-open calendars (24/7 crypto) return `None` instead of pretending midnight is a transition.
- `collect_market_phases()` service dedupes to unique calendars and follows the package's fail-safe convention: unresolvable venues are omitted, never guessed.
- Schema (`schemas/market.py`) types `phase` with the `Phase` StrEnum from #598.

## Test plan
- [x] Unit tests: next-transition instants across a US regular day (open/premarket/aftermarket/closed), a no-extended-hours venue, and the 24/7 None case
- [x] Integration tests: dedupe, empty roster, ungrouped assets excluded
- [x] Full suite: 812 passed; `ruff check .` clean
- [x] Live smoke: `curl /api/market/phases` during EU+US open — correct phases, `24/7` reports `next_change_at: null`

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)