### PR TITLE
fix: floor the σ-Move vol forecast at a fraction of the asset's long-run vol

### DIFF
--- a/backend/app/services/compute/indicators.py
+++ b/backend/app/services/compute/indicators.py
@@ -90,6 +90,38 @@ def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
 # RiskMetrics daily decay; shared by the vnr indicator and its live forecast.
 VNR_LAMBDA = 0.94
 
+# Floor on the vol forecast, as a fraction of the asset's *own* long-run vol.
+# The EWMA is a pure function of recent returns, so a series that stops moving
+# decays it toward zero and the next real move divides by almost nothing. A
+# global floor can't work — instruments legitimately differ in vol by orders of
+# magnitude — so the floor is scaled per asset by its expanding return stdev.
+#
+# 0.15 was measured, not guessed. Swept against every tracked asset's stored
+# history (77 series, ~350 bars each) and a synthetic 1.2%/day name gone flat
+# for 120 sessions before a +3% day:
+#
+#   frac   real bars moved >0.05σ   synthetic σ-move
+#   0.00                        0              92.7
+#   0.10                        0              32.7
+#   0.15                        0              21.8
+#   0.25                       40              13.1
+#
+# 0.15 is the largest floor that changes *no* real observed bar while still
+# cutting the pathological case ~4x. 0.25 looked tidier on the synthetic but
+# clipped genuine quiet regimes — it cut a real RR.L +3.8% day from 2.50σ to
+# 1.99σ, which is precisely the reading vnr exists to produce.
+#
+# Note this bounds the pathology rather than eliminating it: a floored σ still
+# reports ~22σ for a series that has not moved in 120 sessions, because "low
+# recent vol" and "not repricing at all" differ only in degree and one fraction
+# cannot separate them. Detecting a degenerate flat run and withholding the
+# score outright is the honest complement, and is deliberately left out of
+# scope here — it reintroduces a blank, which is a display policy decision.
+VNR_SIGMA_FLOOR_FRAC = 0.15
+# Don't floor until the long-run estimate has enough observations to mean
+# anything; below this the EWMA is the better of two weak estimates.
+VNR_SIGMA_FLOOR_MIN_OBS = 20
+
 
 def session_gap_days(index: pd.Index, session_dates: set[date] | None = None) -> pd.Series:
     """Sessions elapsed between each bar and the previous stored bar.
@@ -129,12 +161,20 @@ def session_gap_days(index: pd.Index, session_dates: set[date] | None = None) ->
     return gaps
 
 
-def _ewma_daily_vol(closes: pd.Series, lam: float, gaps: pd.Series | None = None) -> pd.Series:
+def _ewma_daily_vol(
+    closes: pd.Series,
+    lam: float,
+    gaps: pd.Series | None = None,
+    sigma_floor_frac: float = VNR_SIGMA_FLOOR_FRAC,
+    sigma_floor_min_obs: int = VNR_SIGMA_FLOOR_MIN_OBS,
+) -> pd.Series:
     """Forward EWMA volatility forecast (RiskMetrics zero-mean).
 
     Returns the sqrt of the EWMA variance built from returns *through each bar*
-    — i.e. the volatility with which to normalize the *next* bar's return. Flat
-    stretches (variance 0) become NaN to guard division. This is the un-shifted
+    — i.e. the volatility with which to normalize the *next* bar's return. The
+    forecast is floored at ``VNR_SIGMA_FLOOR_FRAC`` of the asset's expanding
+    return stdev (see below); a fully flat series floors at zero and becomes
+    NaN, which still guards the division. This is the un-shifted
     counterpart of the ``sigma_forecast`` inside :func:`volatility_normalized_return`;
     the value at the last bar is the forecast for the in-progress day, which the
     live snapshot uses to score today's move before its bar is written.
