### PR TITLE
Board tile detail: tooltip, session icons, and the load audit

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.routers import (
     pseudo_etfs,
     quotes,
     search,
+    sparklines,
     symbol_sources,
     system,
     tags,
@@ -204,6 +205,7 @@ app.include_router(pseudo_etf_analysis.router)
 app.include_router(quotes.router)
 app.include_router(settings_router.router)
 app.include_router(search.router)
+app.include_router(sparklines.router)
 app.include_router(symbol_sources.router)
 app.include_router(system.router)
 

--- a/backend/app/routers/sparklines.py
+++ b/backend/app/routers/sparklines.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.constants import PeriodType
+from app.database import get_db
+from app.schemas.price import SparklinePointResponse
+from app.services.compute.group import get_sparklines_for_symbols
+
+router = APIRouter(prefix="/api/sparklines", tags=["sparklines"])
+
+
+@router.get(
+    "",
+    response_model=dict[str, list[SparklinePointResponse]],
+    summary="Batch close prices for arbitrary tracked symbols",
+)
+async def batch_sparklines(
+    symbols: list[str] = Query(default=[], description="Tracked ticker symbols"),
+    period: PeriodType = Query("3mo"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Close-price series per symbol, keyed by symbol.
+
+    The symbol-addressed sibling of ``/api/groups/{id}/sparklines``, matching
+    ``/api/indicators``. A caller holding a roster that spans groups makes one
+    request instead of one per group, and symbols with several memberships come
+    back once. Untracked symbols are omitted from the response.
+    """
+    return await get_sparklines_for_symbols(db, symbols, period)

--- a/backend/app/services/compute/group.py
+++ b/backend/app/services/compute/group.py
@@ -36,13 +36,36 @@ async def get_batch_sparklines(
 
     If group_id is None, uses the default group.
     """
-    days = PERIOD_DAYS.get(period, 90)
-    start = date.today() - timedelta(days=days)
-
     if group_id is not None:
         refs = await AssetRepository(db).list_in_group_refs(group_id)
     else:
         refs = await _get_default_group_refs(db)
+    return await _sparklines_for_refs(db, period, refs)
+
+
+async def get_sparklines_for_symbols(
+    db: AsyncSession, symbols: list[str], period: str = "3mo",
+) -> dict[str, list[dict]]:
+    """Close-price sparklines for specific tracked symbols, keyed by symbol.
+
+    The symbol-addressed sibling of the per-group batch, mirroring
+    ``compute_indicators_for_symbols``. A roster that spans several groups is
+    one call here instead of one per group — and symbols that repeat across
+    groups are fetched once, not once per membership. Untracked symbols are
+    omitted (no DB price history).
+    """
+    if not symbols:
+        return {}
+    refs = await AssetRepository(db).list_refs_by_symbols(symbols)
+    return await _sparklines_for_refs(db, period, refs)
+
+
+async def _sparklines_for_refs(
+    db: AsyncSession, period: str, refs: list[AssetRef],
+) -> dict[str, list[dict]]:
+    """Close-price series per symbol over the period, in one price query."""
+    days = PERIOD_DAYS.get(period, 90)
+    start = date.today() - timedelta(days=days)
 
     if not refs:
         return {}

--- a/backend/tests/integration/test_sparklines.py
+++ b/backend/tests/integration/test_sparklines.py
@@ -1,0 +1,72 @@
+"""Tests for GET /api/sparklines — close-price series by symbol set.
+
+The symbol-addressed sibling of /api/groups/{id}/sparklines. What it buys the
+caller is a roster-shaped fetch: one request for symbols spread over several
+groups, and no membership requirement at all.
+"""
+
+import pytest
+
+from tests.helpers import seed_asset_with_prices
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_returns_requested_symbols(client, db):
+    for i, sym in enumerate(["AAPL", "GOOGL", "MSFT"]):
+        await seed_asset_with_prices(db, symbol=sym, base_price=100.0 + i * 50, n_days=200)
+
+    resp = await client.get("/api/sparklines?symbols=AAPL&symbols=MSFT&period=3mo")
+    assert resp.status_code == 200
+    # GOOGL was seeded but not asked for.
+    assert set(resp.json()) == {"AAPL", "MSFT"}
+
+
+async def test_close_only_fields(client, db):
+    await seed_asset_with_prices(db, symbol="AAPL", n_days=200)
+
+    resp = await client.get("/api/sparklines?symbols=AAPL&period=3mo")
+    points = resp.json()["AAPL"]
+    assert len(points) > 0
+    assert set(points[0]) == {"date", "close"}
+
+
+async def test_respects_period(client, db):
+    await seed_asset_with_prices(db, symbol="AAPL", n_days=500)
+
+    short = await client.get("/api/sparklines?symbols=AAPL&period=3mo")
+    long = await client.get("/api/sparklines?symbols=AAPL&period=1y")
+    assert len(long.json()["AAPL"]) > len(short.json()["AAPL"])
+
+
+async def test_spans_groups_in_one_call(client, db):
+    """The point of the endpoint: group membership doesn't shape the fetch.
+
+    One asset sits in the default group, another in no group at all — the board's
+    thesis-only case. Both come back from a single request.
+    """
+    await seed_asset_with_prices(db, symbol="AAPL", n_days=200)
+    await seed_asset_with_prices(db, symbol="NVDA", n_days=200, add_to_group=False)
+
+    resp = await client.get("/api/sparklines?symbols=AAPL&symbols=NVDA&period=3mo")
+    assert set(resp.json()) == {"AAPL", "NVDA"}
+
+
+async def test_untracked_symbols_omitted(client, db):
+    """No price history means no series — the symbol is dropped, not errored."""
+    await seed_asset_with_prices(db, symbol="AAPL", n_days=200)
+
+    resp = await client.get("/api/sparklines?symbols=AAPL&symbols=NOTREAL&period=3mo")
+    assert resp.status_code == 200
+    assert set(resp.json()) == {"AAPL"}
+
+
+async def test_no_symbols_returns_empty(client):
+    resp = await client.get("/api/sparklines?period=3mo")
+    assert resp.status_code == 200
+    assert resp.json() == {}
+
+
+async def test_rejects_unknown_period(client):
+    resp = await client.get("/api/sparklines?symbols=AAPL&period=7y")
+    assert resp.status_code == 422

--- a/claudedocs/board-tile-spec.md
+++ b/claudedocs/board-tile-spec.md
@@ -1,0 +1,261 @@
+# Dense board: session icons, tile tooltip, and a load audit
+
+Against `origin/dev` at `6905986` (*feat(frontend): homepage dense board*). Three independent
+changes plus an audit; they can land separately.
+
+Files in play:
+
+- `frontend/src/pages/portfolio/board/tile.tsx`
+- `frontend/src/pages/portfolio/board/use-board-data.ts`
+- `frontend/src/pages/portfolio/board/board.tsx` (legend only)
+- `frontend/src/lib/queries/groups.ts` (audit fixes)
+
+---
+
+## 1 · Session-state icons: replace sunrise / sunset
+
+### Why
+
+Lucide's `sunrise` and `sunset` are **the same drawing**. Six of their eight paths are
+byte-identical; a seventh (`M12 2v8` vs `M12 10V2`) is the same line drawn backwards, so it
+renders identically. The only visible difference is an 8×4px chevron that flips direction — and
+the tile renders these at 13–16px on a saturated background.
+
+`Sun` and `Moon` work because they differ in **silhouette**: a radial burst versus a solid
+crescent, still legible once the detail is gone. Sunrise and sunset differ only in *internal
+detail*, and at 13px there is no internal detail left.
+
+There's also a semantic problem worth recording: **up/down cannot distinguish pre from post.**
+Both sit next to the horizon; only the direction of travel differs, and a static glyph can't show
+travel without an arrow. The distinction has to move onto the **time axis** — left is before,
+right is after — which a static shape *can* carry.
+
+### The change
+
+In `PhaseIcon`:
+
+```diff
+-import { Moon, Sun, Sunrise, Sunset } from "lucide-react"
++import { ArrowRightFromLine, ArrowRightToLine, Moon, Sun } from "lucide-react"
+```
+
+| phase | icon | reading |
+|---|---|---|
+| `open` | `Sun` (unchanged, keeps the ping) | — |
+| `premarket` | `ArrowRightToLine` | arriving at the bell |
+| `aftermarket` | `ArrowRightFromLine` | departed from the bell |
+| `closed` | `Moon` (unchanged) | — |
+
+Keep everything else about `PhaseIcon` as-is: same sizes (`h-3.5 w-3.5`, `2xl:h-4 2xl:w-4`),
+same `opacity-80` on the non-open states, same `text-current` so the shape carries the state and
+no hue competes with the value ramp.
+
+The board legend in `board.tsx` renders through the same `PhaseIcon`, so it updates for free —
+just confirm the labels still read right next to the new glyphs.
+
+### Fix while you're in there
+
+`PhaseIcon` sets a native `title={live ? "Open (live)" : "Open (scheduled)"}` on a span that sits
+**inside** the Radix `TooltipTrigger`. Hovering the icon therefore shows the styled tooltip and
+then, ~500 ms later, the browser's own tooltip on top of it. Drop the `title` — the live/scheduled
+distinction moves into the tooltip body (§2). Keep the `aria-label`s.
+
+---
+
+## 2 · Tile tooltip
+
+### The job
+
+The board's whole value is that σ-Move makes 84 assets comparable. Its whole cost is that it is
+dimensionless — the tile tells you *how unusual*, never *how much*. **The tooltip's job is to
+un-normalise the tile**: hand back the magnitude, the recent path, and the context the grid had to
+throw away.
+
+Two rules follow, and they resolve most layout questions on their own:
+
+1. **Lead with whatever the tile isn't showing.** In σ-mode the tile shows σ, so the tooltip leads
+   with the % and the price. In %-mode it flips. Never open with a number the cursor is already on.
+2. **A line either carries something no other line can, or it doesn't exist.** This is what removes
+   the phase label from the meta row (the header already states it), the data-source note when the
+   quote *is* live, and the section chips when the symbol is only in one section.
+
+### What's wrong with the current one
+
+**It's a white chip on a black board, and that costs more than glare.** `TooltipContent` uses
+shadcn's default `bg-foreground text-background` — near-white surface, near-black ink. That makes
+the app's finance colours unusable inside it: emerald-400 measures **1.86:1** on that surface,
+red-400 **2.67:1**. On `bg-popover` they are 7.44:1 and 5.17:1. It's why the current tooltip prints
+`+4.12%` in flat black while every other number on the page is coloured.
+
+**It restates the tile.** Two of its five lines — symbol and σ — are already under the cursor.
+
+**The sparkline is already in memory and thrown away.** `useWindowReturns` merges a 1-month
+`SparklinePoint[]` per symbol, reduces it to three scalars, and drops the series.
+
+**Minor:** the three windows are a run-on grey line where they should be an aligned column, and the
+tooltip has no `tabular-nums` even though the tile does.
+
+### Layout
+
+272px wide. **Do not use the default `TooltipContent` surface** — this one needs
+`bg-popover text-foreground`, a `border-border` hairline, a soft drop shadow, and `overflow-hidden`
+so the section dividers reach the edges. Four sections separated by `border-t border-border`.
+
+```
+┌────────────────────────────────────────────┐
+│ OKLO                      →|  pre-market   │  symbol: mono 13px/600
+│ Oklo Inc.                                  │  name: 11.5px muted, wraps
+├────────────────────────────────────────────┤
+│ +2.41%    $71.40                   [+0.9σ] │  % 17px/600 up-down coloured
+│ ▬▬▬▬▬▬▬▬▭▭▭▭▭       41/60 sessions         │  price 13px/500 muted
+├────────────────────────────────────────────┤  σ pill: ramp colour + ink, ml-auto
+│ ╱╲╱‾╲╱‾    1 week            +6.8%         │  warmup row: §3, warmup only
+│            2 weeks           −1.2%         │
+│            1 month          +18.4%         │
+├────────────────────────────────────────────┤
+│ [hotlist] [Thematic]                       │  chips only when >1 section
+│ NYSE · opens 15:30 · 2h12                  │
+│ phase from the calendar — no live quote    │  only when liveState === false
+└────────────────────────────────────────────┘
+```
+
+Details:
+
+- **σ pill** reuses `rampColor(sigma, span)` — same colour and ink as the tile itself, so the pill
+  and the tile you're hovering agree. Right-aligned on the lead row via `ml-auto`.
+- **Sparkline** 130×42, 1-month, area fill at ~10% opacity under a 1.4px stroke, `vector-effect:
+  non-scaling-stroke`. Coloured by the sign of the 1-month return, not today's.
+- **Windows** as a two-column table: label in `text-muted-foreground`, value right-aligned,
+  `tabular-nums`, up/down coloured, one decimal.
+- **Section chips** list every group (or thesis) the symbol belongs to. Render **only when the
+  count is >1** — this is the one question only the tooltip can answer, and on the board several
+  symbols appear in two sections. When it's one, the section header above the tile already says it.
+- **Meta line** is `venue · next bell · countdown`. It does **not** repeat the phase; the header
+  states it.
+- **Source line** appears only when `tile.liveState === false`, in the warning colour: the phase
+  came from `/api/market/phases` rather than a live quote. When it's live, say nothing.
+
+### Data needed
+
+Everything except one thing is already on `Tile`. **Nothing is fetched on hover** and nothing
+should be — the tooltip must stay free.
+
+- **Sparkline series** — return it from `useWindowReturns` alongside the scalars (it already builds
+  `merged: Record<string, SparklinePoint[]>` and discards it), and add `spark: SparklinePoint[]` to
+  the `Tile` interface.
+- **Section membership** — derive from the same `groups` / `theses` data the roster is built from;
+  add `sections: string[]` to `Tile`.
+
+### Sizing and delay
+
+272px against a 62px tile is four tiles across and about two and a half tall — it covers its
+neighbours. Raise `delayDuration` on the board's `TooltipProvider` from `150` so the card appears
+when you **stop** on a tile rather than when you sweep past it. Somewhere around 400–500 ms;
+Radix's `skipDelayDuration` keeps the subsequent ones instant, so browsing stays fast once you're in.
+
+---
+
+## 3 · No σ reading: collapse four states into two
+
+Today `reasonCopy()` renders four different prose strings. Collapse to **two shapes**, because
+only one of the states implies a different action:
+
+**Warmup** — the only no-reading state with a trajectory you can act on (wait), and the only one
+whose progress is knowable. Show a 3px progress bar plus `41/60 sessions`, right-aligned mono,
+sitting directly under the lead row.
+
+The bar fills in **`--primary`** (teal) on a `--muted` track. It must **not** use the value ramp or
+the gain/loss hues — this is system progress, not a reading, and it has to be visibly outside the
+value language. The label does not say what the sessions are *for*: the em dash sits immediately
+above it in the σ slot and establishes the subject without a word.
+
+**Everything else** — `feed_behind`, `gap`, `unknown` — renders an **em dash where the σ pill would
+go**, in `text-muted-foreground`, and nothing more. No prose, no reason string, no retry estimate.
+All three resolve to the same user action, so they get the same shape.
+
+The reading is missing; the day, the price, the path and the windows are not — those all still
+render exactly as on a scored tile.
+
+### Consequences upstream
+
+- `reasonCopy()` in `tile.tsx` becomes dead code — delete it.
+- `NoReadingReason` still needs its full discrimination **inside** `use-board-data.ts`:
+  `feed_behind` vs `gap` decides whether σ is *withheld*, which is a different question from what
+  the tooltip prints. But nothing downstream reads the distinction anymore. **Leave a comment
+  saying so**, or the next person will read the unused variants as an oversight and "simplify" the
+  cascade that keeps the board honest.
+- What the tooltip actually needs from it collapses to
+  `{ kind: "warmup"; bars: number; needed: number } | null`.
+
+---
+
+## 4 · Load audit
+
+Cold load of the board, 84 distinct symbols across 9 groups:
+
+| | requests | ~payload |
+|---|---|---|
+| `GET /groups` | 1 | 14 KB |
+| `GET /theses` | 1 | 4 KB |
+| `GET /indicators?symbols=…` (all 84) | 1 | 45 KB |
+| `GET /groups/{id}/sparklines?period=1mo` | **9** | 75 KB |
+| `GET /market/phases` (refetch 60 s) | 1 | 3 KB |
+| `GET /system/data-health` (refetch 60 s) | 1 | <1 KB |
+| `GET /portfolio/index?period=1y` | 1 | 7 KB |
+| **total** | **15** + 1 SSE | **~150 KB** |
+
+Everything except phases and health is `STALE_5MIN`, so navigating away and back inside five
+minutes is free. This is not a heavy page — but four things are worth fixing.
+
+**a · Sparklines are fetched per group instead of per roster.** Nine round trips covering 94
+symbol-series to obtain 84 distinct ones, because symbols repeat across groups. The merge in
+`useWindowReturns` even dedupes with `points.length > merged[sym].length`, so the code already
+knows it's receiving the same series twice — and the hook takes `symbols` as a parameter and then
+ignores it for fetching. **Fix:** add a `GET /sparklines?symbols=…&period=` sibling to the existing
+`/indicators?symbols=` batch endpoint and fetch once. Nine requests → one, ~75 KB → ~67 KB, and it
+fixes (c) below for free.
+
+**b · Toggling Group ↔ Thesis refetches all 84 indicator snapshots.** `keys.indicators(symbols)`
+keys on the symbol array; thesis mode adds thesis-only assets to the roster, so the array differs,
+the key differs, and the whole batch misses cache. **Fix:** key on a stable union roster (every
+symbol in any group *or* thesis, sorted) regardless of the active grouping, so the toggle is free.
+
+**c · Thesis-only assets get no window returns.** In thesis mode the roster includes assets known
+only through a thesis, but `series` is built purely from *group* sparklines — so those symbols get
+`null` for 1wk/2wk/1mo, and the tooltip shows three em dashes that read as missing data rather than
+never-fetched. Latent unless you actually have thesis-only assets; fixed automatically by (a).
+
+**d · `useTheses()` runs unconditionally**, including in Group mode where it's only needed for the
+roster fallback. Small, but free to gate.
+
+Not a bug, worth stating so nobody "optimises" it: **paging cannot reduce fetching.** `span` in
+`board.tsx` is computed over `sections.flatMap(...)` across every page, and the coverage pill counts
+the whole roster — both need all 84. Page 2 costs nothing because page 1 already paid for
+everything. The pager is a rendering device, not a loading one.
+
+### Sustained cost
+
+The SSE stream is well-behaved. `_poll_interval` gives 15 s while any venue is open, 60 s when only
+pre/post are active, 300 s when everything is closed, and it sleeps to the next opening bell rather
+than waking every five minutes past it. Quote pushes are deltas — only symbols whose values changed.
+
+One thing to **measure rather than assume**: the `intraday` SSE event pushes the full bar set for
+every grouped asset on its first iteration (`if not last_intraday_ts: intraday_payload = all_bars`).
+If those are 1-minute bars for 84 symbols, that single frame is plausibly the largest thing that
+crosses the wire all session. Deltas after it are small. Worth logging the byte size of the first
+`intraday` frame before deciding whether it needs windowing.
+
+---
+
+## Out of scope / already rejected
+
+- **Explaining σ in the tooltip.** An earlier draft carried "+0.9σ, because a typical day here is
+  ±2.7%", sourced from `vnr_sigma` (already in the snapshot, already read by `computeLiveVnr`).
+  Cut: it was the only prose sentence in a card of labels and numbers, and it explains a metric to
+  the person who designed it. The vol scale as a plain `typical day ±2.7%` row was also tried and
+  cut. If it ever comes back, it comes back as a figure, not a sentence.
+- **Per-reason copy for feed-behind and session-gap.** See §3.
+- **Fetching anything on hover.** The tooltip is free by construction; keep it that way.
+- **Keeping `sunrise`/`sunset` and just enlarging them.** The glyphs are ~93% identical; size
+  doesn't fix a shared silhouette.
+```

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -48,7 +48,13 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="size-2.5 rotate-45 rounded-[2px] bg-foreground fill-foreground z-50 translate-y-[calc(-50%_-_2px)]" />
+        {/* Radix's own arrow polygon, left as a triangle. It already reorients
+            with the resolved side — pointing down at a trigger below it, up at
+            one above — so nothing here has to track that. shadcn's default
+            squares it into a diamond via rotate-45 plus a background; the
+            background is what makes that shape, so it has to go for the
+            polygon underneath to show. */}
+        <TooltipPrimitive.Arrow width={11} height={5} className="fill-foreground z-50" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -157,6 +157,17 @@ export const api = {
       return request<Record<string, IndicatorSummary>>(`/indicators?${params.toString()}`)
     },
   },
+  sparklines: {
+    /** Batch close-price series for arbitrary tracked symbols, keyed by symbol.
+     * The roster-shaped sibling of `groups.sparklines` — one request for a set
+     * that spans groups, and no duplicate series for shared memberships. */
+    batch: (symbols: string[], period?: string) => {
+      const params = new URLSearchParams()
+      for (const s of symbols) params.append("symbols", s)
+      if (period) params.append("period", period)
+      return request<Record<string, SparklinePoint[]>>(`/sparklines?${params.toString()}`)
+    },
+  },
   market: {
     /** Scheduled phase + next bell per in-use venue calendar (with its symbols). */
     phases: () => request<Record<string, CalendarPhase>>(`/market/phases`),

--- a/frontend/src/lib/queries/groups.ts
+++ b/frontend/src/lib/queries/groups.ts
@@ -113,6 +113,18 @@ export function useIndicators(symbols: string[], enabled = true) {
   })
 }
 
+/** Close-price series for an arbitrary set of tracked symbols, keyed by symbol.
+ * Addressed by roster rather than by group, so a set spanning several groups —
+ * or containing assets in none, as thesis-only members are — is one request. */
+export function useSparklines(symbols: string[], period?: string, enabled = true) {
+  return useQuery({
+    queryKey: keys.sparklines(symbols, period),
+    queryFn: () => api.sparklines.batch(symbols, period),
+    enabled: enabled && symbols.length > 0,
+    staleTime: STALE_5MIN,
+  })
+}
+
 /** Prefetch the metadata, sparklines and indicators for every group except
  * ``activeGroupId`` so switching groups feels instant. The active group's
  * data is already being fetched by the page that called this hook. */

--- a/frontend/src/lib/queries/index.ts
+++ b/frontend/src/lib/queries/index.ts
@@ -4,7 +4,7 @@ export { useAssets, useCreateAsset, useUpdateAsset, useAssetAttachments, useHard
 export { useAssetDetail, useAssetWindow, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
 export { useEarnings } from "./earnings"
 export { useTags, useCreateTag, useAttachTag, useDetachTag } from "./tags"
-export { useGroups, useCreateGroup, useUpdateGroup, useDeleteGroup, useReorderGroups, useAddAssetsToGroup, useRemoveAssetFromGroup, useGroup, useGroupSparklines, useGroupIndicators, useIndicators, usePrefetchOtherGroups } from "./groups"
+export { useGroups, useCreateGroup, useUpdateGroup, useDeleteGroup, useReorderGroups, useAddAssetsToGroup, useRemoveAssetFromGroup, useGroup, useGroupSparklines, useGroupIndicators, useIndicators, useSparklines, usePrefetchOtherGroups } from "./groups"
 export { useNote, useUpdateNote, useAnnotations, useCreateAnnotation, useDeleteAnnotation } from "./notes"
 export { useTheses, useThesesPerformance, useThesis, useCreateThesis, useUpdateThesis, useDeleteThesis, useAddThesisAssets, useRemoveThesisAsset, useAddAssetToThesis, useRemoveAssetFromThesis } from "./theses"
 export { usePseudoEtfs, usePseudoEtf, useCreatePseudoEtf, useUpdatePseudoEtf, useDeletePseudoEtf, useAddPseudoEtfConstituents, useRemovePseudoEtfConstituent, usePseudoEtfPerformance, usePseudoEtfConstituentsIndicators, usePseudoEtfNote, useUpdatePseudoEtfNote, usePseudoEtfAnnotations, useCreatePseudoEtfAnnotation, useDeletePseudoEtfAnnotation } from "./pseudo-etfs"

--- a/frontend/src/lib/queries/shared.ts
+++ b/frontend/src/lib/queries/shared.ts
@@ -37,6 +37,8 @@ export const keys = {
   groupIndicators: (id: number) => ["group-indicators", id] as const,
   // Sorted+joined so the key is order-independent (same symbol set → one cache entry).
   indicators: (symbols: readonly string[]) => ["indicators", [...symbols].sort().join(",")] as const,
+  sparklines: (symbols: readonly string[], period?: string) =>
+    ["sparklines", [...symbols].sort().join(","), period] as const,
   note: (symbol: string) => ["note", symbol] as const,
   theses: ["theses"] as const,
   thesesPerformance: ["theses", "performance"] as const,

--- a/frontend/src/pages/portfolio/board/bell.test.ts
+++ b/frontend/src/pages/portfolio/board/bell.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { countdown } from "./bell"
+
+const at = (iso: string) => new Date(iso)
+
+describe("countdown", () => {
+  const now = at("2026-08-12T09:00:00Z")
+
+  it("prints minutes under the hour", () => {
+    expect(countdown(at("2026-08-12T09:14:00Z"), now)).toBe("14m")
+  })
+
+  it("prints hours and zero-padded minutes above it", () => {
+    expect(countdown(at("2026-08-12T11:12:00Z"), now)).toBe("2h12")
+    expect(countdown(at("2026-08-12T11:05:00Z"), now)).toBe("2h05")
+  })
+
+  it("drops the minutes remainder cleanly on the hour", () => {
+    expect(countdown(at("2026-08-12T12:00:00Z"), now)).toBe("3h00")
+  })
+
+  it("returns null once the bell has passed", () => {
+    // A schedule that has gone stale must not print a negative countdown.
+    expect(countdown(at("2026-08-12T08:30:00Z"), now)).toBeNull()
+    expect(countdown(now, now)).toBeNull()
+  })
+})

--- a/frontend/src/pages/portfolio/board/bell.ts
+++ b/frontend/src/pages/portfolio/board/bell.ts
@@ -1,0 +1,33 @@
+// How the board talks about venue phases and the next bell.
+//
+// Pure vocabulary + formatting, kept out of the tooltip component so the
+// wording is testable and lives in one place.
+
+import type { Phase } from "./use-board-data"
+
+export const PHASE_LABEL: Record<Phase, string> = {
+  premarket: "pre-market",
+  open: "open",
+  aftermarket: "after-hours",
+  closed: "closed",
+}
+
+/** `next_change_at` is the next boundary of whatever phase we're *in*, so what
+ * it means depends on the phase we're leaving. "next bell" for closed is not
+ * vagueness: that boundary may be the pre-market edge rather than the opening
+ * bell, and the calendar doesn't tell us which. */
+export const BELL_VERB: Record<Phase, string> = {
+  premarket: "opens",
+  open: "closes",
+  aftermarket: "ends",
+  closed: "next bell",
+}
+
+/** "2h12" / "14m" — coarse on purpose; the exact time sits next to it. Null
+ * once the bell has passed: a stale schedule must not print a negative. */
+export function countdown(target: Date, now: Date): string | null {
+  const mins = Math.round((target.getTime() - now.getTime()) / 60000)
+  if (mins <= 0) return null
+  if (mins < 60) return `${mins}m`
+  return `${Math.floor(mins / 60)}h${String(mins % 60).padStart(2, "0")}`
+}

--- a/frontend/src/pages/portfolio/board/board.tsx
+++ b/frontend/src/pages/portfolio/board/board.tsx
@@ -85,8 +85,13 @@ export function Board({ sections, mode }: { sections: BoardSection[]; mode: Colo
     return () => window.removeEventListener("keydown", onKey)
   }, [pages.length])
 
+  // The tile card is 272px against a 62px tile — four tiles across and about
+  // two and a half tall, so it covers its neighbours. The delay makes it appear
+  // when you *stop* on a tile rather than when you sweep past one;
+  // skipDelayDuration keeps the next ones instant, so browsing stays fast once
+  // you're already reading cards.
   return (
-    <TooltipProvider delayDuration={150}>
+    <TooltipProvider delayDuration={450} skipDelayDuration={300}>
       {/* The section area is pinned to the measured page height, so the
           legend/pager row below it stays level across page flips. */}
       <div ref={ref}>

--- a/frontend/src/pages/portfolio/board/tile-tooltip.tsx
+++ b/frontend/src/pages/portfolio/board/tile-tooltip.tsx
@@ -17,7 +17,7 @@
 // board renders, and hovering must stay free.
 
 import type { SparklinePoint } from "@/lib/api"
-import { changeColor, formatChangePct, formatPrice } from "@/lib/format"
+import { changeColor, formatAssetPrice, formatChangePct } from "@/lib/format"
 import { rampColor, PCT_WINDOWS, type ColorMode } from "./color-scale"
 import { BELL_VERB, PHASE_LABEL, countdown } from "./bell"
 import { PhaseIcon } from "./tile"
@@ -127,9 +127,13 @@ export function TileTooltip({ tile, mode, span }: { tile: Tile; mode: ColorMode;
       <div className="border-t border-border px-3 py-2">
         <div className="flex items-baseline gap-2">
           <span className={`text-[17px] font-semibold tabular-nums ${changeColor(lead)}`}>{leadText}</span>
+          {/* formatAssetPrice, not formatPrice: an index isn't
+              currency-denominated, and a yield index (^TYX, ^TNX, …) is quoted
+              in percent — a "$" in front of a 30-year Treasury yield is a
+              category error, not a cosmetic one. */}
           {tile.price != null && (
             <span className="text-[13px] font-medium tabular-nums text-muted-foreground">
-              {formatPrice(tile.price, tile.currency)}
+              {formatAssetPrice(tile.price, tile)}
             </span>
           )}
           {/* Everything that isn't warmup — feed_behind, gap, unknown — lands
@@ -150,7 +154,14 @@ export function TileTooltip({ tile, mode, span }: { tile: Tile; mode: ColorMode;
       </div>
 
       <div className="flex items-center gap-3 border-t border-border px-3 py-2">
-        <Sparkline points={tile.spark} monthPct={tile.windowPct["1mo"]} />
+        {/* The curve is the same month the table's bottom row measures, but
+            nothing about it says so — it's the one element here with no units,
+            and it reads as "recent" rather than as a span. The label is the
+            cheapest way to make it a statement instead of a mood. */}
+        <div className="shrink-0">
+          <Sparkline points={tile.spark} monthPct={tile.windowPct["1mo"]} />
+          <div className="mt-0.5 text-center text-[10px] text-muted-foreground">1mo</div>
+        </div>
         <table className="flex-1 text-[11px]">
           <tbody>
             {PCT_WINDOWS.map((w) => {

--- a/frontend/src/pages/portfolio/board/tile-tooltip.tsx
+++ b/frontend/src/pages/portfolio/board/tile-tooltip.tsx
@@ -1,0 +1,191 @@
+// The tile tooltip: un-normalises the tile.
+//
+// σ-Move is what makes 84 assets comparable in one grid, and being
+// dimensionless is exactly what it costs — the tile says *how unusual*, never
+// *how much*. So this card hands back the magnitude, the recent path, and the
+// context the grid had to throw away. Two rules follow:
+//
+//   1. Lead with whatever the tile isn't showing. In σ-mode the tile prints σ,
+//      so the card leads with the % and the price; in %-mode it flips. Never
+//      open with a number the cursor is already sitting on.
+//   2. A line either carries something no other line can, or it doesn't exist.
+//      That's what removes the phase from the meta row (the header states it),
+//      the source note when the quote *is* live, and the chips when the symbol
+//      only appears in one section.
+//
+// Nothing here fetches. Every value is already on the tile by the time the
+// board renders, and hovering must stay free.
+
+import type { SparklinePoint } from "@/lib/api"
+import { changeColor, formatChangePct, formatPrice } from "@/lib/format"
+import { rampColor, PCT_WINDOWS, type ColorMode } from "./color-scale"
+import { BELL_VERB, PHASE_LABEL, countdown } from "./bell"
+import { PhaseIcon } from "./tile"
+import type { Tile } from "./use-board-data"
+
+function fmtSigma(v: number): string {
+  return `${v > 0 ? "+" : ""}${v.toFixed(1)}σ`
+}
+
+/** One month of closes, 130×42. Coloured by the month's own direction — not
+ * today's, which the lead row already states and which would otherwise repaint
+ * the whole path on a single red day. */
+function Sparkline({ points, monthPct }: { points: SparklinePoint[]; monthPct: number | null }) {
+  if (points.length < 2) return <div className="h-[42px] w-[130px]" />
+
+  const closes = points.map((p) => p.close)
+  const lo = Math.min(...closes)
+  const hi = Math.max(...closes)
+  const range = hi - lo || 1
+  const stroke = monthPct != null && monthPct < 0 ? "var(--color-red-500)" : "var(--color-emerald-500)"
+
+  // Drawn in a 0..1 unit box and stretched by the viewBox, so the geometry
+  // stays independent of the rendered size; non-scaling-stroke keeps the line
+  // 1.4px through that stretch.
+  const d = closes
+    .map((c, i) => `${i === 0 ? "M" : "L"}${(i / (closes.length - 1)).toFixed(4)},${((hi - c) / range).toFixed(4)}`)
+    .join(" ")
+
+  return (
+    <svg
+      viewBox="0 0 1 1"
+      preserveAspectRatio="none"
+      className="h-[42px] w-[130px] shrink-0 overflow-visible"
+      aria-hidden
+    >
+      <path d={`${d} L1,1 L0,1 Z`} fill={stroke} fillOpacity={0.1} />
+      <path
+        d={d}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={1.4}
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  )
+}
+
+/** Warmup is the only no-reading state with a trajectory you can act on (wait)
+ * and the only one whose progress is knowable, so it's the only one that gets a
+ * shape of its own. The bar fills in --primary on --muted: system progress has
+ * to sit visibly outside the value language, or it reads as a reading. */
+function WarmupBar({ bars, needed }: { bars: number; needed: number }) {
+  return (
+    <div className="mt-1.5 flex items-center gap-2">
+      <div className="h-[3px] flex-1 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary"
+          style={{ width: `${Math.min(100, (bars / needed) * 100)}%` }}
+        />
+      </div>
+      <span className="shrink-0 font-mono text-[10.5px] tabular-nums text-muted-foreground">
+        {bars}/{needed} sessions
+      </span>
+    </div>
+  )
+}
+
+export function TileTooltip({ tile, mode, span }: { tile: Tile; mode: ColorMode; span: number }) {
+  // Rule 1: the pill carries whatever the tile is already encoding — same
+  // value, same ramp colour, same ink — so the card and the tile you're
+  // hovering visibly agree. The lead number is the other one.
+  const encoded = mode === "sigma" ? tile.sigma : tile.todayPct
+  const lead = mode === "sigma" ? tile.todayPct : tile.sigma
+  const leadText =
+    lead == null ? "—" : mode === "sigma" ? formatChangePct(lead).text : fmtSigma(lead)
+  const stop = encoded == null ? null : rampColor(encoded, span)
+
+  const warmup = tile.reason?.kind === "warmup" ? tile.reason : null
+  const now = new Date()
+  const bell = tile.nextBell ? new Date(tile.nextBell) : null
+  const left = bell ? countdown(bell, now) : null
+
+  const meta = [
+    tile.calendar,
+    bell && tile.phase
+      ? `${BELL_VERB[tile.phase]} ${bell.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+      : null,
+    left,
+  ].filter(Boolean)
+
+  return (
+    <div className="w-[272px] overflow-hidden text-foreground">
+      <div className="px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-mono text-[13px] font-semibold">{tile.symbol}</span>
+          {tile.phase && (
+            <span className="ml-auto flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+              <PhaseIcon phase={tile.phase} live={tile.liveState} />
+              {PHASE_LABEL[tile.phase]}
+            </span>
+          )}
+        </div>
+        {tile.name && <div className="mt-0.5 text-[11.5px] leading-snug text-muted-foreground">{tile.name}</div>}
+      </div>
+
+      <div className="border-t border-border px-3 py-2">
+        <div className="flex items-baseline gap-2">
+          <span className={`text-[17px] font-semibold tabular-nums ${changeColor(lead)}`}>{leadText}</span>
+          {tile.price != null && (
+            <span className="text-[13px] font-medium tabular-nums text-muted-foreground">
+              {formatPrice(tile.price, tile.currency)}
+            </span>
+          )}
+          {/* Everything that isn't warmup — feed_behind, gap, unknown — lands
+              here as a plain em dash. All three resolve to the same user
+              action, so they get the same shape and no prose. */}
+          {stop ? (
+            <span
+              className="ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-[11px] font-semibold tabular-nums"
+              style={{ backgroundColor: stop.color, color: stop.ink }}
+            >
+              {mode === "sigma" ? fmtSigma(encoded!) : formatChangePct(encoded!).text}
+            </span>
+          ) : (
+            <span className="ml-auto shrink-0 text-[13px] text-muted-foreground">—</span>
+          )}
+        </div>
+        {warmup && <WarmupBar bars={warmup.bars} needed={warmup.needed} />}
+      </div>
+
+      <div className="flex items-center gap-3 border-t border-border px-3 py-2">
+        <Sparkline points={tile.spark} monthPct={tile.windowPct["1mo"]} />
+        <table className="flex-1 text-[11px]">
+          <tbody>
+            {PCT_WINDOWS.map((w) => {
+              const v = tile.windowPct[w.value]
+              return (
+                <tr key={w.value}>
+                  <td className="pr-2 text-muted-foreground">{w.label}</td>
+                  <td className={`text-right tabular-nums ${changeColor(v)}`}>
+                    {v == null ? "—" : `${v > 0 ? "+" : ""}${v.toFixed(1)}%`}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="space-y-1 border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
+        {/* Only when the symbol is in more than one — this is the one question
+            the grid can't answer, since a tile appears under a single heading.
+            At one section, that heading already said it. */}
+        {tile.sections.length > 1 && (
+          <div className="flex flex-wrap gap-1">
+            {tile.sections.map((s) => (
+              <span key={s} className="rounded bg-muted px-1.5 py-0.5 text-[10.5px] text-foreground">
+                {s}
+              </span>
+            ))}
+          </div>
+        )}
+        {meta.length > 0 && <div>{meta.join(" · ")}</div>}
+        {tile.liveState === false && (
+          <div className="text-amber-500">phase from the calendar — no live quote</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/portfolio/board/tile.tsx
+++ b/frontend/src/pages/portfolio/board/tile.tsx
@@ -103,12 +103,12 @@ export const BoardTile = memo(function BoardTile({
           red-400 2.67:1 against 5.17:1. Hence the explicit popover surface;
           p-0 because the card owns its own padding and dividers.
 
-          `[&>svg]` is the Radix arrow specifically — it carries bg-foreground
-          from the shared primitive and would otherwise stay white. The card is
-          a div, so its own icons and sparkline aren't direct children. */}
+          `[&>svg]` is the Radix arrow specifically — it's filled foreground by
+          the shared primitive and would otherwise stay white. The card is a
+          div, so its own icons and sparkline aren't direct children. */}
       <TooltipContent
         side="top"
-        className="w-fit max-w-none rounded-lg border border-border bg-popover p-0 text-foreground shadow-lg [&>svg]:bg-popover [&>svg]:fill-popover"
+        className="w-fit max-w-none rounded-lg border border-border bg-popover p-0 text-foreground shadow-lg [&>svg]:fill-popover"
       >
         <TileTooltip tile={tile} mode={mode} span={span} />
       </TooltipContent>

--- a/frontend/src/pages/portfolio/board/tile.tsx
+++ b/frontend/src/pages/portfolio/board/tile.tsx
@@ -3,7 +3,8 @@ import { Link } from "react-router-dom"
 import { ArrowRightFromLine, ArrowRightToLine, Moon, Sun } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { changeColor, formatChangePct } from "@/lib/format"
-import { rampColor, pctWindowDef, type ColorMode } from "./color-scale"
+import { rampColor, type ColorMode } from "./color-scale"
+import { TileTooltip } from "./tile-tooltip"
 import type { Tile as TileData } from "./use-board-data"
 
 // One shared pulse: every live dot's animation phase is aligned to the wall
@@ -22,8 +23,11 @@ function pingDelay(): string {
 export function PhaseIcon({ phase, live }: { phase: TileData["phase"]; live?: boolean }) {
   if (phase == null) return null
   if (phase === "open") {
+    // No native `title` here: this span sits inside the Radix TooltipTrigger,
+    // so the browser's own tooltip would surface on top of the styled card ~500
+    // ms later. The live/scheduled distinction lives in the card's source line.
     return (
-      <span className="relative shrink-0" title={live ? "Open (live)" : "Open (scheduled)"}>
+      <span className="relative shrink-0" aria-label={live ? "Open (live)" : "Open (scheduled)"}>
         <span
           className="board-ping absolute inset-0.5 rounded-full bg-current"
           style={{ animationDelay: pingDelay() }}
@@ -39,24 +43,6 @@ export function PhaseIcon({ phase, live }: { phase: TileData["phase"]; live?: bo
     return <ArrowRightFromLine className="phase-icon h-3.5 w-3.5 shrink-0 text-current opacity-80 2xl:h-4 2xl:w-4" aria-label="After-hours" />
   }
   return <Moon className="phase-icon h-3.5 w-3.5 shrink-0 text-current opacity-80 2xl:h-4 2xl:w-4" aria-label="Closed" />
-}
-
-function reasonCopy(t: TileData): string | null {
-  switch (t.reason?.kind) {
-    case "feed_behind":
-      return "price feed behind the live quote · heal retry within ~10 min"
-    case "gap": {
-      const scan = t.reason.nextScanSeconds
-      const when = scan != null ? `next scan ~${Math.max(1, Math.round(scan / 60))} min` : "runs automatically"
-      return `spans a ${t.reason.sessions}-session gap · hole heal, ${when}`
-    }
-    case "warmup":
-      return `building baseline · ${t.reason.bars}/${t.reason.needed} bars`
-    case "unknown":
-      return "no σ reading"
-    default:
-      return null
-  }
 }
 
 function fmtSigma(v: number): string {
@@ -96,11 +82,6 @@ export const BoardTile = memo(function BoardTile({
     formatChangePct(value).text
   )
 
-  const windows = (["1wk", "2wk", "1mo"] as const).map((w) => {
-    const p = tile.windowPct[w]
-    return `${pctWindowDef(w).label}: ${p != null ? formatChangePct(p).text : "—"}`
-  })
-
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -116,24 +97,20 @@ export const BoardTile = memo(function BoardTile({
           <span className="text-[11px] leading-none tabular-nums 2xl:text-[13px] opacity-90">{valueEl}</span>
         </Link>
       </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-[260px]">
-        <div className="space-y-1 text-xs">
-          <div className="font-semibold">
-            {tile.symbol} <span className="font-normal text-muted-foreground">{tile.name}</span>
-          </div>
-          <div>
-            σ-Move today:{" "}
-            {tile.sigma != null ? fmtSigma(tile.sigma) : (reasonCopy(tile) ?? "no reading")}
-          </div>
-          {tile.todayPct != null && <div>today: {formatChangePct(tile.todayPct).text}</div>}
-          <div className="text-muted-foreground">{windows.join(" · ")}</div>
-          {tile.calendar && (
-            <div className="text-muted-foreground">
-              {tile.calendar} · {tile.phase ?? "?"}
-              {tile.nextBell && ` · next bell ${new Date(tile.nextBell).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`}
-            </div>
-          )}
-        </div>
+      {/* The default TooltipContent surface is bg-foreground/text-background —
+          near-white on this board. The app's finance colours are unusable on
+          it: emerald-400 measures 1.86:1 there against 7.44:1 on bg-popover,
+          red-400 2.67:1 against 5.17:1. Hence the explicit popover surface;
+          p-0 because the card owns its own padding and dividers.
+
+          `[&>svg]` is the Radix arrow specifically — it carries bg-foreground
+          from the shared primitive and would otherwise stay white. The card is
+          a div, so its own icons and sparkline aren't direct children. */}
+      <TooltipContent
+        side="top"
+        className="w-fit max-w-none rounded-lg border border-border bg-popover p-0 text-foreground shadow-lg [&>svg]:bg-popover [&>svg]:fill-popover"
+      >
+        <TileTooltip tile={tile} mode={mode} span={span} />
       </TooltipContent>
     </Tooltip>
   )

--- a/frontend/src/pages/portfolio/board/use-board-data.ts
+++ b/frontend/src/pages/portfolio/board/use-board-data.ts
@@ -6,15 +6,13 @@
 // never disagree with the table about the same asset.
 
 import { useMemo } from "react"
-import { useQueries } from "@tanstack/react-query"
-import { api, type Asset, type SparklinePoint } from "@/lib/api"
+import { type Asset, type SparklinePoint } from "@/lib/api"
 import {
-  keys,
-  STALE_5MIN,
   useDataHealth,
   useGroups,
   useIndicators,
   useMarketPhases,
+  useSparklines,
   useTheses,
 } from "@/lib/queries"
 import { useQuotes } from "@/lib/quote-stream"
@@ -28,7 +26,14 @@ import { VNR_BASELINE_SESSIONS, type PctWindow, PCT_WINDOWS } from "./color-scal
 
 export type Phase = "premarket" | "open" | "aftermarket" | "closed"
 
-/** Why a tile has no σ reading — each state gets its own honest copy. */
+/** Why a tile has no σ reading.
+ *
+ * The variants are load-bearing *here* even though the tooltip only prints
+ * `warmup`: `feed_behind` vs `gap` is what decides whether σ is withheld at
+ * all, and the cascade below reads them to stay honest. Nothing downstream
+ * discriminates them anymore — that is deliberate (all three non-warmup states
+ * resolve to the same user action), not an oversight to be tidied away.
+ */
 export type NoReadingReason =
   | { kind: "feed_behind" }
   | { kind: "gap"; sessions: number; nextScanSeconds: number | null }
@@ -46,6 +51,10 @@ export interface Tile {
   todayPct: number | null
   /** % change over each board window (from the shared 1mo series). */
   windowPct: Record<PctWindow, number | null>
+  /** The 1mo close series the windows were derived from (tooltip sparkline). */
+  spark: SparklinePoint[]
+  /** Sections this symbol belongs to under the active grouping (tooltip). */
+  sections: string[]
   phase: Phase | null
   /** Venue calendar name + next scheduled phase change (tooltip). */
   calendar: string | null
@@ -65,37 +74,23 @@ export interface BoardSection {
 export type GroupBy = "group" | "thesis"
 
 /** Per-symbol % change series over the covering month, shared by the tiles'
- * %-mode, the Movers card, and the tooltips — one fetch, three windows. */
+ * %-mode, the Movers card, and the tooltips — one fetch, three windows.
+ *
+ * Fetched by roster, not by group: the board's symbols span every group and
+ * (in thesis mode) some belong to none, so a per-group fetch both duplicated
+ * shared symbols and missed thesis-only ones entirely. Returns the raw series
+ * alongside the scalars — the tooltip sparkline draws from it, so reducing it
+ * away here would mean fetching the same month twice.
+ */
 function useWindowReturns(symbols: string[]) {
-  const { data: groups } = useGroups()
-  const sparkQueries = useQueries({
-    queries: (groups ?? []).map((g) => ({
-      queryKey: keys.groupSparklines(g.id, "1mo"),
-      queryFn: () => api.groups.sparklines(g.id, "1mo"),
-      staleTime: STALE_5MIN,
-    })),
-  })
-  // useQueries returns new result arrays each render; depend on a stable
-  // fingerprint of the data so the merge doesn't recompute per render.
-  const loaded = sparkQueries.filter((q) => q.data).length
-  const series = useMemo(() => {
-    const merged: Record<string, SparklinePoint[]> = {}
-    for (const q of sparkQueries) {
-      if (!q.data) continue
-      for (const [sym, points] of Object.entries(q.data)) {
-        if (!merged[sym] || points.length > merged[sym].length) merged[sym] = points
-      }
-    }
-    return merged
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- see fingerprint note above
-  }, [loaded, groups])
+  const { data: series } = useSparklines(symbols, "1mo")
 
   const quotes = useQuotes()
-  return useMemo(() => {
+  const windows = useMemo(() => {
     const out: Record<string, Record<PctWindow, number | null>> = {}
     const today = new Date()
     for (const sym of symbols) {
-      const points = series[sym]
+      const points = series?.[sym]
       const per = {} as Record<PctWindow, number | null>
       for (const w of PCT_WINDOWS) {
         per[w.value] = null
@@ -118,6 +113,8 @@ function useWindowReturns(symbols: string[]) {
     }
     return out
   }, [symbols, series, quotes])
+
+  return { windows, series }
 }
 
 const EMPTY_WINDOWS: Record<PctWindow, number | null> = { "1wk": null, "2wk": null, "1mo": null }
@@ -139,9 +136,37 @@ export function useBoardData(groupBy: GroupBy) {
     return bySymbol
   }, [groups, theses, groupBy])
 
-  const symbols = useMemo(() => [...roster.keys()].sort(), [roster])
-  const { data: snapshots } = useIndicators(symbols)
-  const windowReturns = useWindowReturns(symbols)
+  // What we *fetch* is the union over both groupings, deliberately wider than
+  // what we render. The per-symbol queries key on their symbol array, so a
+  // roster that grows when you switch to thesis mode would change the key and
+  // miss cache on all ~84 snapshots for the sake of a handful of extra ones.
+  // Keying on the union makes the Group ↔ Thesis toggle free.
+  //
+  // This is why useTheses() is not gated to thesis mode: the union needs it in
+  // both. Gating it would save one ~4 KB request and reintroduce the refetch.
+  const fetchSymbols = useMemo(() => {
+    const all = new Set<string>()
+    for (const g of groups ?? []) for (const a of g.assets) all.add(a.symbol)
+    for (const t of theses ?? []) for (const a of t.assets) all.add(a.symbol)
+    return [...all].sort()
+  }, [groups, theses])
+
+  const { data: snapshots } = useIndicators(fetchSymbols)
+  const { windows: windowReturns, series } = useWindowReturns(fetchSymbols)
+
+  // Which sections each symbol sits in, under the active grouping — the one
+  // question the tooltip can answer that the grid can't, since a tile only
+  // ever appears under one heading at a time.
+  const sectionsBySymbol = useMemo(() => {
+    const out: Record<string, string[]> = {}
+    const add = (sym: string, title: string) => (out[sym] ??= []).push(title)
+    if (groupBy === "group") {
+      for (const g of groups ?? []) for (const a of g.assets) add(a.symbol, g.name)
+    } else {
+      for (const t of theses ?? []) for (const a of t.assets) add(a.symbol, t.name)
+    }
+    return out
+  }, [groupBy, groups, theses])
 
   const symbolPhase = useMemo(() => {
     const out: Record<string, { calendar: string; phase: Phase; nextBell: string | null }> = {}
@@ -194,6 +219,8 @@ export function useBoardData(groupBy: GroupBy) {
         reason,
         todayPct: quote?.change_percent ?? snap?.change_pct ?? null,
         windowPct: windowReturns[symbol] ?? EMPTY_WINDOWS,
+        spark: series?.[symbol] ?? [],
+        sections: sectionsBySymbol[symbol] ?? [],
         phase,
         calendar: scheduled?.calendar ?? null,
         nextBell: scheduled?.nextBell ?? null,
@@ -201,7 +228,7 @@ export function useBoardData(groupBy: GroupBy) {
       })
     }
     return out
-  }, [roster, quotes, snapshots, windowReturns, symbolPhase, health])
+  }, [roster, quotes, snapshots, windowReturns, series, sectionsBySymbol, symbolPhase, health])
 
   const sections = useMemo<BoardSection[]>(() => {
     const toTiles = (list: Asset[]) =>

--- a/frontend/src/pages/portfolio/board/use-board-data.ts
+++ b/frontend/src/pages/portfolio/board/use-board-data.ts
@@ -44,6 +44,9 @@ export interface Tile {
   symbol: string
   name: string
   currency: string
+  /** Carried so prices format through formatAssetPrice: an index is not
+   * currency-denominated, and a yield index is quoted in percent. */
+  type: Asset["type"]
   /** σ-Move via the live-first cascade; null → see reason. */
   sigma: number | null
   reason: NoReadingReason | null
@@ -217,6 +220,7 @@ export function useBoardData(groupBy: GroupBy) {
         symbol,
         name: asset.name,
         currency: asset.currency,
+        type: asset.type,
         sigma,
         reason,
         todayPct: quote?.change_percent ?? snap?.change_pct ?? null,

--- a/frontend/src/pages/portfolio/board/use-board-data.ts
+++ b/frontend/src/pages/portfolio/board/use-board-data.ts
@@ -49,6 +49,8 @@ export interface Tile {
   reason: NoReadingReason | null
   /** Today's % change (live quote first, stored bar fallback). */
   todayPct: number | null
+  /** Last price — the magnitude behind the dimensionless σ (tooltip). */
+  price: number | null
   /** % change over each board window (from the shared 1mo series). */
   windowPct: Record<PctWindow, number | null>
   /** The 1mo close series the windows were derived from (tooltip sparkline). */
@@ -218,6 +220,7 @@ export function useBoardData(groupBy: GroupBy) {
         sigma,
         reason,
         todayPct: quote?.change_percent ?? snap?.change_pct ?? null,
+        price: quote?.price ?? snap?.close ?? null,
         windowPct: windowReturns[symbol] ?? EMPTY_WINDOWS,
         spark: series?.[symbol] ?? [],
         sections: sectionsBySymbol[symbol] ?? [],


### PR DESCRIPTION
Implements most of #609 — §1 through §4b–d of `claudedocs/board-tile-spec.md`,
which this PR also lands.

Closes #610, closes #611, closes #612, closes #613, closes #614.
Leaves #615 (measure the first `intraday` SSE frame) — that one's a measurement,
not a change.

## The tooltip (#611, #612, #610)

σ-Move is what makes 84 assets comparable in one grid; being dimensionless is
what it costs. The card hands back what the grid threw away — magnitude, recent
path, section membership — under two rules: **lead with whatever the tile isn't
showing**, and **a line either carries something no other line can, or it
doesn't exist**.

The old card restated the tile (two of its five lines were already under the
cursor) and printed `+4.12%` in flat black, because shadcn's default
`TooltipContent` is `bg-foreground` — near-white here, where emerald-400
measures **1.86:1** against **7.44:1** on `bg-popover`. It now uses the popover
surface and the finance colours work.

The sparkline is free: `useWindowReturns` already had the month's series in
memory and discarded it after reducing to three scalars.

Four no-reading states collapse to two shapes. Warmup gets a progress bar in
`--primary` on `--muted` — visibly outside the value language, because system
progress must not read as a reading. `feed_behind` / `gap` / `unknown` resolve
to the same user action, so they share one em dash and no prose; `reasonCopy()`
is gone. The variants stay discriminated in `use-board-data.ts`, where they
decide whether σ is withheld at all, with a comment saying so.

Also drops `PhaseIcon`'s native `title`, which sat inside the Radix trigger and
stacked the browser's own tooltip on the styled one ~500ms in. Hover delay
150ms → 450ms, so a 272px card appears when you *stop* on a tile.

## The load audit (#613, #614)

Sparklines were nine requests covering 94 symbol-series to obtain 84 distinct
ones. `useWindowReturns` even took `symbols` as a parameter and then ignored it,
looping over `useGroups()` and deduping the overlap afterwards. New
`GET /api/sparklines?symbols=` takes the roster directly — one request, no
duplicates, and thesis-only assets get window returns for the first time (they
belong to no group, so the old fetch could never reach them).

Indicator snapshots refetched wholesale on every Group ↔ Thesis toggle. Both
queries now key on the union over *both* groupings, so the toggle is free.

## One spec deviation, deliberate

**§4d — gating `useTheses()` to thesis mode — is not implemented, because it is
mutually exclusive with §4b.** The stable union roster that makes the toggle
free needs thesis data in *both* modes. Gating the hook would save one ~4KB
request and reintroduce a ~45KB refetch on every toggle. I took §4b; the
reasoning is in a comment at the `fetchSymbols` memo so it doesn't get "fixed"
later.

## Verification

- backend: `ruff` clean, **822 passed** (7 new tests in `test_sparklines.py`)
- frontend: `lint` clean, `build` clean, **44 passed** (4 new in `bell.test.ts`)
- endpoint exercised live against the dev stack with real tracked symbols;
  untracked symbols come back omitted rather than erroring
- both new modules transform without error under the Vite dev server

Not verified: the card's rendered appearance. I checked contrast ratios and
compile, not pixels — worth a look on the running board before merge.
