### PR TITLE
feat(backend): indicator snapshots report the bar count behind them

### DIFF
--- a/backend/app/schemas/price.py
+++ b/backend/app/schemas/price.py
@@ -75,6 +75,12 @@ class IndicatorSnapshotBase(BaseModel):
 
     close: float | None = Field(default=None, description="Latest closing price")
     change_pct: float | None = Field(default=None, description="1-day percentage change")
+    bars: int | None = Field(
+        default=None,
+        description="Price bars behind this snapshot's computation. Lets clients tell "
+        "'building baseline' (fewer bars than an indicator's warmup, e.g. σ-Move's 60 "
+        "sessions) apart from other null-indicator causes. None when nothing was computed.",
+    )
     values: dict[str, float | str | None] = Field(
         default_factory=dict,
         description="Indicator values keyed by field name (includes derived fields like macd_signal_dir, bb_position)",

--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -97,7 +97,7 @@ async def _compute_snapshots_for_refs(
     for asset_id, ref in by_id.items():
         prices = grouped.get(asset_id, [])
         if len(prices) < 26:  # Need at least MACD slow period
-            out[ref.symbol] = IndicatorSnapshotBase()
+            out[ref.symbol] = IndicatorSnapshotBase(bars=len(prices))
             continue
 
         df = prices_to_df(prices)

--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -612,7 +612,7 @@ def build_indicator_snapshot(indicators: pd.DataFrame) -> IndicatorSnapshotBase:
     fields) in ``values``. Insufficient history yields an all-default snapshot.
     """
     if indicators.empty or len(indicators) < 2:
-        return IndicatorSnapshotBase()
+        return IndicatorSnapshotBase(bars=len(indicators))
 
     latest = indicators.iloc[-1]
     prev_close = indicators.iloc[-2]["close"]
@@ -638,6 +638,7 @@ def build_indicator_snapshot(indicators: pd.DataFrame) -> IndicatorSnapshotBase:
     return IndicatorSnapshotBase(
         close=round(latest["close"], 2),
         change_pct=change_pct,
+        bars=len(indicators),
         values=values,
     )
 
@@ -763,15 +764,17 @@ async def compute_batch_indicator_snapshots(
         currency = currencies.get(sym, "USD")
         df = histories.get(sym)
         if df is None or df.empty or len(df) < 2:
-            results.append(SymbolIndicatorSnapshot(symbol=sym, currency=currency))
+            results.append(SymbolIndicatorSnapshot(
+                symbol=sym, currency=currency, bars=0 if df is None else len(df),
+            ))
             continue
 
         venue = AssetRef(sym).venue
         sessions = venue.session_dates_for_index(df.index) if venue else None
         snapshot = build_indicator_snapshot(compute_indicators(df, session_dates=sessions))
         results.append(SymbolIndicatorSnapshot(
-            symbol=sym, currency=currency,
-            close=snapshot.close, change_pct=snapshot.change_pct, values=snapshot.values,
+            symbol=sym, currency=currency, close=snapshot.close,
+            change_pct=snapshot.change_pct, bars=snapshot.bars, values=snapshot.values,
         ))
 
     # Fundamentals are merged from cache by the caller (non-blocking).

--- a/backend/tests/integration/test_groups.py
+++ b/backend/tests/integration/test_groups.py
@@ -166,6 +166,7 @@ async def test_indicators_has_expected_fields(client, db):
     # Full snapshot has close, change_pct, and nested values
     assert "values" in ind
     assert "close" in ind
+    assert ind["bars"] > 26  # full seeded history behind the snapshot
     from app.services.compute.indicators import get_all_output_fields
     expected_fields = set(get_all_output_fields())
     assert expected_fields.issubset(set(ind["values"].keys()))
@@ -209,8 +210,10 @@ async def test_indicators_null_with_insufficient_data(client, db):
     resp = await client.get(f"/api/groups/{gid}/indicators")
     data = resp.json()
     ind = data["TINY"]
-    # With insufficient data, values dict should be empty
+    # With insufficient data, values dict should be empty — but the bar count
+    # still says how far the baseline has built (#603).
     assert ind["values"] == {}
+    assert ind["bars"] == 5
 
 
 async def test_indicators_empty_group(client, db):

--- a/backend/tests/services/test_compute_group.py
+++ b/backend/tests/services/test_compute_group.py
@@ -135,7 +135,9 @@ class TestComputeAndCacheIndicators:
 
         result = await compute_and_cache_indicators(db, group_id=1)
 
-        assert result["NEW"] == IndicatorSnapshotBase()
+        # Degenerate snapshot still reports how many bars it had — the
+        # "building baseline · N/60" copy needs the numerator (#603).
+        assert result["NEW"] == IndicatorSnapshotBase(bars=10)
 
         _indicator_cache._data.clear()
 

--- a/backend/tests/services/test_indicators_core.py
+++ b/backend/tests/services/test_indicators_core.py
@@ -8,6 +8,7 @@ import pytest
 from app.constants import PERIOD_DAYS, WARMUP_DAYS
 from app.services.compute.indicators import (
     _batch_history_period,
+    build_indicator_snapshot,
     compute_batch_indicator_snapshots,
     compute_indicators,
     get_all_output_fields,
@@ -28,6 +29,16 @@ def test_compute_indicators_length():
     df = _make_price_df(100)
     result = compute_indicators(df)
     assert len(result) == 100
+
+
+def test_snapshot_reports_bar_count():
+    """Every snapshot carries the bars behind it — the numerator of the
+    "building baseline · N/60" copy on the dense board (#603)."""
+    snap = build_indicator_snapshot(compute_indicators(_make_price_df(100)))
+    assert snap.bars == 100
+    tiny = build_indicator_snapshot(compute_indicators(_make_price_df(1)))
+    assert tiny.bars == 1
+    assert tiny.close is None  # degenerate snapshot, but bars still reported
 
 
 def test_atr_adx_in_all_output_fields():


### PR DESCRIPTION
## Summary
- Adds `bars: int | None` to `IndicatorSnapshotBase` — the number of price bars behind the snapshot's computation — populated on every path: full snapshots, the DB-backed `< 26` degenerate branch, and the live-fetch batch path (including no-data symbols, which report `0`).
- Backend prerequisite for the dense board (#604): the "building baseline · N/60 bars" broken-σ copy needs the numerator; the 60 denominator already ships per indicator (`warmup`) in the exported indicator contract. Feed-behind and session-gap states were already API-derivable — this was the last gap.
- Additive wire change (house style `Field(description=...)`); no existing key-set pins in the integration suite, all shapes otherwise unchanged.

## Test plan
- [x] Unit: `build_indicator_snapshot` reports bars for full and degenerate frames; group compute's short-history branch carries `bars=10`
- [x] Integration: group indicators payload includes `bars` (full history `> 26`; 5-bar asset reports `5` with empty `values`)
- [x] Full suite: 807 passed; `ruff check .` clean
- [x] Live smoke: `/api/groups/5/indicators` → `NKT.CO … bars: 370`

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)