### PR TITLE
feat: intraday bars are opt-in and scoped to what the client draws (#621)

### DIFF
--- a/backend/app/routers/quotes.py
+++ b/backend/app/routers/quotes.py
@@ -20,9 +20,18 @@ async def get_quotes(symbols: str = Query(..., description="Comma-separated list
 @router.get(
     "/quotes/stream",
     summary="SSE stream of grouped asset quotes (delta compressed)",
-    responses={200: {"content": {"text/event-stream": {}}, "description": "Server-Sent Events stream. Each event has `event: quotes` with JSON data containing only the symbols whose quote changed since the last push. The first event contains all grouped symbols."}},
+    responses={200: {"content": {"text/event-stream": {}}, "description": "Server-Sent Events stream. Each event has `event: quotes` with JSON data containing only the symbols whose quote changed since the last push. The first event contains all grouped symbols. `event: intraday` is sent only when the `intraday` query param names symbols."}},
 )
-async def stream_quotes():
+async def stream_quotes(
+    intraday: str | None = Query(
+        None,
+        description=(
+            "Comma-separated symbols to also receive 1-minute bars for "
+            "(`event: intraday`). Omit for none — bars are opt-in because the "
+            "first frame is large and most views never draw them."
+        ),
+    ),
+):
     """Open a Server-Sent Events stream that pushes real-time quotes for all
     assets that belong to at least one group.
 
@@ -37,9 +46,16 @@ async def stream_quotes():
     - **300 s** when all markets are closed
 
     Each SSE event uses `event: quotes` with a JSON object keyed by symbol.
+
+    **Intraday bars** arrive as a separate `event: intraday`, and only for the
+    symbols named in the `intraday` param. Quotes are small and every page
+    shows them; a full bar set is neither. To change the selection, reopen the
+    stream with a different param — the new connection's first push carries
+    the full window for the newly requested symbols.
     """
+    symbols = frozenset(s.strip().upper() for s in (intraday or "").split(",") if s.strip())
     return StreamingResponse(
-        quote_service.quote_event_generator(),
+        quote_service.quote_event_generator(symbols),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -77,19 +77,28 @@ async def get_quotes(symbols: str) -> list[Quote]:
     return await get_price_provider().batch_fetch_quotes(symbol_list)
 
 
-async def quote_event_generator():
+async def quote_event_generator(intraday_symbols: frozenset[str] | None = None):
     """Yield SSE events with quotes for all grouped assets, adapting interval to market state.
 
     After the initial full payload, only symbols whose data changed since the
     last push are included (delta mode).  This dramatically reduces bandwidth
     when most markets are closed or prices are stable.
 
-    Also pushes ``event: intraday`` with 1-minute bars for the live day view.
-    First push sends full day data, subsequent pushes send only new bars (delta).
+    ``intraday_symbols`` opts the connection in to ``event: intraday``, the
+    1-minute bars behind the live day view. First push sends the full window,
+    later pushes only new bars (delta).
+
+    **Intraday is opt-in and scoped.** Quotes are small and every page shows
+    them, so they go to everyone; a full bar set is not — measured at 738 KiB
+    for 78 symbols (#615), re-sent on every reconnect. Only two views draw
+    bars, and each wants a handful of symbols, so a connection that doesn't ask
+    gets none. Passing ``None`` is therefore *silence*, not *everything*: the
+    saving is automatic and a caller cannot forget to ask for less.
     """
     last_payload: dict[str, Quote] = {}
     # Track last pushed intraday bar timestamp per symbol
     last_intraday_ts: dict[str, int] = {}
+    wanted_intraday = frozenset(intraday_symbols or ())
 
     while True:
         try:
@@ -140,9 +149,13 @@ async def quote_event_generator():
             has_active_market = any_active(market_states)
 
             # Always push intraday on first iteration or when markets are active
-            if has_active_market or not last_intraday_ts:
+            if wanted_intraday and (has_active_market or not last_intraday_ts):
+                # Scoped to what this connection asked for. Filtering the refs
+                # rather than the result keeps the DB from reading bars nobody
+                # will draw — the query is the expensive half, not the JSON.
+                bar_refs = [r for r in refs if r.symbol in wanted_intraday]
                 async with async_session() as db:
-                    all_bars = await get_intraday_bars(db, refs)
+                    all_bars = await get_intraday_bars(db, bar_refs)
 
                 if all_bars:
                     if not last_intraday_ts:

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -7,6 +7,12 @@ application. Run inside the backend container:
 docker compose exec backend python scripts/<name>.py
 ```
 
+## SSE probes
+
+- `probe_sse_first_frame.py` — measures the first `event: intraday` frame
+  the quote stream pushes, by replaying the generator's first iteration
+  against the live DB. Reads only; no upstream calls. Added for #615.
+
 ## Yahoo Finance probes
 
 These count actual upstream HTTP requests by monkey-patching

--- a/backend/scripts/probe_sse_first_frame.py
+++ b/backend/scripts/probe_sse_first_frame.py
@@ -1,0 +1,149 @@
+"""How big is the first `intraday` SSE frame?
+
+Background: `quote_event_generator` pushes deltas, except on its first
+iteration — there `last_intraday_ts` is empty so the whole bar set for every
+grouped asset goes out in one `event: intraday`. Every browser tab that opens
+(or reconnects) pays that frame. Nothing measured it; #615 asked for a number
+before deciding whether it needs windowing.
+
+This reproduces the first iteration exactly: the same roster query, the same
+`get_intraday_bars`, the same `TypeAdapter.dump_json`. It reads the live DB
+and makes no upstream calls, so it is safe to run any time — but the number
+it prints is only as realistic as the roster and the intraday table behind
+it. Run it late in a session, not on a freshly-wiped intraday table.
+
+    docker compose exec backend python scripts/probe_sse_first_frame.py
+    docker compose exec backend python scripts/probe_sse_first_frame.py --toon
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import gzip
+import sys
+
+sys.path.insert(0, "/app")
+
+
+def _human(n: int) -> str:
+    return f"{n / 1024:.1f} KiB" if n >= 1024 else f"{n} B"
+
+
+async def collect() -> dict:
+    from sqlalchemy import func, select
+
+    from app.database import async_session
+    from app.models.group import Group, group_assets
+    from app.repositories.asset_repo import AssetRepository
+    from app.services.intraday import get_intraday_bars
+    from app.services.quote_service import (
+        _intraday_payload_adapter,
+        _quotes_payload_adapter,
+    )
+
+    async with async_session() as db:
+        refs = await AssetRepository(db).list_in_any_group_refs()
+        all_bars = await get_intraday_bars(db, refs)
+        # The stream's roster is every grouped asset, but a page renders one
+        # group. The biggest group bounds what any single view can consume —
+        # the gap is bars nobody on that page will draw.
+        biggest = (await db.execute(
+            select(Group.name, func.count(group_assets.c.asset_id).label("n"))
+            .join(group_assets, group_assets.c.group_id == Group.id)
+            .group_by(Group.id)
+            .order_by(func.count(group_assets.c.asset_id).desc())
+            .limit(1)
+        )).first()
+
+    frame = _intraday_payload_adapter.dump_json(all_bars)
+    # The bytes actually written to the socket, not just the JSON.
+    wire = len(b"event: intraday\ndata: " + frame + b"\n\n")
+
+    per_symbol = sorted(
+        (
+            {
+                "symbol": sym,
+                "bars": len(bars),
+                "bytes": len(_intraday_payload_adapter.dump_json({sym: bars})),
+            }
+            for sym, bars in all_bars.items()
+        ),
+        key=lambda r: r["bytes"],
+        reverse=True,
+    )
+
+    # One quotes frame for scale — that one is a delta after the first push,
+    # so it is the recurring cost the intraday frame should be judged against.
+    quotes_bytes = len(_quotes_payload_adapter.dump_json({}))
+
+    return {
+        "roster": len(refs),
+        "symbols_with_bars": len(all_bars),
+        "bars": sum(len(b) for b in all_bars.values()),
+        "frame_bytes": wire,
+        "frame_gzip_bytes": len(gzip.compress(frame)),
+        "empty_quotes_frame_bytes": quotes_bytes,
+        "biggest_group": biggest[0] if biggest else None,
+        "biggest_group_size": biggest[1] if biggest else 0,
+        "per_symbol": per_symbol,
+    }
+
+
+def format_toon(d: dict) -> str:
+    lines = [
+        f"roster: {d['roster']}",
+        f"symbols_with_bars: {d['symbols_with_bars']}",
+        f"bars: {d['bars']}",
+        f"frame_bytes: {d['frame_bytes']}",
+        f"frame_gzip_bytes: {d['frame_gzip_bytes']}",
+        f"per_symbol[{len(d['per_symbol'])}]{{symbol,bars,bytes}}:",
+    ]
+    lines += [f"  {r['symbol']},{r['bars']},{r['bytes']}" for r in d["per_symbol"]]
+    return "\n".join(lines)
+
+
+def format_human(d: dict) -> str:
+    out = [
+        "First `event: intraday` frame",
+        "=" * 60,
+        f"  roster                {d['roster']} grouped assets",
+        f"  with bars             {d['symbols_with_bars']}",
+        f"  biggest group         {d['biggest_group_size']} ({d['biggest_group']})"
+        f" — a page can render at most this many",
+        f"  bars total            {d['bars']}",
+        f"  frame on the wire     {_human(d['frame_bytes'])}  ({d['frame_bytes']} B)",
+        f"  gzipped               {_human(d['frame_gzip_bytes'])}"
+        "   (no GZipMiddleware today — SSE is sent raw)",
+        "",
+        f"  bytes per bar         {d['frame_bytes'] / max(d['bars'], 1):.0f}",
+        "",
+        "Heaviest symbols",
+        "-" * 60,
+    ]
+    for r in d["per_symbol"][:15]:
+        out.append(f"  {r['symbol']:<14} {r['bars']:>5} bars   {_human(r['bytes'])}")
+    if len(d["per_symbol"]) > 15:
+        out.append(f"  … {len(d['per_symbol']) - 15} more")
+    return "\n".join(out)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    g = parser.add_mutually_exclusive_group()
+    g.add_argument("--toon", action="store_true", help="TOON output: token-efficient format")
+    g.add_argument("--json", action="store_true", help="JSON output")
+    args = parser.parse_args()
+
+    data = await collect()
+    if args.toon:
+        print(format_toon(data))
+    elif args.json:
+        import json
+
+        print(json.dumps(data, indent=2))
+    else:
+        print(format_human(data))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/services/test_quote_service.py
+++ b/backend/tests/services/test_quote_service.py
@@ -9,9 +9,23 @@ import pytest
 from app.domain import AssetRef
 from app.schemas.intraday import IntradayBar
 from app.schemas.quote import Quote
-from app.services.quote_service import get_quotes, quote_event_generator
+from app.services.quote_service import (
+    _reset_asset_list_cache,
+    get_quotes,
+    quote_event_generator,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture(autouse=True)
+def _clear_roster_cache():
+    """The roster cache is module state with a 30s TTL, so without this a test
+    silently inherits the previous test's symbols. Every test here used AAPL
+    until one didn't, and it failed only when run alongside the others."""
+    _reset_asset_list_cache()
+    yield
+    _reset_asset_list_cache()
 
 
 def _mock_provider(quotes_return=None, quotes_side_effect=None):
@@ -131,7 +145,11 @@ async def test_stream_delta_only_changed():
 
 async def test_stream_intraday_event_serializes_bars():
     """The ``intraday`` SSE event carries {symbol: [bar]} with the wire keys
-    time/price/volume/session (the frontend's ``IntradayPoint`` mirror)."""
+    time/price/volume/session (the frontend's ``IntradayPoint`` mirror).
+
+    Note the explicit subscription: bars are opt-in, so this test has to ask
+    for them the way a live view does.
+    """
     mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"})]
     bars = {
         "AAPL": [
@@ -160,7 +178,7 @@ async def test_stream_intraday_event_serializes_bars():
         MockRepo.return_value.list_in_any_group_refs = AsyncMock(return_value=[AssetRef("AAPL", 1)])
 
         events = []
-        async for event in quote_event_generator():
+        async for event in quote_event_generator(frozenset({"AAPL"})):
             events.append(event)
 
     intraday_events = [e for e in events if e.startswith("event: intraday")]
@@ -172,6 +190,79 @@ async def test_stream_intraday_event_serializes_bars():
             {"time": 1771000060, "price": 185.6, "volume": 800, "session": "regular"},
         ]
     }
+
+
+async def test_stream_without_subscription_sends_no_intraday():
+    """No subscription means silence, not everything.
+
+    The whole saving in #621 rests on this default: the board, the group table
+    and every other view hold this stream without drawing a single bar, and
+    used to be sent 738 KiB anyway.
+    """
+    mock_quotes = [Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"})]
+    bars_call = AsyncMock(return_value={"AAPL": [
+        IntradayBar(time=1771000000, price=185.5, volume=1200, session="regular"),
+    ]})
+
+    async def mock_sleep(seconds):
+        raise asyncio.CancelledError()
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("app.services.quote_service.async_session", return_value=mock_session_ctx),
+        patch("app.services.quote_service.AssetRepository") as MockRepo,
+        patch("app.services.quote_service.get_price_provider", return_value=_mock_provider(mock_quotes)),
+        patch("app.services.quote_service.asyncio.sleep", side_effect=mock_sleep),
+        patch("app.services.quote_service.get_intraday_bars", bars_call),
+    ):
+        MockRepo.return_value.list_in_any_group_refs = AsyncMock(return_value=[AssetRef("AAPL", 1)])
+
+        events = [e async for e in quote_event_generator()]
+
+    assert not [e for e in events if e.startswith("event: intraday")]
+    # Not merely filtered out of the payload — never read from the DB.
+    bars_call.assert_not_awaited()
+    # Quotes still flow: this is scoping intraday, not muting the stream.
+    assert [e for e in events if e.startswith("event: quotes")]
+
+
+async def test_stream_intraday_scoped_to_subscribed_symbols():
+    """A subscription for one symbol must not drag the rest of the roster along."""
+    mock_quotes = [
+        Quote(**{"symbol": "AAPL", "price": 185.50, "market_state": "REGULAR"}),
+        Quote(**{"symbol": "MSFT", "price": 420.00, "market_state": "REGULAR"}),
+    ]
+    seen_refs: list[list[AssetRef]] = []
+
+    async def capture_bars(db, refs):
+        seen_refs.append(list(refs))
+        return {}
+
+    async def mock_sleep(seconds):
+        raise asyncio.CancelledError()
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("app.services.quote_service.async_session", return_value=mock_session_ctx),
+        patch("app.services.quote_service.AssetRepository") as MockRepo,
+        patch("app.services.quote_service.get_price_provider", return_value=_mock_provider(mock_quotes)),
+        patch("app.services.quote_service.asyncio.sleep", side_effect=mock_sleep),
+        patch("app.services.quote_service.get_intraday_bars", capture_bars),
+    ):
+        MockRepo.return_value.list_in_any_group_refs = AsyncMock(
+            return_value=[AssetRef("AAPL", 1), AssetRef("MSFT", 2)]
+        )
+
+        async for _ in quote_event_generator(frozenset({"MSFT"})):
+            pass
+
+    assert seen_refs == [[AssetRef("MSFT", 2)]]
 
 
 async def test_stream_adaptive_interval_regular():

--- a/frontend/src/components/chart/live-day-view.tsx
+++ b/frontend/src/components/chart/live-day-view.tsx
@@ -2,7 +2,7 @@ import { memo } from "react"
 import { Link } from "react-router-dom"
 import type { Quote } from "@/lib/api"
 import type { Asset, IntradayPoint, IndicatorSummary } from "@/lib/types"
-import { useIntraday, useQuoteStatus } from "@/lib/quote-stream"
+import { useIntraday, useIntradaySubscription, useQuoteStatus } from "@/lib/quote-stream"
 import { usePriceFlash } from "@/lib/use-price-flash"
 import { useSettings } from "@/lib/settings"
 import { formatPrice, formatCompactNumber, changeColor } from "@/lib/format"
@@ -20,6 +20,9 @@ interface LiveDayViewProps {
 }
 
 export function LiveDayView({ assets, quotes, indicators }: LiveDayViewProps) {
+  // This view is the reason the group's bars are on the wire at all — nothing
+  // else in the app draws more than one symbol's worth.
+  useIntradaySubscription(assets.map((a) => a.symbol))
   const intraday = useIntraday()
 
   return (

--- a/frontend/src/lib/quote-stream.tsx
+++ b/frontend/src/lib/quote-stream.tsx
@@ -74,6 +74,9 @@ interface QuoteStreamState {
   store: QuoteStore
   intraday: IntradayMap
   status: ConnectionStatus
+  /** Declare that a mounted component will draw bars for these symbols.
+   *  Returns an unsubscribe. See `useIntradaySubscription`. */
+  subscribeIntraday: (symbols: string[]) => () => void
 }
 
 const defaultStore = new QuoteStore()
@@ -81,7 +84,13 @@ const QuoteStreamContext = createContext<QuoteStreamState>({
   store: defaultStore,
   intraday: {},
   status: "connecting",
+  subscribeIntraday: () => () => {},
 })
+
+/** How long to wait after the demand set changes before reconnecting.
+ *  Navigation unmounts one live view and mounts another in quick succession;
+ *  without this, that lands as two reconnects instead of one. */
+const RESUBSCRIBE_DEBOUNCE_MS = 400
 
 export function QuoteStreamProvider({ children }: { children: React.ReactNode }) {
   const [storeRef] = useState(() => new QuoteStore())
@@ -92,12 +101,45 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
   const backoffMs = useRef(1_000)
   const mountedRef = useRef(true)
 
+  // Who currently wants bars, and for what. Keyed by an identity token per
+  // subscriber so two views asking for the same symbol both have to leave
+  // before it drops out of the union.
+  const demands = useRef(new Map<symbol, string[]>())
+  const demandTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The `intraday=` query param, and the effect dependency that reopens the
+  // stream when it changes. Sorted so an unchanged set can't reorder into a
+  // different string and trigger a pointless reconnect.
+  const [intradayParam, setIntradayParam] = useState("")
+
+  const subscribeIntraday = useCallback((symbols: string[]) => {
+    const token = Symbol("intraday-demand")
+    const recompute = () => {
+      if (demandTimer.current) clearTimeout(demandTimer.current)
+      demandTimer.current = setTimeout(() => {
+        const union = new Set<string>()
+        for (const list of demands.current.values()) {
+          for (const s of list) union.add(s.toUpperCase())
+        }
+        setIntradayParam([...union].sort().join(","))
+      }, RESUBSCRIBE_DEBOUNCE_MS)
+    }
+    demands.current.set(token, symbols)
+    recompute()
+    return () => {
+      demands.current.delete(token)
+      recompute()
+    }
+  }, [])
+
   useEffect(() => {
     mountedRef.current = true
 
     function connect() {
       if (!mountedRef.current) return
-      const es = new EventSource("/api/quotes/stream")
+      const url = intradayParam
+        ? `/api/quotes/stream?intraday=${encodeURIComponent(intradayParam)}`
+        : "/api/quotes/stream"
+      const es = new EventSource(url)
       esRef.current = es
 
       es.addEventListener("quotes", (e) => {
@@ -183,10 +225,14 @@ export function QuoteStreamProvider({ children }: { children: React.ReactNode })
       esRef.current = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
     }
-  }, [storeRef])
+    // intradayParam: a changed selection reopens the stream, which is how the
+    // server learns about it. Quotes survive that — the new connection's first
+    // push is a full payload and QuoteStore.merge keeps the previous values,
+    // so nothing on screen blanks.
+  }, [storeRef, intradayParam])
 
   return (
-    <QuoteStreamContext.Provider value={{ store: storeRef, intraday, status }}>
+    <QuoteStreamContext.Provider value={{ store: storeRef, intraday, status, subscribeIntraday }}>
       {children}
     </QuoteStreamContext.Provider>
   )
@@ -221,6 +267,29 @@ export function useQuote(symbol: string): Quote | undefined {
 // eslint-disable-next-line react-refresh/only-export-components
 export function useIntraday(): IntradayMap {
   return useContext(QuoteStreamContext).intraday
+}
+
+/** Ask the stream for 1-minute bars while this component is mounted.
+ *
+ * Bars are opt-in: a connection that doesn't ask receives none, because the
+ * first frame is large (738 KiB for the full roster, #615) and most views
+ * never draw one. Call this from anything that renders an `IntradayChart`,
+ * then read the data with `useIntraday()`.
+ *
+ * Changing the set reopens the SSE connection, so the bars arrive after a
+ * round-trip rather than being there already. Debounced, so navigating
+ * between two live views costs one reconnect, not two.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useIntradaySubscription(symbols: string[]): void {
+  const { subscribeIntraday } = useContext(QuoteStreamContext)
+  // The array identity changes every render at most call sites; the joined
+  // string is what actually decides whether the demand changed.
+  const key = symbols.join(",")
+  useEffect(
+    () => subscribeIntraday(key ? key.split(",") : []),
+    [subscribeIntraday, key],
+  )
 }
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/frontend/src/pages/asset-detail/chart-section.tsx
+++ b/frontend/src/pages/asset-detail/chart-section.tsx
@@ -2,7 +2,7 @@ import { PriceChart } from "@/components/chart/price-chart"
 import { ChartSkeleton } from "@/components/chart/chart-skeleton"
 import { IntradayChart } from "@/components/chart/intraday-chart"
 import { useAssetWindow, useAnnotations } from "@/lib/queries"
-import { useIntraday, useQuote } from "@/lib/quote-stream"
+import { useIntraday, useIntradaySubscription, useQuote } from "@/lib/quote-stream"
 import type { AssetWindow } from "@/lib/asset-window"
 import type { Placement } from "@/lib/indicator-registry"
 import type { AssetType } from "@/lib/api"
@@ -41,8 +41,9 @@ export function ChartSection({
 }
 
 function LiveChartSection({ symbol }: { symbol: string }) {
-  const intraday = useIntraday()
   const upperSymbol = symbol.toUpperCase()
+  useIntradaySubscription([upperSymbol])
+  const intraday = useIntraday()
   const points = intraday[upperSymbol]
   const quote = useQuote(upperSymbol)
   const previousClose = quote?.previous_close ?? null


### PR DESCRIPTION
Closes #621. Builds on the measurement in #615 (PR #620).

## What changed

`GET /api/quotes/stream` gains `?intraday=<comma-separated symbols>`.

**Absent means silence, not everything.** That default is the whole point: it
puts the saving on automatically instead of relying on every caller to remember
to ask for less. The only consumer is our own frontend — the companion app
doesn't use this stream — so there's no third party to break.

Refs are filtered *before* `get_intraday_bars`, so unwanted bars are never read
from the DB, not merely dropped from the payload.

Client side, `useIntradaySubscription(symbols)` registers demand; the provider
unions all live demands and reopens the EventSource when the union changes,
debounced 400ms so navigating between two live views is one reconnect rather
than two. `LiveDayView` declares its group's assets; `LiveChartSection` declares
its one symbol.

## Verified against the live stack

```
no param                    → 0 intraday events
?intraday=BTC-USD,AAPL      → 1 event, {"BTC-USD": 695 bars}, 48.6 KiB
```

(AAPL is correctly absent — it isn't in a group, so it isn't in the roster.)

Against the 738 KiB baseline: a group live view is ~181 KiB, an asset detail
live chart ~10–48 KiB, and every other page in the app is now **zero**.

## The trade, stated plainly

Flipping to a live view now waits a round-trip for bars that used to be sitting
there already, because the stream sent them unconditionally. `IntradayChart`
already renders a skeleton for the empty state, so this shows as a brief skeleton
rather than a blank. Reopening also re-establishes quotes, which is harmless —
the new connection's first quotes push is a full payload and `QuoteStore.merge`
keeps prior values, so nothing on screen blanks.

## Unrelated fix carried along

`test_quote_service.py` gained an autouse fixture calling
`_reset_asset_list_cache()`. That module-level cache has a 30s TTL and leaked
between tests — every test there happened to use AAPL, so it never showed. My
new scoping test uses MSFT and failed only when run alongside the others, passing
in isolation. `_reset_asset_list_cache` existed for exactly this and had no
callers.

## Checks

- `ruff check .` — clean
- `pytest` — 839 passed
- `pnpm lint` + `pnpm build` — clean