@@ -146,17 +186,35 @@ def _ewma_daily_vol(closes: pd.Series, lam: float, gaps: pd.Series | None = None
     (not zeroed) returns leave the variance carried across the gap; with
     ``ignore_na=False`` the skipped position still ages the older observations,
     approximating one extra decay step for the missing stretch.
+
+    Floor: the EWMA is a pure function of *recent* returns, so a series that
+    goes quiet — a suspended ticker, an ETC that stops repricing, anything gone
+    stale in a group that isn't pruned — decays it smoothly toward zero, and the
+    first real move divides by almost nothing. Guarding only exact zero (which
+    floating point rarely reaches) never caught this. The forecast is therefore
+    floored at a fraction of the asset's own long-run vol, estimated by an
+    *expanding* stdev so no future return leaks into a historical bar's
+    denominator. Below ``VNR_SIGMA_FLOOR_MIN_OBS`` observations the estimate is
+    NaN and no floor applies.
     """
     returns = closes.pct_change()
     if gaps is not None:
         returns = returns.where(~(gaps > 1))
     # RiskMetrics zero-mean EWMA variance: sigma^2_t = lam*sigma^2_{t-1} + (1-lam)*r^2_{t-1}
     ewma_var = (returns**2).ewm(alpha=1 - lam, adjust=False, ignore_na=False).mean()
-    return np.sqrt(ewma_var).replace(0, float("nan"))
+    sigma = np.sqrt(ewma_var)
+    floor = returns.expanding(min_periods=sigma_floor_min_obs).std() * sigma_floor_frac
+    # `floor > sigma` is False wherever floor is NaN, so early bars keep sigma.
+    sigma = sigma.where(~(floor > sigma), floor)
+    return sigma.replace(0, float("nan"))
 
 
 def volatility_normalized_return(
-    closes: pd.Series, lam: float = VNR_LAMBDA, gaps: pd.Series | None = None,
+    closes: pd.Series,
+    lam: float = VNR_LAMBDA,
+    gaps: pd.Series | None = None,
+    sigma_floor_frac: float = VNR_SIGMA_FLOOR_FRAC,
+    sigma_floor_min_obs: int = VNR_SIGMA_FLOOR_MIN_OBS,
 ) -> pd.Series:
     """Volatility-normalized daily return — a "sigma move" / return z-score.
 
@@ -191,7 +249,9 @@ def volatility_normalized_return(
     # Forecast vol from data through the previous day; guard flat series (0 -> NaN).
     # The forecast gets the same gap series so gap-spanning returns can't
     # contaminate the denominator either (they would understate later σ-moves).
-    sigma_forecast = _ewma_daily_vol(closes, lam, gaps).shift(1)
+    sigma_forecast = _ewma_daily_vol(
+        closes, lam, gaps, sigma_floor_frac, sigma_floor_min_obs,
+    ).shift(1)
     return (returns / sigma_forecast).where(~(gaps > 1))
 
 
@@ -560,7 +620,11 @@ INDICATOR_REGISTRY: dict[str, IndicatorDef] = {
     ),
     "vnr": IndicatorDef(
         func=volatility_normalized_return,
-        params={"lam": VNR_LAMBDA},
+        params={
+            "lam": VNR_LAMBDA,
+            "sigma_floor_frac": VNR_SIGMA_FLOOR_FRAC,
+            "sigma_floor_min_obs": VNR_SIGMA_FLOOR_MIN_OBS,
+        },
         # vnr_sigma and vnr_gap_sessions are gap-aware companions set directly
         # by compute_indicators, which owns the session-gap series.
         output_fields=["vnr", "vnr_sigma", "vnr_gap_sessions"],

--- a/backend/indicator.contract.json
+++ b/backend/indicator.contract.json
@@ -270,7 +270,9 @@
       "key": "vnr",
       "kernel": "volatility_normalized_return",
       "params": {
-        "lam": 0.94
+        "lam": 0.94,
+        "sigma_floor_frac": 0.15,
+        "sigma_floor_min_obs": 20
       },
       "outputFields": [
         "vnr"

--- a/backend/tests/services/test_indicators_volatility.py
+++ b/backend/tests/services/test_indicators_volatility.py
@@ -8,6 +8,8 @@ import pandas as pd
 import pytest
 
 from app.services.compute.indicators import (
+    VNR_SIGMA_FLOOR_FRAC,
+    _ewma_daily_vol,
     _true_range,
     adx,
     atr,
@@ -621,3 +623,77 @@ def test_snapshot_change_pct_suppressed_on_gap_bar():
     # Contiguous series still reports a change.
     full = _make_price_df(100)
     assert build_indicator_snapshot(compute_indicators(full)).change_pct is not None
+
+
+def _flat_then_move(flat_sessions: int, vol: float = 0.012, move: float = 0.03) -> pd.Series:
+    """A normally-volatile name that goes completely flat, then really moves.
+
+    Models a suspended ticker, an ETC that stops repricing, or anything gone
+    quiet in a group that isn't pruned — the series that decays the EWMA
+    forecast toward zero.
+    """
+    rng = np.random.default_rng(7)
+    closes = [100.0]
+    for r in rng.normal(0, vol, 260):
+        closes.append(closes[-1] * (1 + r))
+    closes.extend([closes[-1]] * flat_sessions)
+    closes.append(closes[-1] * (1 + move))
+    return pd.Series(closes, index=pd.bdate_range("2020-01-01", periods=len(closes)))
+
+
+def test_sigma_floor_bounds_a_flat_series_blowup():
+    """`.replace(0, NaN)` only ever caught variance that reached *exactly* zero,
+    which floating point rarely does. A series that goes quiet decays sigma
+    smoothly toward zero and the first real move divides by almost nothing."""
+    series = _flat_then_move(120)
+    unfloored = volatility_normalized_return(series, sigma_floor_frac=0.0).iloc[-1]
+    floored = volatility_normalized_return(series).iloc[-1]
+    assert unfloored > 90       # the bug: a +3% day scoring like a market crash
+    assert floored < 25         # bounded, though still large — see the constant
+    assert floored < unfloored / 4
+
+
+def test_sigma_floor_is_inert_on_an_ordinary_series():
+    """The floor must not touch normal readings — it is scaled to a fraction of
+    the asset's own long-run vol precisely so a genuinely calm stretch still
+    scores as one. Regression against picking the fraction too high."""
+    series = _flat_then_move(0)
+    assert volatility_normalized_return(series).iloc[-1] == pytest.approx(
+        volatility_normalized_return(series, sigma_floor_frac=0.0).iloc[-1], abs=1e-9
+    )
+
+
+def test_sigma_floor_scales_per_asset_not_globally():
+    """A quiet instrument and a violent one get different floors — a global
+    constant would either be inert for one or clip the other's real moves."""
+    calm = _flat_then_move(0, vol=0.001)
+    wild = _flat_then_move(0, vol=0.05)
+    # Read the forecast *before* the trailing move — that bar's return is a
+    # fixed 3% in both series and would swamp the calm one's own scale.
+    assert _ewma_daily_vol(calm, 0.94).iloc[-2] < _ewma_daily_vol(wild, 0.94).iloc[-2] / 10
+
+
+def test_sigma_floor_uses_no_future_returns():
+    """The long-run anchor is an *expanding* stdev, so truncating the series
+    must not change any bar that survives — a rolling/full-sample estimate
+    would leak later volatility into an earlier bar's denominator."""
+    series = _flat_then_move(120)
+    full = volatility_normalized_return(series)
+    truncated = volatility_normalized_return(series.iloc[:-40])
+    pd.testing.assert_series_equal(full.iloc[:-40], truncated, check_names=False)
+
+
+def test_sigma_floor_still_nans_a_totally_flat_series():
+    """No returns at all means no honest denominator: the floor is zero too, so
+    the division stays guarded rather than producing an infinity."""
+    flat = pd.Series([100.0] * 80, index=pd.bdate_range("2020-01-01", periods=80))
+    assert _ewma_daily_vol(flat, 0.94).dropna().empty
+    assert volatility_normalized_return(flat).dropna().empty
+
+
+def test_sigma_floor_fraction_is_published_to_the_companion_app():
+    """The app re-implements this kernel from indicator.contract.json; a floor
+    that only exists in Python would silently drift the two apart."""
+    from app.services.compute.indicators import INDICATOR_REGISTRY
+
+    assert INDICATOR_REGISTRY["vnr"].params["sigma_floor_frac"] == VNR_SIGMA_FLOOR_FRAC


### PR DESCRIPTION
Closes #630.

`_ewma_daily_vol` guarded only variance that reached **exactly** zero, which floating point rarely does. A series that goes quiet decays the EWMA smoothly toward zero and the first real move divides by almost nothing. Measured on a synthetic 1.2%/day name flat for 120 sessions: a +3% day scored **+92.7σ**.

## The floor is per-asset, and the fraction was measured

A global constant can't work — instruments differ in volatility by orders of magnitude. The floor is a fraction of the asset's own long-run vol, estimated by an **expanding** stdev so no future return leaks into a historical bar's denominator (pinned by a test).

Swept against every tracked asset's stored history (77 series, ~350 bars each):

| frac | real bars moved >0.05σ | synthetic 120-flat σ-move |
|---|---|---|
| 0.00 | 0 | 92.7 |
| 0.10 | 0 | 32.7 |
| **0.15** | **0** | **21.8** |
| 0.25 | 40 | 13.1 |

**0.15 is the largest floor that changes no real observed bar.** I initially picked 0.25 — it looked tidier on the synthetic, but it clipped genuine quiet regimes: it cut a real `RR.L` +3.8% day from **2.50σ to 1.99σ**, which is precisely the reading σ-Move exists to produce. Caught it by checking against stored history rather than trusting the synthetic.

## Honest limitation

This **bounds** the pathology rather than eliminating it — ~22σ still prints for a series that hasn't moved in 120 sessions, because "low recent vol" and "not repricing at all" differ only in degree and one fraction can't separate them. Detecting a degenerate flat run and withholding the score outright is the honest complement, deliberately left out of scope: it reintroduces a blank, which is a display policy decision rather than a numeric one. Say the word and I'll file it.

## Cross-language contract

The floor params are published through the registry into `indicator.contract.json` so the companion app's hand-ported TS kernel can implement them:

```diff
   "params": {
-    "lam": 0.94
+    "lam": 0.94,
+    "sigma_floor_frac": 0.15,
+    "sigma_floor_min_obs": 20
   },
```

⚠️ `indicator.fixtures.json` is **unchanged** — the fixed synthetic fixture series never trips the floor, so the app's golden test would still pass an implementation that omits it. The contract tells the app what to build; the fixture doesn't yet force it. Adding a flat stretch to the fixture would close that, at the cost of a coordinated update in `fibenchi-app`. Flagging rather than deciding unilaterally.

## Verification

6 new tests: the blowup is bounded, the floor is inert on an ordinary series, it scales per asset, it uses no future returns, a totally flat series still NaNs, and the fraction reaches the contract.

`ruff check .` clean · **848 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)