### PR TITLE
unit_kind + provenance: classification advised, not imposed

### DIFF
--- a/backend/alembic/versions/0020_backfill_index_asset_type.py
+++ b/backend/alembic/versions/0020_backfill_index_asset_type.py
@@ -1,25 +1,35 @@
-"""assets: backfill type='index' for ^-prefixed symbols
+"""assets: unit_kind + provenance, and backfill the drifted index rows
 
-Yahoo's quoteType decided an asset's type once at creation and was then
-frozen in the row. For six caret symbols it answered wrong — ^GSPC, ^N225,
-^HSI, ^STOXX50E, ^KS11 and ^TWII landed as 'stock', so every price surface
-formatted them as currency ("$6,9xx" for the S&P 500, "¥39xxx" for the
-Nikkei). Only ^TNX and ^TYX were typed correctly.
+Two related corrections in one revision, because they are the same mistake
+seen from two sides.
 
-A leading caret is Yahoo's index namespace, which is exactly what
-domain/instrument.py::classify() keys on. The predicate is inlined as SQL
-rather than imported from the app: a migration has to keep meaning the same
-thing years from now, and app code is free to change underneath it.
+**The data.** Yahoo's quoteType decided an asset's type once at creation and
+was then frozen in the row. For six caret symbols it answered wrong —
+^GSPC, ^N225, ^HSI, ^STOXX50E, ^KS11 and ^TWII landed as 'stock', so every
+price surface formatted them as currency ("$6,9xx" for the S&P 500,
+"¥39xxx" for the Nikkei). Only ^TNX and ^TYX were typed correctly.
 
-Note the literal is 'INDEX', not 'index'. SQLAlchemy's Enum(AssetType)
-persists the member *name*, so the rows read STOCK/ETF/INDEX. The assettype
-enum also carries an unused lowercase 'index' label from earlier drift —
-writing that one would round-trip to a LookupError, since it matches no
-AssetType member name.
+**The model.** Even typed as indices they were still wrong, because
+``currency`` is non-null and answers only *which* currency — there was no
+way to say "this is a rate" or "this has no unit". Percent-ness lived as a
+hardcoded four-ticker set in the frontend's format.ts, unreachable from the
+API. ``unit_kind`` gives that its own field.
 
-There is no downgrade. The pre-migration values were wrong rather than
-different, so restoring them would be restoring a bug — and 'stock' is not
-recoverable per-row anyway, since we'd have to guess which rows to corrupt.
+``type_source`` / ``unit_source`` record whether Fibenchi worked a value out
+or a human chose it. Everything predating this revision is by definition
+auto-detected — no UI ever wrote provenance — so AUTO is the correct
+backfill for every existing row, including the six being repaired here.
+
+Enum literals are the member *names* (INDEX, CURRENCY, AUTO), matching
+SQLAlchemy's default Enum() persistence and the rest of this schema. Note
+the assettype enum also carries an unused lowercase 'index' label from
+earlier drift; writing that one would round-trip to a LookupError.
+
+The predicate is inlined SQL rather than an import of classify(): a
+migration has to keep meaning the same thing after the app moves on.
+
+No downgrade for the type repair — the old values were wrong rather than
+different, so restoring them would be restoring a bug.
 
 Revision ID: 0020
 Revises: 0019
@@ -28,6 +38,7 @@ Create Date: 2026-08-12
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -36,12 +47,46 @@ down_revision: Union[str, None] = "0019"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+UNIT_KIND = sa.Enum("CURRENCY", "PERCENT", "POINTS", name="unitkind")
+FIELD_SOURCE = sa.Enum("AUTO", "USER", name="fieldsource")
+
+# Indices quoted as a rate, not a level — mirrors PERCENT_QUOTED_INDICES in
+# market_calendar/listings.py. Duplicated on purpose: see the note on inlining.
+PERCENT_INDICES = ("^TYX", "^TNX", "^FVX", "^IRX")
+
 
 def upgrade() -> None:
+    bind = op.get_bind()
+    UNIT_KIND.create(bind, checkfirst=True)
+    FIELD_SOURCE.create(bind, checkfirst=True)
+
+    op.add_column("assets", sa.Column("unit_kind", UNIT_KIND, nullable=False, server_default="CURRENCY"))
+    op.add_column("assets", sa.Column("type_source", FIELD_SOURCE, nullable=False, server_default="AUTO"))
+    op.add_column("assets", sa.Column("unit_source", FIELD_SOURCE, nullable=False, server_default="AUTO"))
+
     # LIKE '^%' — the caret is a literal here, only % and _ are wildcards.
     # Idempotent, and a no-op on instances that never tracked an index.
     op.execute("UPDATE assets SET type = 'INDEX' WHERE symbol LIKE '^%' AND type <> 'INDEX'")
 
+    # Order matters: percent first would be undone by the points sweep.
+    op.execute(
+        "UPDATE assets SET unit_kind = 'POINTS' WHERE symbol LIKE '^%'"
+    )
+    op.execute(
+        "UPDATE assets SET unit_kind = 'PERCENT' WHERE symbol IN "
+        f"({', '.join(repr(s) for s in PERCENT_INDICES)})"
+    )
+
 
 def downgrade() -> None:
-    """Deliberately empty — see the module docstring."""
+    """Drops the new columns only — the type repair is deliberately kept.
+
+    IF EXISTS throughout: a downgrade should be able to run against a
+    partially-applied revision without needing hand-repair first.
+    """
+    op.execute("ALTER TABLE assets DROP COLUMN IF EXISTS unit_source")
+    op.execute("ALTER TABLE assets DROP COLUMN IF EXISTS type_source")
+    op.execute("ALTER TABLE assets DROP COLUMN IF EXISTS unit_kind")
+    bind = op.get_bind()
+    FIELD_SOURCE.drop(bind, checkfirst=True)
+    UNIT_KIND.drop(bind, checkfirst=True)

--- a/backend/alembic/versions/0020_backfill_index_asset_type.py
+++ b/backend/alembic/versions/0020_backfill_index_asset_type.py
@@ -1,0 +1,47 @@
+"""assets: backfill type='index' for ^-prefixed symbols
+
+Yahoo's quoteType decided an asset's type once at creation and was then
+frozen in the row. For six caret symbols it answered wrong — ^GSPC, ^N225,
+^HSI, ^STOXX50E, ^KS11 and ^TWII landed as 'stock', so every price surface
+formatted them as currency ("$6,9xx" for the S&P 500, "¥39xxx" for the
+Nikkei). Only ^TNX and ^TYX were typed correctly.
+
+A leading caret is Yahoo's index namespace, which is exactly what
+domain/instrument.py::classify() keys on. The predicate is inlined as SQL
+rather than imported from the app: a migration has to keep meaning the same
+thing years from now, and app code is free to change underneath it.
+
+Note the literal is 'INDEX', not 'index'. SQLAlchemy's Enum(AssetType)
+persists the member *name*, so the rows read STOCK/ETF/INDEX. The assettype
+enum also carries an unused lowercase 'index' label from earlier drift —
+writing that one would round-trip to a LookupError, since it matches no
+AssetType member name.
+
+There is no downgrade. The pre-migration values were wrong rather than
+different, so restoring them would be restoring a bug — and 'stock' is not
+recoverable per-row anyway, since we'd have to guess which rows to corrupt.
+
+Revision ID: 0020
+Revises: 0019
+Create Date: 2026-08-12
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0020"
+down_revision: Union[str, None] = "0019"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # LIKE '^%' — the caret is a literal here, only % and _ are wildcards.
+    # Idempotent, and a no-op on instances that never tracked an index.
+    op.execute("UPDATE assets SET type = 'INDEX' WHERE symbol LIKE '^%' AND type <> 'INDEX'")
+
+
+def downgrade() -> None:
+    """Deliberately empty — see the module docstring."""

--- a/backend/app/domain/__init__.py
+++ b/backend/app/domain/__init__.py
@@ -4,7 +4,7 @@ on this layer.
 """
 
 from app.domain.assetref import AssetRef
-from app.domain.instrument import AssetKind, Instrument
+from app.domain.instrument import AssetKind, Instrument, UnitKind
 from app.domain.phases import Phase, Session
 
-__all__ = ["AssetKind", "AssetRef", "Instrument", "Phase", "Session"]
+__all__ = ["AssetKind", "AssetRef", "Instrument", "Phase", "Session", "UnitKind"]

--- a/backend/app/domain/assetref.py
+++ b/backend/app/domain/assetref.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from functools import cached_property
 
-from app.domain.instrument import AssetKind, Instrument, classify
+from app.domain.instrument import AssetKind, Instrument, UnitKind, classify
 from app.services.market_calendar.venue import Venue, _venue_for
 
 
@@ -68,6 +68,12 @@ class AssetRef(str):
         """What kind of instrument the ticker's shape says this is —
         ``ref.kind.is_future`` etc., never re-inspect the characters."""
         return self._instrument.kind
+
+    @property
+    def unit(self) -> UnitKind:
+        """How this ticker's price number should be read (currency/percent/
+        points) — the shape's recommendation, not the stored choice."""
+        return self._instrument.unit
 
     @property
     def calendar_name(self) -> str | None:

--- a/backend/app/domain/instrument.py
+++ b/backend/app/domain/instrument.py
@@ -2,8 +2,9 @@
 
 The one-pass ``classify`` is the single place ticker characters are
 interpreted. It decides *everything* the shape can tell — what kind of
-instrument it is, which venue calendar governs it, and its inferred
-currency — captured together in an :class:`Instrument` so no later code
+instrument it is, which venue calendar governs it, how its price number
+should be read, and its inferred currency — captured together in an
+:class:`Instrument` so no later code
 ever re-inspects the characters ("is this a future?" is
 ``ref.kind.is_future``, not another ``endswith`` somewhere).
 """
@@ -50,6 +51,25 @@ class AssetKind(str, Enum):
         return self is AssetKind.FUTURE
 
 
+class UnitKind(str, Enum):
+    """How an instrument's price number should be read.
+
+    Distinct from ``currency``, which only answers *which* currency and so
+    can't express the other two cases at all. A 30-year Treasury yield of
+    "46.28" is 4.628%, and the S&P 500 at "6912.34" is a level in points —
+    neither is denominated in anything, yet both were forced to carry a
+    currency code because the column is non-null.
+    """
+
+    CURRENCY = "currency"   # $71.40 — the currency field says which
+    PERCENT = "percent"     # 4.63% — the number is a rate
+    POINTS = "points"       # 6,912.34 — an index level, no unit
+
+    @property
+    def is_currency(self) -> bool:
+        return self is UnitKind.CURRENCY
+
+
 @dataclass(frozen=True)
 class Instrument:
     """Everything a ticker's shape can tell, decided once by ``classify``."""
@@ -57,6 +77,7 @@ class Instrument:
     kind: AssetKind
     calendar: str | None = None
     currency: str | None = None
+    unit: UnitKind = UnitKind.CURRENCY
 
 
 def classify(ticker: str) -> Instrument:
@@ -70,17 +91,23 @@ def classify(ticker: str) -> Instrument:
         DEFAULT_US_CALENDAR,
         FIAT_QUOTES,
         INDEX_CALENDARS,
+        PERCENT_QUOTED_INDICES,
         SUFFIX_LISTINGS,
         Listing,
     )
+
+    def index(sym: str, calendar: str | None = None) -> Instrument:
+        # An index is never denominated: it's a rate or a level, never money.
+        unit = UnitKind.PERCENT if sym in PERCENT_QUOTED_INDICES else UnitKind.POINTS
+        return Instrument(AssetKind.INDEX, calendar=calendar, unit=unit)
 
     sym = ticker.upper().strip()
     if not sym:
         return Instrument(AssetKind.UNKNOWN)
     if sym in INDEX_CALENDARS:
-        return Instrument(AssetKind.INDEX, calendar=INDEX_CALENDARS[sym])
+        return index(sym, INDEX_CALENDARS[sym])
     if sym.startswith("^"):
-        return Instrument(AssetKind.INDEX)  # unknown index — don't guess a venue
+        return index(sym)  # unknown index — don't guess a venue
     if sym.endswith("=X"):
         return Instrument(AssetKind.FX)      # not exchange-session shaped
     if sym.endswith("=F"):

--- a/backend/app/domain/provenance.py
+++ b/backend/app/domain/provenance.py
@@ -1,0 +1,24 @@
+"""Where a stored field's value came from.
+
+Only two answers matter: the app worked it out, or a human said so. That
+distinction is what lets a recommendation stay a recommendation — a field
+Fibenchi guessed can be re-guessed and offered up when the guess improves,
+while a field you chose is never second-guessed at you.
+
+Without it the choice collapses to overwrite-everything or
+overwrite-nothing, which is how six index assets sat mistyped for months:
+nothing could tell "Yahoo said stock once" from "the user means stock".
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class FieldSource(str, Enum):
+    AUTO = "auto"   # derived by Fibenchi; safe to re-derive and re-suggest
+    USER = "user"   # set deliberately by a human; suggestions stay quiet
+
+    @property
+    def is_auto(self) -> bool:
+        return self is FieldSource.AUTO

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -5,6 +5,8 @@ from sqlalchemy import DateTime, Enum, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+from app.domain.instrument import UnitKind
+from app.domain.provenance import FieldSource
 
 
 class AssetType(str, enum.Enum):
@@ -21,6 +23,22 @@ class Asset(Base):
     name: Mapped[str] = mapped_column(String(200))
     type: Mapped[AssetType] = mapped_column(Enum(AssetType))
     currency: Mapped[str] = mapped_column(String(10), default="EUR", server_default="EUR")
+    # How the price number reads. ``currency`` answers *which* currency and so
+    # can't express "percent" or "no unit at all" — an index had to claim a
+    # denomination it doesn't have. Only meaningful when unit_kind is CURRENCY.
+    unit_kind: Mapped[UnitKind] = mapped_column(
+        Enum(UnitKind), default=UnitKind.CURRENCY, server_default="CURRENCY",
+    )
+    # Provenance, per editable concept: did Fibenchi work this out, or did a
+    # human say so? AUTO fields may be re-suggested when the guess improves;
+    # USER fields are left alone. ``unit_source`` covers unit_kind *and*
+    # currency — they're one decision ("how is this quoted"), not two.
+    type_source: Mapped[FieldSource] = mapped_column(
+        Enum(FieldSource), default=FieldSource.AUTO, server_default="AUTO",
+    )
+    unit_source: Mapped[FieldSource] = mapped_column(
+        Enum(FieldSource), default=FieldSource.AUTO, server_default="AUTO",
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     prices: Mapped[list["PriceHistory"]] = relationship(back_populates="asset", cascade="all, delete-orphan")

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -4,8 +4,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.schemas.asset import AssetAttachments, AssetCreate, AssetResponse, AssetUpdate
 from app.services import asset_service
+from app.services.asset_suggestion import suggest_for_asset
 
 router = APIRouter(prefix="/api/assets", tags=["assets"])
+
+
+def _with_suggestion(asset):
+    """Attach Fibenchi's read on the row, for ``AssetResponse.suggested``.
+
+    A transient attribute rather than a column, and attached here rather than
+    in the service because it is a presentation concern: the suggestion is
+    re-derived on every read so it can never go stale, and is never written —
+    the whole point is that stored values change only when a user applies one.
+    """
+    asset.suggested = suggest_for_asset(asset)
+    return asset
 
 
 @router.get("", response_model=list[AssetResponse], summary="List all assets")
@@ -16,7 +29,7 @@ async def list_assets(db: AsyncSession = Depends(get_db)):
     until ``POST /api/groups/{id}/assets`` attaches them. Internal views that need
     only grouped assets use repository-level filters directly.
     """
-    return await asset_service.list_assets(db)
+    return [_with_suggestion(a) for a in await asset_service.list_assets(db)]
 
 
 @router.post("", response_model=AssetResponse, status_code=201, summary="Add an asset")
@@ -28,22 +41,27 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     ``POST /api/groups/{id}/assets`` afterwards to attach it to the Watchlist
     or any other group.
     """
-    return await asset_service.create_asset(db, data.symbol, data.name, data.type)
+    return _with_suggestion(await asset_service.create_asset(db, data.symbol, data.name, data.type))
 
 
 @router.patch("/{asset_id}", response_model=AssetResponse, summary="Update asset metadata")
 async def update_asset(asset_id: int, data: AssetUpdate, db: AsyncSession = Depends(get_db)):
-    """Patch an asset's metadata (name, type, currency). Useful for reclassifying
-    a ticker (e.g. stock → index) or fixing an incorrect auto-detected currency.
-    Fields omitted from the request body are left untouched.
+    """Patch an asset's metadata (name, type, currency, unit_kind). Useful for
+    reclassifying a ticker (e.g. stock → index), fixing an auto-detected
+    currency, or saying how the price number reads. Fields omitted from the
+    request body are left untouched.
+
+    Any field supplied is recorded as *your* choice, so Fibenchi stops
+    suggesting alternatives for it — see ``suggested`` on the response.
     """
-    return await asset_service.update_asset(
+    return _with_suggestion(await asset_service.update_asset(
         db,
         asset_id,
         name=data.name,
         asset_type=data.type,
         currency=data.currency,
-    )
+        unit_kind=data.unit_kind,
+    ))
 
 
 @router.get(

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -2,7 +2,13 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.schemas.asset import AssetAttachments, AssetCreate, AssetResponse, AssetUpdate
+from app.schemas.asset import (
+    AssetAttachments,
+    AssetCreate,
+    AssetDetectionReset,
+    AssetResponse,
+    AssetUpdate,
+)
 from app.services import asset_service
 from app.services.asset_suggestion import suggest_for_asset
 
@@ -62,6 +68,24 @@ async def update_asset(asset_id: int, data: AssetUpdate, db: AsyncSession = Depe
         currency=data.currency,
         unit_kind=data.unit_kind,
     ))
+
+
+@router.post(
+    "/{asset_id}/reset-detection",
+    response_model=AssetResponse,
+    summary="Hand classification fields back to auto-detection",
+)
+async def reset_detection(asset_id: int, data: AssetDetectionReset, db: AsyncSession = Depends(get_db)):
+    """Adopt Fibenchi's read for the named fields and clear their user flag, so
+    they track future improvements again.
+
+    The inverse of a PATCH: editing says "I've decided", this says "you decide".
+    ``currency`` is never reset — the shape's currency is a venue-suffix fallback,
+    weaker than Yahoo's, and inert once the unit says the number isn't money.
+    """
+    return _with_suggestion(
+        await asset_service.reset_asset_detection(db, asset_id, set(data.fields))
+    )
 
 
 @router.get(

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -10,21 +10,8 @@ from app.schemas.asset import (
     AssetUpdate,
 )
 from app.services import asset_service
-from app.services.asset_suggestion import suggest_for_asset
 
 router = APIRouter(prefix="/api/assets", tags=["assets"])
-
-
-def _with_suggestion(asset):
-    """Attach Fibenchi's read on the row, for ``AssetResponse.suggested``.
-
-    A transient attribute rather than a column, and attached here rather than
-    in the service because it is a presentation concern: the suggestion is
-    re-derived on every read so it can never go stale, and is never written —
-    the whole point is that stored values change only when a user applies one.
-    """
-    asset.suggested = suggest_for_asset(asset)
-    return asset
 
 
 @router.get("", response_model=list[AssetResponse], summary="List all assets")
@@ -35,7 +22,7 @@ async def list_assets(db: AsyncSession = Depends(get_db)):
     until ``POST /api/groups/{id}/assets`` attaches them. Internal views that need
     only grouped assets use repository-level filters directly.
     """
-    return [_with_suggestion(a) for a in await asset_service.list_assets(db)]
+    return await asset_service.list_assets(db)
 
 
 @router.post("", response_model=AssetResponse, status_code=201, summary="Add an asset")
@@ -47,7 +34,7 @@ async def create_asset(data: AssetCreate, db: AsyncSession = Depends(get_db)):
     ``POST /api/groups/{id}/assets`` afterwards to attach it to the Watchlist
     or any other group.
     """
-    return _with_suggestion(await asset_service.create_asset(db, data.symbol, data.name, data.type))
+    return await asset_service.create_asset(db, data.symbol, data.name, data.type)
 
 
 @router.patch("/{asset_id}", response_model=AssetResponse, summary="Update asset metadata")
@@ -60,14 +47,14 @@ async def update_asset(asset_id: int, data: AssetUpdate, db: AsyncSession = Depe
     Any field supplied is recorded as *your* choice, so Fibenchi stops
     suggesting alternatives for it — see ``suggested`` on the response.
     """
-    return _with_suggestion(await asset_service.update_asset(
+    return await asset_service.update_asset(
         db,
         asset_id,
         name=data.name,
         asset_type=data.type,
         currency=data.currency,
         unit_kind=data.unit_kind,
-    ))
+    )
 
 
 @router.post(
@@ -83,9 +70,7 @@ async def reset_detection(asset_id: int, data: AssetDetectionReset, db: AsyncSes
     ``currency`` is never reset — the shape's currency is a venue-suffix fallback,
     weaker than Yahoo's, and inert once the unit says the number isn't money.
     """
-    return _with_suggestion(
-        await asset_service.reset_asset_detection(db, asset_id, set(data.fields))
-    )
+    return await asset_service.reset_asset_detection(db, asset_id, set(data.fields))
 
 
 @router.get(

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -1,6 +1,6 @@
 import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.domain.instrument import UnitKind
 from app.domain.provenance import FieldSource
@@ -111,7 +111,7 @@ class AssetResponse(BaseModel):
         default=FieldSource.AUTO, description="Who set 'unit_kind'/'currency': auto or user",
     )
     suggested: AssetSuggestionResponse | None = Field(
-        default=None, description="Fibenchi's read on this ticker; null when not computed",
+        default=None, description="Fibenchi's read on this ticker",
     )
     created_at: datetime.datetime = Field(description="Timestamp when the asset was first added")
     tags: list[TagBrief] = Field(default=[], description="Tags attached to this asset")
@@ -124,3 +124,22 @@ class AssetResponse(BaseModel):
         """Convert raw Yahoo code (e.g. 'GBp') to display code ('GBP') for API responses."""
         display, _ = currency_lookup(v)
         return display
+
+    @model_validator(mode="after")
+    def derive_suggestion(self):
+        """Compute the suggestion here rather than in each router.
+
+        Every field it needs is already on this model, and attaching it
+        per-endpoint meant an asset served through /api/groups arrived with
+        ``suggested: null`` — so the edit dialog, which reads group data, could
+        never show one. Deriving it in the schema makes that unforgettable.
+        """
+        # Imported here: app.services imports app.schemas, so a module-level
+        # import would close the loop.
+        from app.services.asset_suggestion import suggest_for_asset
+
+        if self.suggested is None:
+            self.suggested = AssetSuggestionResponse.model_validate(
+                suggest_for_asset(self), from_attributes=True,
+            )
+        return self

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -38,6 +38,15 @@ class AssetUpdate(BaseModel):
     )
 
 
+class AssetDetectionReset(BaseModel):
+    """Which fields to hand back to auto-detection."""
+
+    fields: list[str] = Field(
+        default=["type", "unit_kind"],
+        description="Field names to reset: 'type' and/or 'unit_kind'. Defaults to both.",
+    )
+
+
 class TagBrief(BaseModel):
     id: int = Field(description="Tag ID")
     name: str = Field(description="Tag label (e.g. 'tech', 'growth')")
@@ -71,7 +80,20 @@ class AssetSuggestionResponse(BaseModel):
     type: AssetType = Field(description="Type the ticker's shape implies")
     unit_kind: UnitKind = Field(description="How the price number should read")
     currency: str | None = Field(default=None, description="Inferred currency, null for indices")
-    disagrees: list[str] = Field(default=[], description="Auto fields differing from stored values")
+    differs: list[str] = Field(
+        default=[],
+        description=(
+            "Fields where the shape meaningfully differs from the stored value, whoever "
+            "set it. These are the fields that can be reset to auto-detection."
+        ),
+    )
+    disagrees: list[str] = Field(
+        default=[],
+        description=(
+            "The subset of 'differs' still auto-detected — what may be surfaced "
+            "unprompted. A user-set field never appears here."
+        ),
+    )
 
 
 class AssetResponse(BaseModel):

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -2,6 +2,8 @@ import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.domain.instrument import UnitKind
+from app.domain.provenance import FieldSource
 from app.models.asset import AssetType
 from app.services.currency_service import lookup as currency_lookup
 
@@ -9,13 +11,31 @@ from app.services.currency_service import lookup as currency_lookup
 class AssetCreate(BaseModel):
     symbol: str = Field(max_length=20, description="Ticker symbol (e.g. AAPL, VOO). Validated against Yahoo Finance.")
     name: str | None = Field(default=None, max_length=200, description="Display name. Auto-detected from Yahoo Finance if omitted.")
-    type: AssetType = Field(default=AssetType.STOCK, description="Asset type: stock or etf. Auto-detected if name is omitted.")
+    type: AssetType | None = Field(
+        default=None,
+        description=(
+            "Asset type. Omit to let Fibenchi decide (recorded as auto-detected, and "
+            "re-suggested if the guess later improves); supplying one marks it as your "
+            "choice, which suppresses suggestions against it."
+        ),
+    )
 
 
 class AssetUpdate(BaseModel):
+    """Partial update. Any field supplied here is recorded as a user choice, so
+    Fibenchi stops suggesting alternatives for it."""
+
     name: str | None = Field(default=None, max_length=200, description="New display name.")
     type: AssetType | None = Field(default=None, description="Override asset type (stock/etf/index).")
     currency: str | None = Field(default=None, max_length=10, description="Override currency code (e.g. 'USD', 'EUR').")
+    unit_kind: UnitKind | None = Field(
+        default=None,
+        description=(
+            "Override how the price number reads: 'currency' (uses the currency field), "
+            "'percent' (the number is a rate, e.g. a Treasury yield), or 'points' "
+            "(an index level, no unit)."
+        ),
+    )
 
 
 class TagBrief(BaseModel):
@@ -40,12 +60,37 @@ class AssetAttachments(BaseModel):
     annotation_count: int = Field(default=0, description="Number of chart annotations")
 
 
+class AssetSuggestionResponse(BaseModel):
+    """What Fibenchi reads the ticker as — advisory, never applied on its own.
+
+    ``disagrees`` lists only fields that are still auto-detected *and* differ
+    from what is stored; a field the user set never appears, however much the
+    shape disagrees with it. An empty list means there is nothing to show.
+    """
+
+    type: AssetType = Field(description="Type the ticker's shape implies")
+    unit_kind: UnitKind = Field(description="How the price number should read")
+    currency: str | None = Field(default=None, description="Inferred currency, null for indices")
+    disagrees: list[str] = Field(default=[], description="Auto fields differing from stored values")
+
+
 class AssetResponse(BaseModel):
     id: int = Field(description="Internal asset ID")
     symbol: str = Field(description="Ticker symbol")
     name: str = Field(description="Display name")
     type: AssetType = Field(description="Asset type: stock or etf")
     currency: str = Field(default="USD", description="ISO 4217 currency code")
+    unit_kind: UnitKind = Field(
+        default=UnitKind.CURRENCY,
+        description="How the price number reads: currency, percent, or points",
+    )
+    type_source: FieldSource = Field(default=FieldSource.AUTO, description="Who set 'type': auto or user")
+    unit_source: FieldSource = Field(
+        default=FieldSource.AUTO, description="Who set 'unit_kind'/'currency': auto or user",
+    )
+    suggested: AssetSuggestionResponse | None = Field(
+        default=None, description="Fibenchi's read on this ticker; null when not computed",
+    )
     created_at: datetime.datetime = Field(description="Timestamp when the asset was first added")
     tags: list[TagBrief] = Field(default=[], description="Tags attached to this asset")
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -2,7 +2,8 @@ from fastapi import HTTPException
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.domain import AssetRef
+from app.domain import AssetRef, UnitKind
+from app.domain.provenance import FieldSource
 from app.models import (
     Annotation,
     Asset,
@@ -16,6 +17,7 @@ from app.models import (
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
 from app.schemas.asset import AssetAttachments
+from app.services.asset_suggestion import suggest_for
 from app.services.currency_service import ensure_currency
 from app.services.entity_lookups import get_asset
 from app.services.yahoo import yahoo_client
@@ -29,11 +31,17 @@ async def create_asset(
     db: AsyncSession,
     symbol: str,
     name: str | None,
-    asset_type: AssetType,
+    asset_type: AssetType | None = None,
 ):
     """Create an asset row. Group attachment is the caller's responsibility —
     use ``POST /api/groups/{id}/assets`` afterwards to put it in a group
-    (Watchlist or otherwise)."""
+    (Watchlist or otherwise).
+
+    ``asset_type`` None means "you decide" and is recorded as AUTO; an
+    explicit value is a human's call and is recorded as USER, which keeps
+    later suggestions quiet about it. The two were indistinguishable while
+    the schema defaulted to STOCK.
+    """
     repo = AssetRepository(db)
     symbol = symbol.upper()
 
@@ -42,32 +50,31 @@ async def create_asset(
         return existing
 
     ref = AssetRef(symbol)
+    suggestion = suggest_for(ref)
     info = await yahoo_client.validate(symbol)
     if not info:
         if not name:
             raise HTTPException(404, f"Symbol {symbol} not found on Yahoo Finance")
         currency = ref.currency or "USD"
+        detected = suggestion.type
     else:
         currency = info.get("currency_code") or info.get("currency", "USD")
         if not name:
             name = info["name"]
-        if info["type"] == "ETF":
-            asset_type = AssetType.ETF
-        elif info["type"] == "INDEX":
-            asset_type = AssetType.INDEX
-
-    # Shape has the last word on index-ness. Yahoo's quoteType is a live lookup
-    # resolved once and then frozen in the row, and it has already been wrong:
-    # ^GSPC, ^N225 and four others landed as stock and rendered with a currency
-    # symbol ever since. classify() answers the same question from the ticker
-    # alone, deterministically and offline, so it can't disagree with itself
-    # later. Yahoo stays authoritative for ETF-vs-stock, which shape can't see.
-    if ref.kind.is_index:
-        asset_type = AssetType.INDEX
+        # Yahoo owns the ETF/stock call — shape can't see that distinction —
+        # but shape owns index-ness, because quoteType is a live lookup frozen
+        # into the row and it has already been wrong (see migration 0020).
+        detected = AssetType.ETF if info["type"] == "ETF" else suggestion.type
 
     await ensure_currency(db, currency)
     return await repo.create(
-        symbol=symbol, name=name, type=asset_type, currency=currency,
+        symbol=symbol,
+        name=name,
+        type=asset_type or detected,
+        type_source=FieldSource.AUTO if asset_type is None else FieldSource.USER,
+        currency=currency,
+        unit_kind=suggestion.unit_kind,
+        unit_source=FieldSource.AUTO,
     )
 
 
@@ -77,12 +84,18 @@ async def update_asset(
     name: str | None = None,
     asset_type: AssetType | None = None,
     currency: str | None = None,
+    unit_kind: UnitKind | None = None,
 ):
-    """Apply partial updates to an asset row (name, type, currency).
+    """Apply partial updates to an asset row (name, type, currency, unit).
 
-    Lets users reclassify a ticker after the fact (e.g. flip an index that
-    was auto-detected as a stock to ``AssetType.INDEX``) and override the
-    Yahoo-derived currency. None-valued fields are left untouched.
+    Lets users reclassify a ticker after the fact and override the
+    Yahoo-derived currency or unit. None-valued fields are left untouched.
+
+    Touching a field marks it USER, which is what stops Fibenchi from
+    suggesting against it afterwards — the point isn't that the value is
+    right, it's that a human decided it. ``unit_source`` covers both
+    ``unit_kind`` and ``currency``: they answer one question together, so
+    setting either means the caller has taken over the whole answer.
     """
     asset = await db.get(Asset, asset_id)
     if not asset:
@@ -92,9 +105,14 @@ async def update_asset(
         asset.name = name
     if asset_type is not None:
         asset.type = asset_type
+        asset.type_source = FieldSource.USER
     if currency is not None:
         await ensure_currency(db, currency)
         asset.currency = currency
+        asset.unit_source = FieldSource.USER
+    if unit_kind is not None:
+        asset.unit_kind = unit_kind
+        asset.unit_source = FieldSource.USER
 
     return await AssetRepository(db).save(asset)
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -17,7 +17,7 @@ from app.models import (
 from app.repositories.asset_repo import AssetRepository
 from app.repositories.group_repo import GroupRepository
 from app.schemas.asset import AssetAttachments
-from app.services.asset_suggestion import suggest_for
+from app.services.asset_suggestion import reset_detection, suggest_for
 from app.services.currency_service import ensure_currency
 from app.services.entity_lookups import get_asset
 from app.services.yahoo import yahoo_client
@@ -114,6 +114,21 @@ async def update_asset(
         asset.unit_kind = unit_kind
         asset.unit_source = FieldSource.USER
 
+    return await AssetRepository(db).save(asset)
+
+
+async def reset_asset_detection(db: AsyncSession, asset_id: int, fields: set[str]):
+    """Hand the named fields back to auto-detection.
+
+    The inverse of an edit: an edit says "I've decided", this says "you decide
+    again". Without it a classification choice would be one-way — the recommendation
+    invisible forever and the value only changeable by hand — which is not what
+    "Fibenchi doesn't argue with you" was supposed to mean.
+    """
+    asset = await db.get(Asset, asset_id)
+    if not asset:
+        raise HTTPException(404, f"Asset {asset_id} not found")
+    await reset_detection(asset, fields)
     return await AssetRepository(db).save(asset)
 
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -41,11 +41,12 @@ async def create_asset(
     if existing:
         return existing
 
+    ref = AssetRef(symbol)
     info = await yahoo_client.validate(symbol)
     if not info:
         if not name:
             raise HTTPException(404, f"Symbol {symbol} not found on Yahoo Finance")
-        currency = AssetRef(symbol).currency or "USD"
+        currency = ref.currency or "USD"
     else:
         currency = info.get("currency_code") or info.get("currency", "USD")
         if not name:
@@ -54,6 +55,15 @@ async def create_asset(
             asset_type = AssetType.ETF
         elif info["type"] == "INDEX":
             asset_type = AssetType.INDEX
+
+    # Shape has the last word on index-ness. Yahoo's quoteType is a live lookup
+    # resolved once and then frozen in the row, and it has already been wrong:
+    # ^GSPC, ^N225 and four others landed as stock and rendered with a currency
+    # symbol ever since. classify() answers the same question from the ticker
+    # alone, deterministically and offline, so it can't disagree with itself
+    # later. Yahoo stays authoritative for ETF-vs-stock, which shape can't see.
+    if ref.kind.is_index:
+        asset_type = AssetType.INDEX
 
     await ensure_currency(db, currency)
     return await repo.create(

--- a/backend/app/services/asset_suggestion.py
+++ b/backend/app/services/asset_suggestion.py
@@ -110,8 +110,3 @@ async def reset_detection(asset: Asset, fields: set[str]) -> None:
     if "unit_kind" in fields:
         asset.unit_kind = base.unit_kind
         asset.unit_source = FieldSource.AUTO
-
-
-def source_for(explicit: object | None) -> FieldSource:
-    """USER when a caller supplied a value, AUTO when it left the field alone."""
-    return FieldSource.USER if explicit is not None else FieldSource.AUTO

--- a/backend/app/services/asset_suggestion.py
+++ b/backend/app/services/asset_suggestion.py
@@ -1,0 +1,78 @@
+"""What Fibenchi thinks an asset is, offered rather than imposed.
+
+``classify`` already decides everything a ticker's shape can tell. This
+module turns that into a *proposal* about the two stored fields a user can
+edit — the asset's type and how its price reads — and answers whether the
+proposal disagrees with what's stored.
+
+The policy lives here, in one place, so it can't drift between the create
+path and the read path:
+
+- A field the app derived (``FieldSource.AUTO``) may be re-derived and
+  offered up when the guess improves.
+- A field a human set (``FieldSource.USER``) is never argued with. The
+  suggestion is still computed — it just isn't flagged as disagreeing, so
+  the UI has nothing to nag about.
+
+Nothing here writes. Stored values change only when a user applies a
+suggestion, which is an ordinary update through ``update_asset``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.domain import AssetRef, UnitKind
+from app.domain.provenance import FieldSource
+from app.models import Asset, AssetType
+
+
+@dataclass(frozen=True)
+class AssetSuggestion:
+    """The shape's read on an asset, plus where it disagrees with the row."""
+
+    type: AssetType
+    unit_kind: UnitKind
+    currency: str | None
+    #: Fields that are AUTO *and* differ from what's stored — i.e. the ones
+    #: worth showing the user. A USER-set field never appears here.
+    disagrees: frozenset[str] = frozenset()
+
+    @property
+    def has_disagreement(self) -> bool:
+        return bool(self.disagrees)
+
+
+def suggest_for(ref: AssetRef) -> AssetSuggestion:
+    """The shape's read on a ticker, with no stored row to compare against."""
+    if ref.kind.is_index:
+        # An index is a rate or a level, never money — so it carries no
+        # currency, and unit_kind is the only thing that says how to read it.
+        return AssetSuggestion(AssetType.INDEX, ref.unit, None)
+    # Shape can't tell an ETF from a stock; that call stays with Yahoo, and
+    # STOCK is only the fallback when nothing better is known.
+    return AssetSuggestion(AssetType.STOCK, ref.unit, ref.currency)
+
+
+def suggest_for_asset(asset: Asset) -> AssetSuggestion:
+    """The shape's read on a stored asset, flagging only actionable gaps."""
+    base = suggest_for(AssetRef(asset.symbol))
+
+    disagrees: set[str] = set()
+    # Type: only meaningful for indices. Shape can't distinguish stock from
+    # ETF, so proposing STOCK over a stored ETF would be noise, not a finding.
+    if (
+        asset.type_source.is_auto
+        and base.type is AssetType.INDEX
+        and asset.type is not AssetType.INDEX
+    ):
+        disagrees.add("type")
+    if asset.unit_source.is_auto and base.unit_kind is not asset.unit_kind:
+        disagrees.add("unit_kind")
+
+    return AssetSuggestion(base.type, base.unit_kind, base.currency, frozenset(disagrees))
+
+
+def source_for(explicit: object | None) -> FieldSource:
+    """USER when a caller supplied a value, AUTO when it left the field alone."""
+    return FieldSource.USER if explicit is not None else FieldSource.AUTO

--- a/backend/app/services/asset_suggestion.py
+++ b/backend/app/services/asset_suggestion.py
@@ -34,13 +34,14 @@ class AssetSuggestion:
     type: AssetType
     unit_kind: UnitKind
     currency: str | None
-    #: Fields that are AUTO *and* differ from what's stored — i.e. the ones
-    #: worth showing the user. A USER-set field never appears here.
+    #: Fields where the shape meaningfully differs from what's stored,
+    #: regardless of who stored it. This is what makes a value *resettable*.
+    differs: frozenset[str] = frozenset()
+    #: The subset of ``differs`` that is still AUTO — i.e. what Fibenchi may
+    #: raise unprompted. A field the user set never appears here, however much
+    #: the shape disagrees with it; going looking for that is the user's move,
+    #: which is why ``differs`` is exposed separately.
     disagrees: frozenset[str] = frozenset()
-
-    @property
-    def has_disagreement(self) -> bool:
-        return bool(self.disagrees)
 
 
 def suggest_for(ref: AssetRef) -> AssetSuggestion:
@@ -55,22 +56,44 @@ def suggest_for(ref: AssetRef) -> AssetSuggestion:
 
 
 def suggest_for_asset(asset: Asset) -> AssetSuggestion:
-    """The shape's read on a stored asset, flagging only actionable gaps."""
+    """The shape's read on a stored asset, and where it differs from the row."""
     base = suggest_for(AssetRef(asset.symbol))
 
-    disagrees: set[str] = set()
+    differs: set[str] = set()
     # Type: only meaningful for indices. Shape can't distinguish stock from
     # ETF, so proposing STOCK over a stored ETF would be noise, not a finding.
-    if (
-        asset.type_source.is_auto
-        and base.type is AssetType.INDEX
-        and asset.type is not AssetType.INDEX
-    ):
-        disagrees.add("type")
-    if asset.unit_source.is_auto and base.unit_kind is not asset.unit_kind:
-        disagrees.add("unit_kind")
+    if base.type is AssetType.INDEX and asset.type is not AssetType.INDEX:
+        differs.add("type")
+    if base.unit_kind is not asset.unit_kind:
+        differs.add("unit_kind")
 
-    return AssetSuggestion(base.type, base.unit_kind, base.currency, frozenset(disagrees))
+    # Provenance gates only the *unprompted* half. A user-set field stays in
+    # ``differs`` so it remains resettable and can be shown on request —
+    # "don't argue with you" must not collapse into "never speak again".
+    source = {"type": asset.type_source, "unit_kind": asset.unit_source}
+    disagrees = {f for f in differs if source[f].is_auto}
+
+    return AssetSuggestion(
+        base.type, base.unit_kind, base.currency, frozenset(differs), frozenset(disagrees),
+    )
+
+
+async def reset_detection(asset: Asset, fields: set[str]) -> None:
+    """Hand a field back to auto-detection: adopt the shape's answer, and
+    clear the provenance so future improvements are picked up again.
+
+    ``currency`` is deliberately not reset. The shape's currency is a
+    *fallback* inferred from the venue suffix — Yahoo's answer is better, and
+    an index's currency is inert anyway once unit_kind says the number isn't
+    money. Resetting it could only make things worse.
+    """
+    base = suggest_for(AssetRef(asset.symbol))
+    if "type" in fields:
+        asset.type = base.type
+        asset.type_source = FieldSource.AUTO
+    if "unit_kind" in fields:
+        asset.unit_kind = base.unit_kind
+        asset.unit_source = FieldSource.AUTO
 
 
 def source_for(explicit: object | None) -> FieldSource:

--- a/backend/app/services/asset_suggestion.py
+++ b/backend/app/services/asset_suggestion.py
@@ -21,10 +21,26 @@ suggestion, which is an ordinary update through ``update_asset``.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from app.domain import AssetRef, UnitKind
 from app.domain.provenance import FieldSource
 from app.models import Asset, AssetType
+
+
+class Classified(Protocol):
+    """The fields a suggestion is computed from.
+
+    A Protocol rather than ``Asset`` because ``AssetResponse`` carries exactly
+    these too, and deriving the suggestion in the response schema is what stops
+    it depending on which router happened to remember to attach it.
+    """
+
+    symbol: str
+    type: AssetType
+    unit_kind: UnitKind
+    type_source: FieldSource
+    unit_source: FieldSource
 
 
 @dataclass(frozen=True)
@@ -55,7 +71,7 @@ def suggest_for(ref: AssetRef) -> AssetSuggestion:
     return AssetSuggestion(AssetType.STOCK, ref.unit, ref.currency)
 
 
-def suggest_for_asset(asset: Asset) -> AssetSuggestion:
+def suggest_for_asset(asset: Classified) -> AssetSuggestion:
     """The shape's read on a stored asset, and where it differs from the row."""
     base = suggest_for(AssetRef(asset.symbol))
 

--- a/backend/app/services/market_calendar/listings.py
+++ b/backend/app/services/market_calendar/listings.py
@@ -105,6 +105,21 @@ INDEX_CALENDARS: dict[str, str] = {
     "^HSI": "XHKG",
 }
 
+# Indices quoted as a rate rather than a level: the number *is* a percentage,
+# so "4.63" means 4.63%, not 4.63 points and certainly not $4.63. Every other
+# index is a level in points and carries no unit at all.
+#
+# This lived in the frontend as a hardcoded set in format.ts, which meant a
+# yield index outside those four rendered as bare points with no way for the
+# user to say otherwise. It's venue-adjacent trait data keyed by symbol, same
+# as INDEX_CALENDARS above, so it belongs in the same table file.
+PERCENT_QUOTED_INDICES: frozenset[str] = frozenset({
+    "^TYX",   # CBOE 30-year Treasury yield
+    "^TNX",   # CBOE 10-year Treasury yield
+    "^FVX",   # CBOE 5-year Treasury yield
+    "^IRX",   # CBOE 13-week T-bill rate
+})
+
 # Unsuffixed Yahoo symbols are US listings (NYSE/NASDAQ share the holiday set).
 DEFAULT_US_CALENDAR = "XNYS"
 

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -266,3 +266,50 @@ async def test_list_assets_includes_orphans(client):
     assert resp.status_code == 200
     symbols = [a["symbol"] for a in resp.json()]
     assert "OKLO" in symbols
+
+
+# --- Index classification (#617) ---
+#
+# Yahoo's quoteType is a live lookup frozen into the row at creation, and it
+# has been wrong: six caret symbols landed as stock and formatted as currency
+# ever since. The ticker's shape answers the same question offline and can't
+# drift, so it gets the last word.
+
+async def test_caret_symbol_is_index_despite_yahoo_saying_equity(client):
+    """The exact ^GSPC failure: Yahoo calls it EQUITY, shape overrules."""
+    mock_info = {"symbol": "^GSPC", "name": "S&P 500", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        resp = await client.post("/api/assets", json={"symbol": "^GSPC"})
+    assert resp.status_code == 201
+    assert resp.json()["type"] == "index"
+
+
+async def test_caret_symbol_is_index_when_yahoo_agrees(client):
+    mock_info = {"symbol": "^TYX", "name": "Treasury Yield 30 Years", "type": "INDEX", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        resp = await client.post("/api/assets", json={"symbol": "^TYX"})
+    assert resp.status_code == 201
+    assert resp.json()["type"] == "index"
+
+
+async def test_caret_symbol_is_index_over_explicit_request(client):
+    """A caller asking for type=stock on a caret symbol doesn't get one — the
+    shape isn't a preference, and a mis-typed index is what caused #617."""
+    mock_info = {"symbol": "^N225", "name": "Nikkei 225", "type": "EQUITY", "currency": "JPY", "currency_code": "JPY"}
+    with _mock_validate(return_value=mock_info):
+        resp = await client.post("/api/assets", json={"symbol": "^N225", "type": "stock"})
+    assert resp.status_code == 201
+    assert resp.json()["type"] == "index"
+
+
+async def test_yahoo_still_decides_etf_vs_stock(client):
+    """Shape can't see the ETF/stock distinction, so Yahoo keeps that call."""
+    mock_info = {"symbol": "VWCE.DE", "name": "Vanguard FTSE All-World", "type": "ETF", "currency": "EUR", "currency_code": "EUR"}
+    with _mock_validate(return_value=mock_info):
+        resp = await client.post("/api/assets", json={"symbol": "VWCE.DE"})
+    assert resp.json()["type"] == "etf"
+
+    mock_info = {"symbol": "AAPL", "name": "Apple Inc.", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        resp = await client.post("/api/assets", json={"symbol": "AAPL"})
+    assert resp.json()["type"] == "stock"

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -379,3 +379,72 @@ async def test_patching_currency_also_claims_the_unit(client):
     resp = await client.patch(f"/api/assets/{created.json()['id']}", json={"currency": "EUR"})
     assert resp.json()["currency"] == "EUR"
     assert resp.json()["unit_source"] == "user"
+
+
+async def test_user_set_field_stays_visible_and_resettable(client, db):
+    """"Don't argue with you" must not collapse into "never speak again".
+
+    A field the user set leaves `disagrees` (no nagging) but stays in
+    `differs` — otherwise the recommendation vanishes the moment you touch the
+    field, and the choice becomes one-way.
+    """
+    mock_info = {"symbol": "^N225", "name": "Nikkei 225", "type": "EQUITY", "currency": "JPY", "currency_code": "JPY"}
+    with _mock_validate(return_value=mock_info):
+        created = await client.post("/api/assets", json={"symbol": "^N225"})
+    aid = created.json()["id"]
+
+    resp = await client.patch(f"/api/assets/{aid}", json={"type": "etf", "unit_kind": "currency"})
+    data = resp.json()
+    assert data["type"] == "etf"
+    assert data["suggested"]["disagrees"] == []          # quiet
+    assert set(data["suggested"]["differs"]) == {"type", "unit_kind"}  # but visible
+
+
+async def test_reset_detection_restores_auto(client):
+    """The inverse of an edit: adopt the shape's answer and clear the flag, so
+    the field tracks improvements again."""
+    mock_info = {"symbol": "^N225", "name": "Nikkei 225", "type": "EQUITY", "currency": "JPY", "currency_code": "JPY"}
+    with _mock_validate(return_value=mock_info):
+        created = await client.post("/api/assets", json={"symbol": "^N225"})
+    aid = created.json()["id"]
+    await client.patch(f"/api/assets/{aid}", json={"type": "etf", "unit_kind": "currency"})
+
+    resp = await client.post(f"/api/assets/{aid}/reset-detection", json={})
+    data = resp.json()
+    assert resp.status_code == 200
+    assert data["type"] == "index"
+    assert data["unit_kind"] == "points"
+    assert data["type_source"] == "auto"
+    assert data["unit_source"] == "auto"
+    assert data["suggested"]["differs"] == []
+
+
+async def test_reset_detection_is_per_field(client):
+    mock_info = {"symbol": "^N225", "name": "Nikkei 225", "type": "EQUITY", "currency": "JPY", "currency_code": "JPY"}
+    with _mock_validate(return_value=mock_info):
+        created = await client.post("/api/assets", json={"symbol": "^N225"})
+    aid = created.json()["id"]
+    await client.patch(f"/api/assets/{aid}", json={"type": "etf", "unit_kind": "currency"})
+
+    resp = await client.post(f"/api/assets/{aid}/reset-detection", json={"fields": ["unit_kind"]})
+    data = resp.json()
+    assert data["unit_kind"] == "points" and data["unit_source"] == "auto"
+    assert data["type"] == "etf" and data["type_source"] == "user"
+
+
+async def test_reset_detection_leaves_currency_alone(client):
+    """The shape's currency is a venue-suffix fallback, weaker than Yahoo's —
+    resetting it could only make things worse."""
+    mock_info = {"symbol": "AAPL", "name": "Apple Inc.", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        created = await client.post("/api/assets", json={"symbol": "AAPL"})
+    aid = created.json()["id"]
+    await client.patch(f"/api/assets/{aid}", json={"currency": "EUR"})
+
+    resp = await client.post(f"/api/assets/{aid}/reset-detection", json={})
+    assert resp.json()["currency"] == "EUR"
+
+
+async def test_reset_detection_unknown_asset_404(client):
+    resp = await client.post("/api/assets/9999/reset-detection", json={})
+    assert resp.status_code == 404

--- a/backend/tests/integration/test_assets.py
+++ b/backend/tests/integration/test_assets.py
@@ -268,38 +268,44 @@ async def test_list_assets_includes_orphans(client):
     assert "OKLO" in symbols
 
 
-# --- Index classification (#617) ---
+# --- Classification, units and provenance (#617) ---
 #
-# Yahoo's quoteType is a live lookup frozen into the row at creation, and it
-# has been wrong: six caret symbols landed as stock and formatted as currency
-# ever since. The ticker's shape answers the same question offline and can't
-# drift, so it gets the last word.
+# Yahoo's quoteType is a live lookup frozen into the row at creation, and it has
+# been wrong: six caret symbols landed as stock and formatted as currency ever
+# since. Shape answers the same question offline and can't drift. But shape does
+# not get to overrule a human — provenance is what keeps a recommendation a
+# recommendation.
 
-async def test_caret_symbol_is_index_despite_yahoo_saying_equity(client):
-    """The exact ^GSPC failure: Yahoo calls it EQUITY, shape overrules."""
+async def test_caret_symbol_detected_as_index(client):
+    """The exact ^GSPC failure: Yahoo says EQUITY, shape says index."""
     mock_info = {"symbol": "^GSPC", "name": "S&P 500", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
     with _mock_validate(return_value=mock_info):
         resp = await client.post("/api/assets", json={"symbol": "^GSPC"})
     assert resp.status_code == 201
-    assert resp.json()["type"] == "index"
+    data = resp.json()
+    assert data["type"] == "index"
+    assert data["unit_kind"] == "points"
+    assert data["type_source"] == "auto"
 
 
-async def test_caret_symbol_is_index_when_yahoo_agrees(client):
+async def test_yield_index_is_quoted_in_percent(client):
     mock_info = {"symbol": "^TYX", "name": "Treasury Yield 30 Years", "type": "INDEX", "currency": "USD", "currency_code": "USD"}
     with _mock_validate(return_value=mock_info):
         resp = await client.post("/api/assets", json={"symbol": "^TYX"})
-    assert resp.status_code == 201
-    assert resp.json()["type"] == "index"
+    assert resp.json()["unit_kind"] == "percent"
 
 
-async def test_caret_symbol_is_index_over_explicit_request(client):
-    """A caller asking for type=stock on a caret symbol doesn't get one — the
-    shape isn't a preference, and a mis-typed index is what caused #617."""
+async def test_explicit_type_is_honoured_and_marked_user(client):
+    """Shape does not overrule a human. An explicit type is a decision, and
+    recording it as USER is what stops Fibenchi arguing with it later."""
     mock_info = {"symbol": "^N225", "name": "Nikkei 225", "type": "EQUITY", "currency": "JPY", "currency_code": "JPY"}
     with _mock_validate(return_value=mock_info):
         resp = await client.post("/api/assets", json={"symbol": "^N225", "type": "stock"})
-    assert resp.status_code == 201
-    assert resp.json()["type"] == "index"
+    data = resp.json()
+    assert data["type"] == "stock"
+    assert data["type_source"] == "user"
+    # ...and the suggestion stays silent about the field the user owns.
+    assert "type" not in data["suggested"]["disagrees"]
 
 
 async def test_yahoo_still_decides_etf_vs_stock(client):
@@ -308,8 +314,68 @@ async def test_yahoo_still_decides_etf_vs_stock(client):
     with _mock_validate(return_value=mock_info):
         resp = await client.post("/api/assets", json={"symbol": "VWCE.DE"})
     assert resp.json()["type"] == "etf"
+    assert resp.json()["unit_kind"] == "currency"
 
+
+async def test_suggestion_is_silent_when_it_agrees(client):
     mock_info = {"symbol": "AAPL", "name": "Apple Inc.", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
     with _mock_validate(return_value=mock_info):
         resp = await client.post("/api/assets", json={"symbol": "AAPL"})
-    assert resp.json()["type"] == "stock"
+    assert resp.json()["suggested"]["disagrees"] == []
+
+
+async def test_suggestion_flags_a_drifted_auto_row(client, db):
+    """A row Fibenchi guessed wrong should offer itself up for correction."""
+    from app.models import Asset, AssetType
+
+    mock_info = {"symbol": "^GSPC", "name": "S&P 500", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        created = await client.post("/api/assets", json={"symbol": "^GSPC"})
+
+    # Simulate the pre-migration state: auto-detected, and wrong.
+    asset = await db.get(Asset, created.json()["id"])
+    asset.type = AssetType.STOCK
+    asset.unit_kind = "CURRENCY"
+    await db.commit()
+
+    resp = await client.get("/api/assets")
+    data = [a for a in resp.json() if a["symbol"] == "^GSPC"][0]
+    assert set(data["suggested"]["disagrees"]) == {"type", "unit_kind"}
+    assert data["suggested"]["type"] == "index"
+    assert data["suggested"]["unit_kind"] == "points"
+    # Advisory only — nothing was rewritten behind the user's back.
+    assert data["type"] == "stock"
+
+
+async def test_editing_a_field_silences_its_suggestion(client, db):
+    """The whole point of provenance: once you decide, Fibenchi stops nagging —
+    even though the shape still disagrees just as much."""
+    from app.models import Asset
+
+    mock_info = {"symbol": "^GSPC", "name": "S&P 500", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        created = await client.post("/api/assets", json={"symbol": "^GSPC"})
+    aid = created.json()["id"]
+
+    asset = await db.get(Asset, aid)
+    asset.unit_kind = "CURRENCY"
+    await db.commit()
+    before = await client.get("/api/assets")
+    assert "unit_kind" in [a for a in before.json() if a["id"] == aid][0]["suggested"]["disagrees"]
+
+    resp = await client.patch(f"/api/assets/{aid}", json={"unit_kind": "currency"})
+    assert resp.status_code == 200
+    assert resp.json()["unit_source"] == "user"
+    assert resp.json()["suggested"]["disagrees"] == []
+
+
+async def test_patching_currency_also_claims_the_unit(client):
+    """unit_kind and currency answer one question together, so taking over
+    either means taking over both."""
+    mock_info = {"symbol": "AAPL", "name": "Apple Inc.", "type": "EQUITY", "currency": "USD", "currency_code": "USD"}
+    with _mock_validate(return_value=mock_info):
+        created = await client.post("/api/assets", json={"symbol": "AAPL"})
+
+    resp = await client.patch(f"/api/assets/{created.json()['id']}", json={"currency": "EUR"})
+    assert resp.json()["currency"] == "EUR"
+    assert resp.json()["unit_source"] == "user"

--- a/backend/tests/integration/test_groups.py
+++ b/backend/tests/integration/test_groups.py
@@ -221,3 +221,23 @@ async def test_indicators_empty_group(client, db):
     resp = await client.get(f"/api/groups/{gid}/indicators")
     assert resp.status_code == 200
     assert resp.json() == {}
+
+
+async def test_group_assets_carry_the_suggestion(client, db):
+    """Regression: the edit dialog reads group data, not /api/assets.
+
+    The suggestion was attached per-router, so an asset served through a group
+    arrived with suggested=null and the dialog could never show one. It's
+    derived in AssetResponse now, which is why this holds for every endpoint
+    that serialises an asset rather than the ones someone remembered.
+    """
+    gid = await _get_default_group_id(db)
+    asset = await seed_asset_with_prices(db, symbol="^N225", n_days=10)
+    asset.type = AssetType.STOCK
+    await db.commit()
+
+    resp = await client.get(f"/api/groups/{gid}")
+    served = [a for a in resp.json()["assets"] if a["symbol"] == "^N225"][0]
+    assert served["suggested"] is not None
+    assert served["suggested"]["type"] == "index"
+    assert "type" in served["suggested"]["differs"]

--- a/backend/tests/services/test_asset_service.py
+++ b/backend/tests/services/test_asset_service.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.domain import UnitKind
+from app.domain.provenance import FieldSource
 from app.models import AssetType
 from app.services.asset_service import create_asset, delete_asset, list_assets, update_asset
 from tests.helpers import make_model_asset as _make_asset
@@ -140,10 +142,13 @@ async def test_create_asset_detects_etf_type(MockAssetRepo, mock_validate, _mock
     new_asset = _make_asset(symbol="SPY", type=AssetType.ETF)
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    await create_asset(db, symbol="SPY", name=None, asset_type=AssetType.STOCK)
+    # None = "you decide". An explicit STOCK here would be a user choice and
+    # would win — see test_create_asset_explicit_type_beats_detection.
+    await create_asset(db, symbol="SPY", name=None, asset_type=None)
 
     call_kwargs = mock_repo.create.call_args[1]
     assert call_kwargs["type"] == AssetType.ETF
+    assert call_kwargs["type_source"] is FieldSource.AUTO
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)
@@ -159,10 +164,34 @@ async def test_create_asset_detects_index_type(MockAssetRepo, mock_validate, _mo
     new_asset = _make_asset(symbol="^TYX", type=AssetType.INDEX)
     mock_repo.create = AsyncMock(return_value=new_asset)
 
-    await create_asset(db, symbol="^TYX", name=None, asset_type=AssetType.STOCK)
+    await create_asset(db, symbol="^TYX", name=None, asset_type=None)
 
     call_kwargs = mock_repo.create.call_args[1]
     assert call_kwargs["type"] == AssetType.INDEX
+    # Shape also says how the number reads: a yield is a rate, not a price.
+    assert call_kwargs["unit_kind"] is UnitKind.PERCENT
+    assert call_kwargs["unit_source"] is FieldSource.AUTO
+
+
+@patch(_ensure_patch, new_callable=AsyncMock)
+@patch("app.services.asset_service.yahoo_client")
+@patch("app.services.asset_service.AssetRepository")
+async def test_create_asset_explicit_type_beats_detection(MockAssetRepo, mock_validate, _mock_ensure):
+    """A supplied type is a human decision: detection yields to it, and the row
+    records that a human made the call so suggestions stay quiet afterwards."""
+    db = AsyncMock()
+    mock_repo = MockAssetRepo.return_value
+    mock_repo.find_by_symbol = AsyncMock(return_value=None)
+    mock_validate.validate = AsyncMock(); mock_validate.validate.return_value = {
+        "symbol": "^TYX", "name": "Treasury Yield 30 Years", "type": "INDEX", "currency": "USD", "currency_code": "USD",
+    }
+    mock_repo.create = AsyncMock(return_value=_make_asset(symbol="^TYX", type=AssetType.STOCK))
+
+    await create_asset(db, symbol="^TYX", name=None, asset_type=AssetType.STOCK)
+
+    call_kwargs = mock_repo.create.call_args[1]
+    assert call_kwargs["type"] == AssetType.STOCK
+    assert call_kwargs["type_source"] is FieldSource.USER
 
 
 @patch(_ensure_patch, new_callable=AsyncMock)

--- a/frontend/src/components/assets/asset-card.tsx
+++ b/frontend/src/components/assets/asset-card.tsx
@@ -11,7 +11,7 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { useAddAssetToThesis } from "@/lib/queries"
 import { DeferredSparkline } from "@/components/chart/sparkline"
 import { TagBadge } from "@/components/tags/tag-badge"
-import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary } from "@/lib/api"
+import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary, UnitKind, AssetSuggestion } from "@/lib/api"
 import { formatAssetPriceWithSettings } from "@/lib/format"
 import { ChangePct } from "@/components/change-pct"
 import { getCardDescriptors, isVisibleAt, type IndicatorDescriptor, type Placement } from "@/lib/indicator-registry"
@@ -28,6 +28,8 @@ export interface AssetCardProps {
   name: string
   type: AssetType
   currency: string
+  unitKind: UnitKind
+  suggested?: AssetSuggestion | null
   tags: TagBrief[]
   quote?: Quote
   sparklineData?: SparklinePoint[]
@@ -66,6 +68,8 @@ export const AssetCard = memo(function AssetCard({
   name,
   type,
   currency,
+  unitKind,
+  suggested,
   tags,
   quote,
   sparklineData,
@@ -89,7 +93,7 @@ export const AssetCard = memo(function AssetCard({
   const addToThesis = useAddAssetToThesis()
 
   const priceFmt = lastPrice != null
-    ? formatAssetPriceWithSettings(lastPrice, { type, symbol, currency }, {
+    ? formatAssetPriceWithSettings(lastPrice, { type, symbol, currency, unit_kind: unitKind }, {
         compact: settings.compact_numbers,
         group: settings.thousands_separator,
       })
@@ -175,7 +179,7 @@ export const AssetCard = memo(function AssetCard({
         onNewThesis={() => setNewThesisOpen(true)}
       />
       <EditAssetDialog
-        asset={{ id: assetId, symbol, name, type, currency }}
+        asset={{ id: assetId, symbol, name, type, currency, unit_kind: unitKind, suggested }}
         open={editOpen}
         onOpenChange={setEditOpen}
       />

--- a/frontend/src/components/assets/asset-card.tsx
+++ b/frontend/src/components/assets/asset-card.tsx
@@ -11,7 +11,7 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { useAddAssetToThesis } from "@/lib/queries"
 import { DeferredSparkline } from "@/components/chart/sparkline"
 import { TagBadge } from "@/components/tags/tag-badge"
-import type { AssetType, Quote, TagBrief, SparklinePoint, IndicatorSummary, UnitKind, AssetSuggestion } from "@/lib/api"
+import type { Asset, Quote, SparklinePoint, IndicatorSummary } from "@/lib/api"
 import { formatAssetPriceWithSettings } from "@/lib/format"
 import { ChangePct } from "@/components/change-pct"
 import { getCardDescriptors, isVisibleAt, type IndicatorDescriptor, type Placement } from "@/lib/indicator-registry"
@@ -23,14 +23,10 @@ const CARD_DESCRIPTORS = getCardDescriptors()
 
 export interface AssetCardProps {
   groupId: number
-  assetId: number
-  symbol: string
-  name: string
-  type: AssetType
-  currency: string
-  unitKind: UnitKind
-  suggested?: AssetSuggestion | null
-  tags: TagBrief[]
+  /** The row itself, not its fields spread out: a new asset field (unit_kind,
+   * suggested, whatever comes next) then costs nothing here or in the parent,
+   * which is holding the whole Asset anyway. */
+  asset: Asset
   quote?: Quote
   sparklineData?: SparklinePoint[]
   indicatorData?: IndicatorSummary
@@ -63,14 +59,7 @@ function MiniIndicatorCard({
 
 export const AssetCard = memo(function AssetCard({
   groupId,
-  assetId,
-  symbol,
-  name,
-  type,
-  currency,
-  unitKind,
-  suggested,
-  tags,
+  asset,
   quote,
   sparklineData,
   indicatorData,
@@ -79,6 +68,7 @@ export const AssetCard = memo(function AssetCard({
   showSparkline,
   indicatorVisibility,
 }: AssetCardProps) {
+  const { id: assetId, symbol, name, type, currency, tags } = asset
   const { settings } = useSettings()
   const enabledCards = useMemo(
     () => CARD_DESCRIPTORS.filter((d) => isVisibleAt(indicatorVisibility, d.id, "group_card")),
@@ -93,7 +83,7 @@ export const AssetCard = memo(function AssetCard({
   const addToThesis = useAddAssetToThesis()
 
   const priceFmt = lastPrice != null
-    ? formatAssetPriceWithSettings(lastPrice, { type, symbol, currency, unit_kind: unitKind }, {
+    ? formatAssetPriceWithSettings(lastPrice, asset, {
         compact: settings.compact_numbers,
         group: settings.thousands_separator,
       })
@@ -179,7 +169,7 @@ export const AssetCard = memo(function AssetCard({
         onNewThesis={() => setNewThesisOpen(true)}
       />
       <EditAssetDialog
-        asset={{ id: assetId, symbol, name, type, currency, unit_kind: unitKind, suggested }}
+        asset={asset}
         open={editOpen}
         onOpenChange={setEditOpen}
       />

--- a/frontend/src/components/assets/asset-suggestion-banner.tsx
+++ b/frontend/src/components/assets/asset-suggestion-banner.tsx
@@ -1,60 +1,90 @@
 // Fibenchi's read on a ticker, offered rather than applied.
 //
-// The banner only appears when the backend says a field is still
-// auto-detected *and* disagrees with what's stored — a value you chose never
-// produces one, however much the ticker's shape argues otherwise. That's the
-// whole point of the provenance flag: it decides whether we're allowed to
-// bring this up, not whether we're allowed to overwrite you. Nothing changes
-// until Apply, which is an ordinary edit like any other.
+// Two registers, and the difference is who decided:
+//
+//   - A field Fibenchi guessed (`disagrees`) gets a banner with an apply
+//     action. It's still only a suggestion — nothing changes until clicked.
+//   - A field *you* set (`differs` minus `disagrees`) gets one muted line and
+//     a way back to auto. No banner, no nagging: you already decided. But it
+//     stays visible and reversible, because "don't argue with you" shouldn't
+//     collapse into "never speak again" — which is exactly what happens if
+//     the recommendation disappears the moment you touch the field.
+//
+// Wording is `Suggestion: Index · Points` rather than a sentence: this is a
+// form of labels and values, and prose reads as chatter next to them.
 
 import { Info } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { AssetSuggestion, AssetType, UnitKind } from "@/lib/api"
 
 const TYPE_LABEL: Record<AssetType, string> = {
-  stock: "a stock",
-  etf: "an ETF",
-  index: "an index",
+  stock: "Stock",
+  etf: "ETF",
+  index: "Index",
 }
 
 const UNIT_LABEL: Record<UnitKind, string> = {
-  currency: "a price",
-  percent: "a rate, in percent",
-  points: "a level, in points",
+  currency: "Currency",
+  percent: "Percent",
+  points: "Points",
 }
 
-/** "an index quoted as a level, in points" — only the parts under dispute, so
- * the sentence never states something the form already agrees with. */
-function phrase(suggestion: AssetSuggestion): string {
+/** Only the parts under dispute, so the line never restates what the form
+ * already agrees with. */
+function summarise(suggestion: AssetSuggestion, fields: string[]): string {
   const parts: string[] = []
-  if (suggestion.disagrees.includes("type")) parts.push(TYPE_LABEL[suggestion.type])
-  if (suggestion.disagrees.includes("unit_kind")) parts.push(`quoted as ${UNIT_LABEL[suggestion.unit_kind]}`)
-  return parts.join(", ")
+  if (fields.includes("type")) parts.push(TYPE_LABEL[suggestion.type])
+  if (fields.includes("unit_kind")) parts.push(UNIT_LABEL[suggestion.unit_kind])
+  return parts.join(" · ")
 }
 
 export function AssetSuggestionBanner({
-  symbol,
   suggestion,
   onApply,
+  onReset,
+  resetPending,
 }: {
-  symbol: string
   suggestion: AssetSuggestion | null | undefined
   onApply: () => void
+  onReset: () => void
+  resetPending?: boolean
 }) {
-  if (!suggestion?.disagrees.length) return null
+  if (!suggestion?.differs.length) return null
+
+  const open = suggestion.disagrees
+  // Fields you set that the shape still reads differently. Shown, not pushed.
+  const owned = suggestion.differs.filter((f) => !open.includes(f))
 
   return (
-    <div className="flex items-start gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 text-[12px]">
-      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-      <div className="flex-1 space-y-1.5">
-        <p className="leading-snug text-muted-foreground">
-          Fibenchi reads <span className="font-medium text-foreground">{symbol}</span> as{" "}
-          <span className="font-medium text-foreground">{phrase(suggestion)}</span>.
+    <div className="space-y-2">
+      {open.length > 0 && (
+        <div className="flex items-start gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 text-[12px]">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <div className="flex-1 space-y-1.5">
+            <p className="leading-snug text-muted-foreground">
+              Suggestion:{" "}
+              <span className="font-medium text-foreground">{summarise(suggestion, open)}</span>
+            </p>
+            <Button type="button" variant="outline" size="sm" className="h-6 px-2 text-[11px]" onClick={onApply}>
+              Use this
+            </Button>
+          </div>
+        </div>
+      )}
+      {owned.length > 0 && (
+        <p className="px-0.5 text-[11px] leading-snug text-muted-foreground">
+          Suggestion: <span className="text-foreground">{summarise(suggestion, owned)}</span>
+          {" — "}
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={resetPending}
+            className="underline underline-offset-2 hover:text-foreground disabled:opacity-50"
+          >
+            reset to auto-detect
+          </button>
         </p>
-        <Button type="button" variant="outline" size="sm" className="h-6 px-2 text-[11px]" onClick={onApply}>
-          Use this
-        </Button>
-      </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/assets/asset-suggestion-banner.tsx
+++ b/frontend/src/components/assets/asset-suggestion-banner.tsx
@@ -1,0 +1,60 @@
+// Fibenchi's read on a ticker, offered rather than applied.
+//
+// The banner only appears when the backend says a field is still
+// auto-detected *and* disagrees with what's stored — a value you chose never
+// produces one, however much the ticker's shape argues otherwise. That's the
+// whole point of the provenance flag: it decides whether we're allowed to
+// bring this up, not whether we're allowed to overwrite you. Nothing changes
+// until Apply, which is an ordinary edit like any other.
+
+import { Info } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { AssetSuggestion, AssetType, UnitKind } from "@/lib/api"
+
+const TYPE_LABEL: Record<AssetType, string> = {
+  stock: "a stock",
+  etf: "an ETF",
+  index: "an index",
+}
+
+const UNIT_LABEL: Record<UnitKind, string> = {
+  currency: "a price",
+  percent: "a rate, in percent",
+  points: "a level, in points",
+}
+
+/** "an index quoted as a level, in points" — only the parts under dispute, so
+ * the sentence never states something the form already agrees with. */
+function phrase(suggestion: AssetSuggestion): string {
+  const parts: string[] = []
+  if (suggestion.disagrees.includes("type")) parts.push(TYPE_LABEL[suggestion.type])
+  if (suggestion.disagrees.includes("unit_kind")) parts.push(`quoted as ${UNIT_LABEL[suggestion.unit_kind]}`)
+  return parts.join(", ")
+}
+
+export function AssetSuggestionBanner({
+  symbol,
+  suggestion,
+  onApply,
+}: {
+  symbol: string
+  suggestion: AssetSuggestion | null | undefined
+  onApply: () => void
+}) {
+  if (!suggestion?.disagrees.length) return null
+
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 text-[12px]">
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <div className="flex-1 space-y-1.5">
+        <p className="leading-snug text-muted-foreground">
+          Fibenchi reads <span className="font-medium text-foreground">{symbol}</span> as{" "}
+          <span className="font-medium text-foreground">{phrase(suggestion)}</span>.
+        </p>
+        <Button type="button" variant="outline" size="sm" className="h-6 px-2 text-[11px]" onClick={onApply}>
+          Use this
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/assets/edit-asset-dialog.tsx
+++ b/frontend/src/components/assets/edit-asset-dialog.tsx
@@ -15,7 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { useUpdateAsset } from "@/lib/queries"
+import { useResetAssetDetection, useUpdateAsset } from "@/lib/queries"
 import { AssetSuggestionBanner } from "@/components/assets/asset-suggestion-banner"
 import type { Asset, AssetType, UnitKind } from "@/lib/api"
 
@@ -47,6 +47,7 @@ const UNIT_OPTIONS: { value: UnitKind; label: string; hint: string }[] = [
 
 function EditAssetForm({ asset, onClose }: { asset: EditableAsset; onClose: () => void }) {
   const updateAsset = useUpdateAsset()
+  const resetDetection = useResetAssetDetection()
   const [name, setName] = useState(asset.name)
   const [type, setType] = useState<AssetType>(asset.type)
   const [currency, setCurrency] = useState(asset.currency)
@@ -69,6 +70,25 @@ function EditAssetForm({ asset, onClose }: { asset: EditableAsset; onClose: () =
     if (!s) return
     if (s.disagrees.includes("type")) setType(s.type)
     if (s.disagrees.includes("unit_kind")) setUnitKind(s.unit_kind)
+  }
+
+  // Resetting is the inverse of an edit and has to go straight to the server:
+  // it clears the user flag, which no PATCH of a value could express. Local
+  // form state follows so the dialog doesn't sit on a stale selection.
+  const handleReset = () => {
+    const s = asset.suggested
+    if (!s) return
+    const fields = s.differs.filter((f) => !s.disagrees.includes(f))
+    resetDetection.mutate(
+      { id: asset.id, fields },
+      {
+        onSuccess: (updated) => {
+          setType(updated.type)
+          setUnitKind(updated.unit_kind)
+          setCurrency(updated.currency)
+        },
+      },
+    )
   }
 
   const handleSave = () => {
@@ -97,9 +117,10 @@ function EditAssetForm({ asset, onClose }: { asset: EditableAsset; onClose: () =
       </DialogHeader>
       <div className="space-y-4 py-2">
         <AssetSuggestionBanner
-          symbol={asset.symbol}
           suggestion={asset.suggested}
           onApply={applySuggestion}
+          onReset={handleReset}
+          resetPending={resetDetection.isPending}
         />
         <div className="space-y-2">
           <Label htmlFor="asset-name">Name</Label>

--- a/frontend/src/components/assets/edit-asset-dialog.tsx
+++ b/frontend/src/components/assets/edit-asset-dialog.tsx
@@ -16,10 +16,12 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useUpdateAsset } from "@/lib/queries"
-import type { Asset, AssetType } from "@/lib/api"
+import { AssetSuggestionBanner } from "@/components/assets/asset-suggestion-banner"
+import type { Asset, AssetType, UnitKind } from "@/lib/api"
 
 /** Only the fields the edit form reads/writes — callers needn't supply a full Asset. */
-type EditableAsset = Pick<Asset, "id" | "symbol" | "name" | "type" | "currency">
+type EditableAsset = Pick<Asset, "id" | "symbol" | "name" | "type" | "currency" | "unit_kind"> &
+  Partial<Pick<Asset, "suggested">>
 
 interface EditAssetDialogProps {
   asset: EditableAsset | null
@@ -33,27 +35,53 @@ const TYPE_OPTIONS: { value: AssetType; label: string }[] = [
   { value: "index", label: "Index" },
 ]
 
+// Unit answers "how does this number read", which currency alone can't: it
+// only ever says *which* currency, so an index had to claim a denomination it
+// doesn't have. Percent used to be a hardcoded four-ticker list in format.ts,
+// unreachable from here.
+const UNIT_OPTIONS: { value: UnitKind; label: string; hint: string }[] = [
+  { value: "currency", label: "Currency", hint: "$71.40" },
+  { value: "percent", label: "Percent", hint: "4.63%" },
+  { value: "points", label: "Points", hint: "6,912.34" },
+]
+
 function EditAssetForm({ asset, onClose }: { asset: EditableAsset; onClose: () => void }) {
   const updateAsset = useUpdateAsset()
   const [name, setName] = useState(asset.name)
   const [type, setType] = useState<AssetType>(asset.type)
   const [currency, setCurrency] = useState(asset.currency)
+  const [unitKind, setUnitKind] = useState<UnitKind>(asset.unit_kind)
+
+  // Currency only means anything when the number *is* money; for a rate or an
+  // index level there is nothing to denominate.
+  const currencyApplies = unitKind === "currency"
 
   const dirty =
     name.trim() !== asset.name ||
     type !== asset.type ||
-    currency.trim().toUpperCase() !== asset.currency.toUpperCase()
+    unitKind !== asset.unit_kind ||
+    (currencyApplies && currency.trim().toUpperCase() !== asset.currency.toUpperCase())
+
+  // Applying is just a normal edit — which is also what records it as your
+  // choice, so the banner won't come back.
+  const applySuggestion = () => {
+    const s = asset.suggested
+    if (!s) return
+    if (s.disagrees.includes("type")) setType(s.type)
+    if (s.disagrees.includes("unit_kind")) setUnitKind(s.unit_kind)
+  }
 
   const handleSave = () => {
-    if (!name.trim() || !currency.trim()) return
+    if (!name.trim() || (currencyApplies && !currency.trim())) return
     updateAsset.mutate(
       {
         id: asset.id,
         data: {
           name: name.trim() !== asset.name ? name.trim() : undefined,
           type: type !== asset.type ? type : undefined,
+          unit_kind: unitKind !== asset.unit_kind ? unitKind : undefined,
           currency:
-            currency.trim().toUpperCase() !== asset.currency.toUpperCase()
+            currencyApplies && currency.trim().toUpperCase() !== asset.currency.toUpperCase()
               ? currency.trim().toUpperCase()
               : undefined,
         },
@@ -68,6 +96,11 @@ function EditAssetForm({ asset, onClose }: { asset: EditableAsset; onClose: () =
         <DialogTitle>Edit {asset.symbol}</DialogTitle>
       </DialogHeader>
       <div className="space-y-4 py-2">
+        <AssetSuggestionBanner
+          symbol={asset.symbol}
+          suggestion={asset.suggested}
+          onApply={applySuggestion}
+        />
         <div className="space-y-2">
           <Label htmlFor="asset-name">Name</Label>
           <Input
@@ -92,15 +125,36 @@ function EditAssetForm({ asset, onClose }: { asset: EditableAsset; onClose: () =
           </Select>
         </div>
         <div className="space-y-2">
-          <Label htmlFor="asset-currency">Currency</Label>
-          <Input
-            id="asset-currency"
-            value={currency}
-            onChange={(e) => setCurrency(e.target.value)}
-            maxLength={10}
-            placeholder="USD, EUR, GBP, ..."
-          />
+          <Label htmlFor="asset-unit">Unit</Label>
+          <Select value={unitKind} onValueChange={(v) => setUnitKind(v as UnitKind)}>
+            <SelectTrigger id="asset-unit" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {UNIT_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                  <span className="ml-2 font-mono text-[11px] text-muted-foreground">{opt.hint}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
+        {/* Hidden rather than disabled when it doesn't apply: a greyed-out
+            field still implies the asset has a currency, which is the exact
+            confusion this whole change is undoing. */}
+        {currencyApplies && (
+          <div className="space-y-2">
+            <Label htmlFor="asset-currency">Currency</Label>
+            <Input
+              id="asset-currency"
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value)}
+              maxLength={10}
+              placeholder="USD, EUR, GBP, ..."
+            />
+          </div>
+        )}
       </div>
       <DialogFooter>
         <Button variant="outline" onClick={onClose}>
@@ -108,7 +162,7 @@ function EditAssetForm({ asset, onClose }: { asset: EditableAsset; onClose: () =
         </Button>
         <Button
           onClick={handleSave}
-          disabled={!dirty || !name.trim() || !currency.trim() || updateAsset.isPending}
+          disabled={!dirty || !name.trim() || (currencyApplies && !currency.trim()) || updateAsset.isPending}
         >
           Save
         </Button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -82,6 +82,13 @@ export const api = {
     list: () => request<Asset[]>("/assets"),
     create: (data: AssetCreate) =>
       request<Asset>("/assets", { method: "POST", body: JSON.stringify(data) }),
+    /** Hand classification fields back to auto-detection: adopt Fibenchi's
+     * read and clear the user flag, so they track improvements again. */
+    resetDetection: (id: number, fields?: string[]) =>
+      request<Asset>(`/assets/${id}/reset-detection`, {
+        method: "POST",
+        body: JSON.stringify(fields ? { fields } : {}),
+      }),
     update: (id: number, data: AssetUpdate) =>
       request<Asset>(`/assets/${id}`, { method: "PATCH", body: JSON.stringify(data) }),
     attachments: (symbol: string) =>

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
-import { compactSigFig, formatCompactNumber, formatCompactPrice } from "./format"
+import { compactSigFig, formatAssetPrice, formatCompactNumber, formatCompactPrice } from "./format"
+import type { AssetFormatHints } from "./format"
 
 describe("compactSigFig", () => {
   it("keeps ~3 significant figures so low-thousands prices stay distinct (NKT.CO case)", () => {
@@ -69,5 +70,57 @@ describe("formatCompactPrice", () => {
   it("handles currencies without a symbol (NKT.CO / DKK)", () => {
     expect(formatCompactPrice(1122, "DKK")).toBe("DKK 1.12K")
     expect(formatCompactPrice(72000, "DKK")).toBe("DKK 72.0K")
+  })
+})
+
+// --- Unit-aware asset prices (#617) ---
+//
+// `currency` only ever answers *which* currency, so an index was forced to
+// claim a denomination it doesn't have — the S&P 500 rendered as "$6,912.34"
+// and a 30-year Treasury yield as "$46.28". `unit_kind` is the field that can
+// say "this is a rate" or "this has no unit", and it replaced a hardcoded
+// four-ticker YIELD_INDICES set that nothing outside format.ts could reach.
+
+describe("formatAssetPrice / unit_kind", () => {
+  const hints = (over: Partial<AssetFormatHints> = {}): AssetFormatHints => ({
+    type: "stock",
+    symbol: "AAPL",
+    currency: "USD",
+    ...over,
+  })
+
+  it("denominates a currency-quoted asset", () => {
+    expect(formatAssetPrice(71.4, hints({ unit_kind: "currency" }))).toBe("$71.40")
+  })
+
+  it("prints a percent-quoted index as a rate", () => {
+    expect(
+      formatAssetPrice(4.628, hints({ symbol: "^TYX", type: "index", unit_kind: "percent" })),
+    ).toBe("4.63%")
+  })
+
+  it("prints a points-quoted index bare — no symbol, no percent", () => {
+    const s = formatAssetPrice(6912.34, hints({ symbol: "^GSPC", type: "index", unit_kind: "points" }), undefined, true)
+    expect(s).toBe("6,912.34")
+  })
+
+  it("honours unit_kind over the ticker, so any yield index can be marked", () => {
+    // ^BVSP was never in the old hardcoded set; the user can now say so.
+    expect(
+      formatAssetPrice(10.5, hints({ symbol: "^BVSP", type: "index", unit_kind: "percent" })),
+    ).toBe("10.50%")
+  })
+
+  it("honours unit_kind over the ticker in the other direction too", () => {
+    // Currency wins even on a caret symbol, if that is what the user chose.
+    expect(
+      formatAssetPrice(46.28, hints({ symbol: "^TYX", type: "index", unit_kind: "currency" })),
+    ).toBe("$46.28")
+  })
+
+  it("falls back on type when unit_kind is absent", () => {
+    // Endpoints predating unit_kind must not start printing "$" on an index.
+    expect(formatAssetPrice(6912.34, hints({ symbol: "^GSPC", type: "index" }))).toBe("6912.34")
+    expect(formatAssetPrice(71.4, hints())).toBe("$71.40")
   })
 })

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,4 +1,4 @@
-import type { AssetType } from "@/lib/types"
+import type { AssetType, UnitKind } from "@/lib/types"
 
 /**
  * Pick a legible foreground (near-black or white) for content sitting on a solid
@@ -29,16 +29,28 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   CHF: "CHF\u00a0",
 }
 
-const YIELD_INDICES = new Set(["^TYX", "^TNX", "^FVX", "^IRX"])
-
+/**
+ * What an asset needs to format its own price. `unit_kind` is the answer to
+ * "how does this number read" and is the only thing consulted — `type` and
+ * `symbol` are kept for callers and for the pre-unit_kind fallback below.
+ *
+ * This replaced a hardcoded four-ticker YIELD_INDICES set: percent-ness is a
+ * property of the asset now, set by the backend and overridable by the user,
+ * rather than a list in the frontend nothing outside it could reach.
+ */
 export interface AssetFormatHints {
   type: AssetType
   symbol: string
   currency: string
+  // snake_case to match the API shape, so a whole `Asset` is a valid hint.
+  unit_kind?: UnitKind
 }
 
-function isYieldIndex(symbol: string): boolean {
-  return YIELD_INDICES.has(symbol.toUpperCase())
+/** Assets fetched through endpoints that predate `unit_kind` don't carry one.
+ * Falling back on `type` keeps them formatting as they always did rather than
+ * printing a currency symbol on an index. */
+function unitOf(asset: AssetFormatHints): UnitKind {
+  return asset.unit_kind ?? (asset.type === "index" ? "points" : "currency")
 }
 
 const ZERO_DECIMAL_CURRENCIES = new Set(["KRW", "JPY", "IDR", "HUF", "VND", "CLP", "TWD"])
@@ -66,13 +78,14 @@ export function formatAssetPrice(
   decimals?: number,
   groupDigits = false,
 ): string {
-  if (asset.type !== "index") return formatPrice(value, asset.currency, decimals, groupDigits)
+  const unit = unitOf(asset)
+  if (unit === "currency") return formatPrice(value, asset.currency, decimals, groupDigits)
   const d = decimals ?? 2
   const fixed = value.toFixed(d)
   const [int, frac] = fixed.split(".")
   const grouped = groupDigits ? int.replace(/\B(?=(\d{3})+(?!\d))/g, ",") : int
   const body = frac !== undefined ? `${grouped}.${frac}` : grouped
-  return isYieldIndex(asset.symbol) ? `${body}%` : body
+  return unit === "percent" ? `${body}%` : body
 }
 
 /** Significant figures kept by the compact abbreviation. Tuning knob, not a user setting. */
@@ -120,7 +133,7 @@ export function formatCompactPrice(value: number, currency: string): string {
 }
 
 export function formatAssetCompactPrice(value: number, asset: AssetFormatHints): string {
-  if (asset.type !== "index") return formatCompactPrice(value, asset.currency)
+  if (unitOf(asset) === "currency") return formatCompactPrice(value, asset.currency)
   return formatAssetPrice(value, asset, 2)
 }
 

--- a/frontend/src/lib/queries/assets.ts
+++ b/frontend/src/lib/queries/assets.ts
@@ -45,6 +45,15 @@ export function useUpdateAsset() {
   )
 }
 
+/** Hand an asset's classification fields back to auto-detection. Invalidates
+ * the same keys as an edit — it is an edit, just in the other direction. */
+export function useResetAssetDetection() {
+  return useInvalidatingMutation(
+    ({ id, fields }: { id: number; fields?: string[] }) => api.assets.resetDetection(id, fields),
+    [keys.assets, keys.groups],
+  )
+}
+
 // Search
 export function useLocalSearch(query: string) {
   return useQuery<SymbolSearchResult[]>({

--- a/frontend/src/lib/queries/index.ts
+++ b/frontend/src/lib/queries/index.ts
@@ -1,6 +1,6 @@
 export { keys, STALE_1MIN, STALE_5MIN, STALE_24H, useInvalidatingMutation } from "./shared"
 export { usePortfolioIndex, usePortfolioPerformers } from "./portfolio"
-export { useAssets, useCreateAsset, useUpdateAsset, useAssetAttachments, useHardDeleteAsset, useLocalSearch, useYahooSearch } from "./assets"
+export { useAssets, useCreateAsset, useUpdateAsset, useResetAssetDetection, useAssetAttachments, useHardDeleteAsset, useLocalSearch, useYahooSearch } from "./assets"
 export { useAssetDetail, useAssetWindow, useEtfHoldings, useHoldingsIndicators, useRefreshPrices, usePrefetchAssetDetail } from "./prices"
 export { useEarnings } from "./earnings"
 export { useTags, useCreateTag, useAttachTag, useDetachTag } from "./tags"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,6 +4,25 @@ import type { MarketState } from "./market-state"
 
 export type AssetType = "stock" | "etf" | "index"
 
+/** How an asset's price number reads. Distinct from `currency`, which only
+ * answers *which* currency and so can't express a rate or a bare index level. */
+export type UnitKind = "currency" | "percent" | "points"
+
+/** Whether a stored field was derived by Fibenchi or chosen by the user.
+ * Auto fields may be re-suggested when the guess improves; user fields are
+ * never argued with. */
+export type FieldSource = "auto" | "user"
+
+/** Fibenchi's read on a ticker — advisory, never applied on its own.
+ * `disagrees` lists only auto fields that differ from what's stored, so an
+ * empty array means there is nothing worth showing. */
+export interface AssetSuggestion {
+  type: AssetType
+  unit_kind: UnitKind
+  currency: string | null
+  disagrees: string[]
+}
+
 export interface TagBrief {
   id: number
   name: string
@@ -34,6 +53,10 @@ export interface Asset {
   name: string
   type: AssetType
   currency: string
+  unit_kind: UnitKind
+  type_source: FieldSource
+  unit_source: FieldSource
+  suggested?: AssetSuggestion | null
   created_at: string
   tags: TagBrief[]
 }
@@ -59,6 +82,7 @@ export interface AssetUpdate {
   name?: string
   type?: AssetType
   currency?: string
+  unit_kind?: UnitKind
 }
 
 export interface SymbolSearchResult {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -14,12 +14,16 @@ export type UnitKind = "currency" | "percent" | "points"
 export type FieldSource = "auto" | "user"
 
 /** Fibenchi's read on a ticker — advisory, never applied on its own.
- * `disagrees` lists only auto fields that differ from what's stored, so an
- * empty array means there is nothing worth showing. */
+ *
+ * `differs` is every field the shape reads differently, whoever set it: these
+ * are the resettable ones. `disagrees` is the auto-only subset — what may be
+ * raised unprompted. A field you set stays in `differs` but leaves
+ * `disagrees`, so it's still visible and reversible without nagging. */
 export interface AssetSuggestion {
   type: AssetType
   unit_kind: UnitKind
   currency: string | null
+  differs: string[]
   disagrees: string[]
 }
 

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -14,7 +14,7 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { resolveIcon } from "@/lib/icon-utils"
 import { buildYahooFinanceUrl, buildYahooQuoteUrl, formatAssetPriceWithSettings } from "@/lib/format"
 import { ChangePct } from "@/components/change-pct"
-import type { AssetType } from "@/lib/api"
+import type { UnitKind, AssetType } from "@/lib/api"
 import { useQuote } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useRefreshPrices, useCreateAsset, useGroups, useAddAssetsToGroup } from "@/lib/queries"
@@ -27,6 +27,7 @@ export function Header({
   name,
   currency,
   type,
+  unitKind,
   assetWindow,
   setAssetWindow,
   isTracked,
@@ -38,6 +39,7 @@ export function Header({
   name?: string
   currency: string
   type: AssetType
+  unitKind?: UnitKind
   assetWindow: AssetWindow
   setAssetWindow: (w: AssetWindow) => void
   isTracked: boolean
@@ -55,7 +57,7 @@ export function Header({
   const changePct = quote?.change_percent ?? null
   const [priceRef, pctRef] = usePriceFlash(price)
   const priceFmt = price != null
-    ? formatAssetPriceWithSettings(price, { type, symbol, currency }, {
+    ? formatAssetPriceWithSettings(price, { type, symbol, currency, unit_kind: unitKind }, {
         compact: settings.compact_numbers,
         group: settings.thousands_separator,
       })

--- a/frontend/src/pages/asset-detail/header.tsx
+++ b/frontend/src/pages/asset-detail/header.tsx
@@ -14,7 +14,7 @@ import { MarketStatusDot } from "@/components/market-status-dot"
 import { resolveIcon } from "@/lib/icon-utils"
 import { buildYahooFinanceUrl, buildYahooQuoteUrl, formatAssetPriceWithSettings } from "@/lib/format"
 import { ChangePct } from "@/components/change-pct"
-import type { UnitKind, AssetType } from "@/lib/api"
+import type { Asset } from "@/lib/api"
 import { useQuote } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useRefreshPrices, useCreateAsset, useGroups, useAddAssetsToGroup } from "@/lib/queries"
@@ -24,29 +24,24 @@ export type ChartMode = "live" | "historical"
 
 export function Header({
   symbol,
-  name,
-  currency,
-  type,
-  unitKind,
+  asset,
   assetWindow,
   setAssetWindow,
   isTracked,
-  assetId,
   mode,
   setMode,
 }: {
+  /** Stays separate from `asset`: this page renders for untracked symbols too,
+   * where there is no row yet — that's the whole point of the Track button. */
   symbol: string
-  name?: string
-  currency: string
-  type: AssetType
-  unitKind?: UnitKind
+  asset?: Asset
   assetWindow: AssetWindow
   setAssetWindow: (w: AssetWindow) => void
   isTracked: boolean
-  assetId?: number
   mode: ChartMode
   setMode: (m: ChartMode) => void
 }) {
+  const { id: assetId, name } = asset ?? {}
   const { settings } = useSettings()
   const refresh = useRefreshPrices(symbol)
   const createAsset = useCreateAsset()
@@ -57,7 +52,7 @@ export function Header({
   const changePct = quote?.change_percent ?? null
   const [priceRef, pctRef] = usePriceFlash(price)
   const priceFmt = price != null
-    ? formatAssetPriceWithSettings(price, { type, symbol, currency, unit_kind: unitKind }, {
+    ? formatAssetPriceWithSettings(price, asset ?? { type: "stock", symbol, currency: "USD" }, {
         compact: settings.compact_numbers,
         group: settings.thousands_separator,
       })

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -45,7 +45,7 @@ export function AssetDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} type={asset?.type ?? "stock"} unitKind={asset?.unit_kind} assetWindow={assetWindow} setAssetWindow={setAssetWindow} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
+      <Header symbol={symbol} asset={asset} assetWindow={assetWindow} setAssetWindow={setAssetWindow} isTracked={isTracked} mode={mode} setMode={setMode} />
       <ChartSection
         symbol={symbol}
         assetWindow={assetWindow}
@@ -60,9 +60,7 @@ export function AssetDetailPage() {
           prices={prices}
           label={windowLabel}
           symbol={symbol}
-          currency={asset?.currency ?? "USD"}
-          assetType={asset?.type ?? "stock"}
-          unitKind={asset?.unit_kind}
+          asset={asset}
         />
       )}
       {mode === "historical" && indicators && indicators.length > 0 && (

--- a/frontend/src/pages/asset-detail/index.tsx
+++ b/frontend/src/pages/asset-detail/index.tsx
@@ -45,7 +45,7 @@ export function AssetDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} type={asset?.type ?? "stock"} assetWindow={assetWindow} setAssetWindow={setAssetWindow} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
+      <Header symbol={symbol} name={asset?.name} currency={asset?.currency ?? "USD"} type={asset?.type ?? "stock"} unitKind={asset?.unit_kind} assetWindow={assetWindow} setAssetWindow={setAssetWindow} isTracked={isTracked} assetId={asset?.id} mode={mode} setMode={setMode} />
       <ChartSection
         symbol={symbol}
         assetWindow={assetWindow}
@@ -62,6 +62,7 @@ export function AssetDetailPage() {
           symbol={symbol}
           currency={asset?.currency ?? "USD"}
           assetType={asset?.type ?? "stock"}
+          unitKind={asset?.unit_kind}
         />
       )}
       {mode === "historical" && indicators && indicators.length > 0 && (

--- a/frontend/src/pages/asset-detail/movement-stats.tsx
+++ b/frontend/src/pages/asset-detail/movement-stats.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react"
 import { computeMovementStats } from "@/lib/movement-stats"
 import { formatChangePct, changeColor, formatAssetPrice, formatDateLong } from "@/lib/format"
-import type { Price, AssetType } from "@/lib/types"
+import type { Price, AssetType, UnitKind } from "@/lib/types"
 
 interface MovementStatsProps {
   prices: Price[]
@@ -9,13 +9,14 @@ interface MovementStatsProps {
   symbol: string
   currency: string
   assetType: AssetType
+  unitKind?: UnitKind
 }
 
-export function MovementStats({ prices, label, symbol, currency, assetType }: MovementStatsProps) {
+export function MovementStats({ prices, label, symbol, currency, assetType, unitKind }: MovementStatsProps) {
   const stats = useMemo(() => computeMovementStats(prices), [prices])
   if (!stats) return null
 
-  const hints = { type: assetType, symbol, currency }
+  const hints = { type: assetType, symbol, currency, unit_kind: unitKind }
   const ret = formatChangePct(stats.periodReturnPct)
 
   return (

--- a/frontend/src/pages/asset-detail/movement-stats.tsx
+++ b/frontend/src/pages/asset-detail/movement-stats.tsx
@@ -1,22 +1,20 @@
 import { useMemo } from "react"
 import { computeMovementStats } from "@/lib/movement-stats"
 import { formatChangePct, changeColor, formatAssetPrice, formatDateLong } from "@/lib/format"
-import type { Price, AssetType, UnitKind } from "@/lib/types"
+import type { Price, Asset } from "@/lib/types"
 
 interface MovementStatsProps {
   prices: Price[]
   label: string
   symbol: string
-  currency: string
-  assetType: AssetType
-  unitKind?: UnitKind
+  asset?: Asset
 }
 
-export function MovementStats({ prices, label, symbol, currency, assetType, unitKind }: MovementStatsProps) {
+export function MovementStats({ prices, label, symbol, asset }: MovementStatsProps) {
   const stats = useMemo(() => computeMovementStats(prices), [prices])
   if (!stats) return null
 
-  const hints = { type: assetType, symbol, currency, unit_kind: unitKind }
+  const hints = asset ?? { type: "stock" as const, symbol, currency: "USD" }
   const ret = formatChangePct(stats.periodReturnPct)
 
   return (

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -392,14 +392,7 @@ export function GroupPage({ groupId }: { groupId: number }) {
             <AssetCard
               key={asset.id}
               groupId={groupId}
-              assetId={asset.id}
-              symbol={asset.symbol}
-              name={asset.name}
-              type={asset.type}
-              currency={asset.currency}
-              unitKind={asset.unit_kind}
-              suggested={asset.suggested}
-              tags={asset.tags}
+              asset={asset}
               quote={quotes[asset.symbol]}
               sparklineData={batchSparklines?.[asset.symbol]}
               indicatorData={batchIndicators?.[asset.symbol]}

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -397,6 +397,8 @@ export function GroupPage({ groupId }: { groupId: number }) {
               name={asset.name}
               type={asset.type}
               currency={asset.currency}
+              unitKind={asset.unit_kind}
+              suggested={asset.suggested}
               tags={asset.tags}
               quote={quotes[asset.symbol]}
               sparklineData={batchSparklines?.[asset.symbol]}

--- a/frontend/src/pages/portfolio/board/tile-tooltip.tsx
+++ b/frontend/src/pages/portfolio/board/tile-tooltip.tsx
@@ -121,7 +121,7 @@ export function TileTooltip({ tile, mode, span }: { tile: Tile; mode: ColorMode;
             </span>
           )}
         </div>
-        {tile.name && <div className="mt-0.5 text-[11.5px] leading-snug text-muted-foreground">{tile.name}</div>}
+        {tile.asset.name && <div className="mt-0.5 text-[11.5px] leading-snug text-muted-foreground">{tile.asset.name}</div>}
       </div>
 
       <div className="border-t border-border px-3 py-2">
@@ -133,7 +133,7 @@ export function TileTooltip({ tile, mode, span }: { tile: Tile; mode: ColorMode;
               category error, not a cosmetic one. */}
           {tile.price != null && (
             <span className="text-[13px] font-medium tabular-nums text-muted-foreground">
-              {formatAssetPrice(tile.price, tile)}
+              {formatAssetPrice(tile.price, tile.asset)}
             </span>
           )}
           {/* Everything that isn't warmup — feed_behind, gap, unknown — lands

--- a/frontend/src/pages/portfolio/board/use-board-data.ts
+++ b/frontend/src/pages/portfolio/board/use-board-data.ts
@@ -41,13 +41,13 @@ export type NoReadingReason =
   | { kind: "unknown" }
 
 export interface Tile {
+  /** The tile's identity — also its React key, route param and lookup key. */
   symbol: string
-  name: string
-  currency: string
-  /** Carried so prices format through formatAssetPrice: an index is not
-   * currency-denominated, and a yield index is quoted in percent. */
-  type: Asset["type"]
-  unit_kind: Asset["unit_kind"]
+  /** The row behind the tile. Held whole rather than copied field by field, so
+   * it satisfies AssetFormatHints directly (an index isn't
+   * currency-denominated, a yield index is quoted in percent) and a new asset
+   * field costs nothing here. */
+  asset: Asset
   /** σ-Move via the live-first cascade; null → see reason. */
   sigma: number | null
   reason: NoReadingReason | null
@@ -219,10 +219,7 @@ export function useBoardData(groupBy: GroupBy) {
 
       out.set(symbol, {
         symbol,
-        name: asset.name,
-        currency: asset.currency,
-        type: asset.type,
-        unit_kind: asset.unit_kind,
+        asset,
         sigma,
         reason,
         todayPct: quote?.change_percent ?? snap?.change_pct ?? null,

--- a/frontend/src/pages/portfolio/board/use-board-data.ts
+++ b/frontend/src/pages/portfolio/board/use-board-data.ts
@@ -47,6 +47,7 @@ export interface Tile {
   /** Carried so prices format through formatAssetPrice: an index is not
    * currency-denominated, and a yield index is quoted in percent. */
   type: Asset["type"]
+  unit_kind: Asset["unit_kind"]
   /** σ-Move via the live-first cascade; null → see reason. */
   sigma: number | null
   reason: NoReadingReason | null
@@ -221,6 +222,7 @@ export function useBoardData(groupBy: GroupBy) {
         name: asset.name,
         currency: asset.currency,
         type: asset.type,
+        unit_kind: asset.unit_kind,
         sigma,
         reason,
         todayPct: quote?.change_percent ?? snap?.change_pct ?? null,


### PR DESCRIPTION
Closes #617. **Rewritten** from the first pass after we talked it through — that
version made ticker shape *authoritative*, which fixed the data by taking the
decision away from the user. This one makes it a recommendation.

## What was actually missing

Two gaps, which turn out to be the same gap.

**Units.** `currency` only ever answers *which* currency, so an index had to
claim a denomination it doesn't have. "This is a rate" and "this has no unit"
were unrepresentable. Percent-ness lived as a hardcoded set in `format.ts`:

```ts
const YIELD_INDICES = new Set(["^TYX", "^TNX", "^FVX", "^IRX"])
```

Four tickers, frontend-only. `^BVSP` or a gilt yield rendered as bare points and
there was no way — through the dialog or the API — to say otherwise.
`UnitKind` (`currency` / `percent` / `points`) gives that its own field, decided
by `classify()` alongside kind and calendar, and editable.

**Provenance.** Nothing distinguished *"Yahoo said stock once"* from *"the user
means stock"*, so the choice collapsed to overwrite-everything or
overwrite-nothing — and overwrite-nothing is how six rows stayed wrong for
months. `FieldSource` (`auto` / `user`) makes both possible.

## What provenance is *not* doing here

Nothing self-heals. Stored values change **only** when someone applies a
suggestion, which is an ordinary edit — and which marks the field `user`, so the
banner doesn't come back. The flag decides whether Fibenchi may *raise the
subject*, not whether it may act.

```
stored: stock / currency   sources: auto auto  -> disagrees: [type, unit_kind]
stored: stock / currency   sources: user auto  -> disagrees: [unit_kind]
```

Verified against the live dev DB, both directions.

## Notable consequences

- **`AssetCreate.type` is now nullable.** It defaulted to `STOCK`, which made
  "you decide" and "I say stock" indistinguishable — that is precisely why the
  first version had to overrule explicit requests to work at all. All three
  frontend callers already omit it. An explicit type now wins and records `user`.
- Yahoo keeps the ETF-vs-stock call, which shape can't see.
- The suggestion is derived per read in the router, never stored, so it can't go
  stale. It's a transient attribute, not a column.
- The **Unit** selector replaces **Currency** in the edit dialog when the number
  isn't money. Hidden rather than disabled — a greyed-out currency field still
  implies the asset has one, which is the confusion being undone.

## Migration 0020

Adds `unit_kind` / `type_source` / `unit_source`, repairs the six rows, and sets
`unit_kind` from the symbol. Everything predating it is auto-detected by
definition (no UI ever wrote provenance), so `AUTO` is correct throughout.

```
STOCK | CURRENCY | AUTO | AUTO |  39
ETF   | CURRENCY | AUTO | AUTO |  35
INDEX | PERCENT  | AUTO | AUTO |   2   {^TNX,^TYX}
INDEX | POINTS   | AUTO | AUTO |   6   {^GSPC,^HSI,^KS11,^N225,^STOXX50E,^TWII}
```

Two things worth a second look, both caught by inspecting rather than reasoning:

- **The literal is `'INDEX'`, not `'index'`.** `Enum(AssetType)` persists the
  member *name*. I had `'index'` first; it would have round-tripped to a
  `LookupError` and made those six assets unreadable.
- **The `assettype` enum carries an unused lowercase `index` label** from
  earlier drift, sitting next to `INDEX`. Left in place — dropping a label means
  recreating the type — but it is exactly the trap above, armed for the next
  person who writes raw SQL here.

## Verification

- backend: `ruff` clean, **831 passed**
- frontend: `lint` + `build` clean, **50 passed** (6 new format tests, including
  that a symbol outside the old hardcoded set can now be marked percent)
- two service tests changed behaviour and were updated, not weakened: they
  passed `asset_type=STOCK` as a stand-in for "the default", which is now a user
  choice that legitimately wins. Added a test pinning that distinction.
- contract artifacts regenerate byte-identical

**Cross-repo note:** `ConfigTicker` doesn't carry `unit_kind`, so the companion
app has the same `$`-on-an-index problem if it renders prices. Adding it is an
additive v1 change plus a Zod regen on the app side — deliberately not in this
PR, worth its own issue.
